### PR TITLE
Added Cursor trait.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+bigdecimal = "~0.1"
+chrono = "~0.4"
 failure = "~0.1"
 failure_derive = "~0.1"

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,0 +1,76 @@
+use crate::data_source::IonDataSource;
+use crate::types::{IonType, SymbolId};
+use crate::result::IonResult;
+use bigdecimal::BigDecimal;
+use chrono::{DateTime, FixedOffset};
+
+/**
+ * This trait captures the format-agnostic, system-level parser functionality needed to
+ * navigate within an Ion stream and read the values encountered into native Rust data types.
+ *
+ * Cursor implementations are not expected to interpret symbol table declarations, resolve symbol
+ * IDs into text, or otherwise interpret system-level constructs for use at a user level.
+ *
+ * Once a value has successfully been read from the stream using one of the read_* functions,
+ * calling that function again may return an Err. This is left to the discretion of the implementor.
+ */
+pub trait Cursor<D: IonDataSource> {
+    /// Attempts to advance the cursor to the next value in the stream at the current depth.
+    /// If no value is encountered, returns None; otherwise, returns the Ion type of the next value.
+    fn next(&mut self) -> IonResult<Option<IonType>>;
+
+    /// Returns the Ion type of the value currently positioned under the cursor. If the cursor
+    /// is not positioned over a value, returns None.
+    fn ion_type(&self) -> Option<IonType>;
+
+    /// Returns a slice containing all of the annotation symbol IDs for the current value.
+    /// If there is no current value, returns an empty slice.
+    fn annotation_ids(&mut self) -> &[SymbolId];
+
+    /// If the current value is a field within a struct, returns the symbol ID of that
+    /// field's name; otherwise, returns None.
+    fn field_id(&self) -> Option<SymbolId>;
+
+    /// If the current value is a null, returns the Ion type of the null; otherwise,
+    /// returns None.
+    fn read_null(&mut self) -> IonResult<Option<IonType>>;
+
+    /// If the current value is a boolean, returns its value as a bool; otherwise, returns None.
+    fn read_bool(&mut self) -> IonResult<Option<bool>>;
+
+    /// If the current value is an integer, returns its value as an i64; otherwise, returns None.
+    fn read_i64(&mut self) -> IonResult<Option<i64>>;
+
+    /// If the current value is a float, returns its value as an f64; otherwise, returns None.
+    fn read_f64(&mut self) -> IonResult<Option<f64>>;
+
+    /// If the current value is a decimal, returns its value as an BigDecimal; otherwise,
+    /// returns None.
+    fn read_big_decimal(&mut self) -> IonResult<Option<BigDecimal>>;
+
+    /// If the current value is a string, returns its value as a String; otherwise, returns None.
+    fn read_string(&mut self) -> IonResult<Option<String>>;
+
+    /// If the current value is a symbol, returns its value as a SymbolId; otherwise, returns None.
+    fn read_symbol_id(&mut self) -> IonResult<Option<SymbolId>>;
+
+    /// If the current value is a blob, returns its value as a Vec<u8>; otherwise, returns None.
+    fn read_blob_bytes(&mut self) -> IonResult<Option<Vec<u8>>>;
+
+    /// If the current value is a clob, returns its value as a Vec<u8>; otherwise, returns None.
+    fn read_clob_bytes(&mut self) -> IonResult<Option<Vec<u8>>>;
+
+    /// If the current value is a timestamp, returns its value as a DateTime<FixedOffset>;
+    /// otherwise, returns None.
+    fn read_datetime(&mut self) -> IonResult<Option<DateTime<FixedOffset>>>;
+
+    /// If the current value is a container (i.e. a struct, list, or s-expression), positions the
+    /// cursor at the beginning of that container's sequence of child values. If the current value
+    /// is not a container, returns Err.
+    fn step_in(&mut self) -> IonResult<()>;
+
+    /// Positions the cursor at the end of the container currently being traversed. Calling next()
+    /// will position the cursor over the value that follows the container. If the cursor is not in
+    /// a container (i.e. it is already at the top level), returns Err.
+    fn step_out(&mut self) -> IonResult<()>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod result;
 mod binary;
 mod data_source;
 mod types;
+mod cursor;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,6 +2,8 @@
 //! [Ion Data Model](http://amzn.github.io/ion-docs/docs/spec.html#the-ion-data-model)
 //! section of the Ion 1.0 spec.
 
+pub type SymbolId = usize;
+
 mod r#type;
 
 pub use r#type::IonType;


### PR DESCRIPTION
*Description of changes:*

* Adds a `Cursor` trait that captures the format-agnostic, system-level parser functionality needed to navigate within an Ion stream and read the values encountered into native Rust data types.
  * All `read_{data_type}` functions are named after the Rust data type they produce rather than the Ion data type they represent. This accommodates adding other representations in the future. I intend to add other flavors (e.g. `read_i32`, `read_u32`, `read_u64`, etc) soon.
* Adds a dependency on the `chrono` and `bigdecimal` crates to represent `timestamp` and `decimal` respectively.
* Adds a `SymbolId` type. It's currently a type alias for `usize`, allowing it to be used as an index into various containers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
