### PR TITLE
Bin cursor inlining

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ chrono = "~0.4"
 walkdir = "~2.3"
 failure = "~0.1"
 failure_derive = "~0.1"
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -1,0 +1,78 @@
+extern crate ion_rust;
+
+use ion_rust::cursor::StreamItem;
+use ion_rust::result::IonResult;
+use ion_rust::{BinaryIonCursor, Cursor, IonDataSource, IonType};
+use std::fs::File;
+use std::process::exit;
+
+fn main() -> IonResult<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let path = args.get(1).unwrap_or_else(|| {
+        eprintln!("USAGE:\n\n    {} [Binary Ion file]\n", args.get(0).unwrap());
+        eprintln!("No input file was specified.");
+        exit(1);
+    });
+
+    let file = File::open(path)?;
+    let buf_reader = std::io::BufReader::new(file);
+    let mut cursor = BinaryIonCursor::new(buf_reader);
+    let number_of_values = read_all_values(&mut cursor)?;
+    println!("Read {} values", number_of_values);
+    Ok(())
+}
+
+// Visits each value in the stream recursively, reading each scalar into a native Rust type.
+// Prints the total number of values read upon completion.
+fn read_all_values<R: IonDataSource>(cursor: &mut BinaryIonCursor<R>) -> IonResult<usize> {
+    use IonType::*;
+    use StreamItem::*;
+    let mut count: usize = 0;
+    loop {
+        match cursor.next()? {
+            Some(VersionMarker) => {}
+            Some(StreamItem::Value(ion_type, is_null)) => {
+                count += 1;
+                if is_null {
+                    continue;
+                }
+                match ion_type {
+                    Struct | List | SExpression => cursor.step_in()?,
+                    String => {
+                        let _text = cursor.string_ref_map(|_s| ())?.unwrap();
+                    }
+                    Symbol => {
+                        let _symbol_id = cursor.read_symbol_id()?.unwrap();
+                    }
+                    Integer => {
+                        let _int = cursor.read_i64()?.unwrap();
+                    }
+                    Float => {
+                        let _float = cursor.read_f64()?.unwrap();
+                    }
+                    Decimal => {
+                        let _decimal = cursor.read_big_decimal()?.unwrap();
+                    }
+                    Timestamp => {
+                        let _timestamp = cursor.read_datetime()?.unwrap();
+                    }
+                    Boolean => {
+                        let _boolean = cursor.read_bool()?.unwrap();
+                    }
+                    Blob => {
+                        let _blob = cursor.blob_ref_map(|_b| ())?.unwrap();
+                    }
+                    Clob => {
+                        let _clob = cursor.clob_ref_map(|_c| ())?.unwrap();
+                    }
+                    Null => {}
+                }
+            }
+            None if cursor.depth() > 0 => {
+                cursor.step_out()?;
+            }
+            _ => break,
+        }
+    }
+    Ok(count)
+}

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -420,11 +420,11 @@ where
         }
     }
 
-    fn depth(&self) -> usize {
+    pub fn depth(&self) -> usize {
         self.cursor.depth
     }
 
-    fn is_null(&self) -> bool {
+    pub fn is_null(&self) -> bool {
         self.cursor.value.is_null
     }
 
@@ -433,12 +433,14 @@ where
             && self.cursor.bytes_read >= self.cursor.value.last_byte
     }
 
+    #[inline(always)]
     fn read_var_uint(&mut self) -> IonResult<VarUInt> {
         let var_uint = VarUInt::read(&mut self.data_source)?;
         self.cursor.bytes_read += var_uint.size_in_bytes();
         Ok(var_uint)
     }
 
+    #[inline(always)]
     fn read_var_int(&mut self) -> IonResult<VarInt> {
         let var_int = VarInt::read(&mut self.data_source)?;
         self.cursor.bytes_read += var_int.size_in_bytes() as usize;
@@ -447,17 +449,20 @@ where
 
     // Useful when the entire value (all bytes after the type/length header) are represented by
     // a single UInt. (i.e. Integer and Symbol)
+    #[inline(always)]
     fn read_value_as_uint(&mut self) -> IonResult<UInt> {
         let number_of_bytes = self.cursor.value.length_in_bytes;
         self.read_uint(number_of_bytes)
     }
 
+    #[inline(always)]
     fn read_uint(&mut self, number_of_bytes: usize) -> IonResult<UInt> {
         let uint = UInt::read(&mut self.data_source, number_of_bytes)?;
         self.cursor.bytes_read += uint.size_in_bytes();
         Ok(uint)
     }
 
+    #[inline(always)]
     fn read_int(&mut self, number_of_bytes: usize) -> IonResult<Int> {
         let int = Int::read(&mut self.data_source, number_of_bytes)?;
         self.cursor.bytes_read += int.size_in_bytes();
@@ -521,6 +526,7 @@ where
         Ok(length)
     }
 
+    #[inline(always)]
     fn read_next_value_header(&mut self) -> IonResult<Option<Header>> {
         let next_byte: u8 = match self.next_byte() {
             Ok(Some(byte)) => byte,      // This is the one-byte header of the next value.

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1,7 +1,7 @@
 //! This module provides the necessary structures and logic to read values from a binary Ion
 //! data stream.
 mod constants;
-mod cursor;
+pub(crate) mod cursor;
 mod header;
 mod int;
 mod nibbles;

--- a/src/binary/var_uint.rs
+++ b/src/binary/var_uint.rs
@@ -64,12 +64,14 @@ impl VarUInt {
     }
 
     /// Returns the magnitude of the unsigned integer
+    #[inline(always)]
     pub fn value(&self) -> VarUIntStorage {
         self.value
     }
 
     /// Returns the number of bytes that were read from the data source to construct this
     /// unsigned integer
+    #[inline(always)]
     pub fn size_in_bytes(&self) -> VarUIntSizeStorage {
         self.size_in_bytes
     }

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -66,6 +66,7 @@ impl<T: BufRead> IonDataSource for T {
 
     // Returns the next byte in the input buffer if one is available. Otherwise reads one from the
     // underlying data source.
+    #[inline(always)]
     fn next_byte(&mut self) -> IonResult<Option<u8>> {
         match self.fill_buf()?.first() {
             Some(&byte) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,12 @@ extern crate failure_derive;
 
 pub mod result;
 
-mod binary;
-mod cursor;
-mod data_source;
-mod types;
+pub mod binary;
+pub mod cursor;
+pub mod data_source;
+pub mod types;
+
+pub use binary::cursor::BinaryIonCursor;
+pub use cursor::Cursor;
+pub use data_source::IonDataSource;
+pub use types::IonType;


### PR DESCRIPTION
*Description of changes:*

* Adds an example, `read_all_values`, that recursively visits all values in the provided binary Ion file and reads each scalar into a native Rust type.
* Makes a few data types public.
* Configures the `release` build target to perform extra optimizations.
* Sets `#[inline(always)]` on some functions that were hotspots in profiled runs of `read_all_values`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
