### PR TITLE
Added SymbolTable and Reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,6 @@ failure = "~0.1"
 failure_derive = "~0.1"
 
 [dev-dependencies]
-# These are used by the ion_grep example
-crossbeam = "~0.7"
-memmap = "~0.7"
-num_cpus = "~1.13"
-regex = "~1"
 # Used by ion-tests integration
 walkdir = "~2.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,18 @@ edition = "2018"
 bigdecimal = "~0.1"
 bytes = "~0.4"
 chrono = "~0.4"
-walkdir = "~2.3"
+delegate = "0.4.2"
 failure = "~0.1"
 failure_derive = "~0.1"
+
+[dev-dependencies]
+# These are used by the ion_grep example
+crossbeam = "~0.7"
+memmap = "~0.7"
+num_cpus = "~1.13"
+regex = "~1"
+# Used by ion-tests integration
+walkdir = "~2.3"
 
 [profile.release]
 lto = true

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1,6 +1,6 @@
 //! This module provides the necessary structures and logic to read values from a binary Ion
 //! data stream.
-mod constants;
+pub(crate) mod constants;
 pub(crate) mod cursor;
 mod header;
 mod int;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,26 @@
+pub(crate) mod v1_0 {
+    pub const SYSTEM_SYMBOLS: &[&str] = &[
+        "$0",                       // $0
+        "$ion",                     // $1
+        "$ion_1_0",                 // $2
+        "$ion_symbol_table",        // $3
+        "name",                     // $4
+        "version",                  // $5
+        "imports",                  // $6
+        "symbols",                  // $7
+        "max_id",                   // $8
+        "$ion_shared_symbol_table", // $9
+    ];
+
+    pub(crate) mod system_symbol_ids {
+        pub const ION: usize = 1;
+        pub const ION_1_0: usize = 2;
+        pub const ION_SYMBOL_TABLE: usize = 3;
+        pub const NAME: usize = 4;
+        pub const VERSION: usize = 5;
+        pub const IMPORTS: usize = 6;
+        pub const SYMBOLS: usize = 7;
+        pub const MAX_ID: usize = 8;
+        pub const ION_SHARED_SYMBOL_TABLE: usize = 9;
+    }
+}

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -58,6 +58,24 @@ pub trait Cursor<D: IonDataSource> {
     /// If the current value is a string, returns its value as a String; otherwise, returns None.
     fn read_string(&mut self) -> IonResult<Option<String>>;
 
+    /// Runs the provided closure, passing in a reference to the string to be read and allowing a
+    /// calculated value of any type to be returned. When possible, string_ref_map will pass a
+    /// reference directly to the bytes in the input buffer rather than copying the string.
+    fn string_ref_map<F, T>(&mut self, f: F) -> IonResult<Option<T>>
+    where
+        F: FnOnce(&str) -> T;
+
+    /// Runs the provided closure, passing in a reference to the unparsed, unvalidated bytes of
+    /// the string to be read and allowing a calculated value of any type to be returned. When
+    /// possible, string_bytes_map will pass a reference directly to the bytes in the input buffer
+    /// rather than copying the data.
+    ///
+    /// This function can be used to avoid the cost of utf8 validation for strings that are not
+    /// yet known to be of interest.
+    fn string_bytes_map<F, T>(&mut self, f: F) -> IonResult<Option<T>>
+    where
+        F: FnOnce(&[u8]) -> T;
+
     /// If the current value is a symbol, returns its value as a SymbolId; otherwise, returns None.
     fn read_symbol_id(&mut self) -> IonResult<Option<SymbolId>>;
 
@@ -80,6 +98,8 @@ pub trait Cursor<D: IonDataSource> {
     /// will position the cursor over the value that follows the container. If the cursor is not in
     /// a container (i.e. it is already at the top level), returns Err.
     fn step_out(&mut self) -> IonResult<()>;
+
+    fn depth(&self) -> usize;
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,14 @@ pub mod cursor;
 pub mod data_source;
 pub mod types;
 
+mod constants;
+mod reader;
+mod symbol_table;
+
 pub use binary::cursor::BinaryIonCursor;
 pub use cursor::Cursor;
 pub use data_source::IonDataSource;
+pub use reader::Reader;
+pub use symbol_table::SymbolTable;
+pub use symbol_table::SymbolTableEventHandler;
 pub use types::IonType;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,331 @@
+use crate::cursor::StreamItem::*;
+use crate::result::IonResult;
+use crate::symbol_table::SymbolTable;
+use crate::types::SymbolId;
+use crate::{Cursor, IonDataSource, IonType, SymbolTableEventHandler, BinaryIonCursor};
+use crate::constants::v1_0::system_symbol_ids;
+use bigdecimal::BigDecimal;
+use chrono::{DateTime, FixedOffset};
+use delegate::delegate;
+use std::boxed::Box;
+use std::marker::PhantomData;
+use std::io;
+
+/// A streaming Ion reader that resolves symbol IDs into the appropriate text.
+///
+/// Reader itself is format-agnostic; all format-specific logic is handled by the
+/// wrapped Cursor implementation.
+pub struct Reader<D: IonDataSource, C: Cursor<D>> {
+    cursor: C,
+    symbol_table: SymbolTable,
+    spooky: PhantomData<D>,
+    symtab_event_handler: Option<Box<dyn SymbolTableEventHandler>>,
+}
+
+impl<D: IonDataSource, C: Cursor<D>> Reader<D, C> {
+    pub fn new(cursor: C) -> Reader<D, C> {
+        Reader {
+            cursor,
+            symbol_table: SymbolTable::new(),
+            spooky: PhantomData,
+            symtab_event_handler: None,
+        }
+    }
+
+    /// Allows the user to specify an implementation of SymbolTableEventHandler to respond
+    /// to otherwise internal events like symbol table imports and appends.
+    // TODO: Boxing this type means that it is impossible to retrieve from the Reader later.
+    //       This complicates checking the internal state of the handler. We should make
+    //       Reader generic over the handler type and set the Boxed trait object as the default.
+    pub fn set_symtab_event_handler<H>(&mut self, handler: H)
+    where
+        H: 'static + SymbolTableEventHandler,
+    {
+        self.symtab_event_handler = Some(Box::new(handler));
+    }
+
+    /// Advances the cursor to the next user-level Ion value, processing any system-level directives
+    /// encountered along the way.
+    pub fn next(&mut self) -> IonResult<Option<(IonType, bool)>> {
+        loop {
+            match self.cursor.next()? {
+                Some(VersionMarker) => {
+                    self.symbol_table.reset();
+                }
+                Some(Value(IonType::Struct, false)) => {
+                    if let [system_symbol_ids::ION_SYMBOL_TABLE, ..] = self.cursor.annotation_ids() {
+                        self.read_symbol_table()?;
+                    } else {
+                        return Ok(Some((IonType::Struct, false)));
+                    }
+                }
+                Some(Value(ion_type, is_null)) => return Ok(Some((ion_type, is_null))),
+                None => return Ok(None),
+            }
+        }
+    }
+
+    fn read_symbol_table(&mut self) -> IonResult<()> {
+        self.cursor.step_in()?;
+
+        let mut is_append = false;
+        let mut new_symbols = vec![];
+
+        while let Some(Value(ion_type, is_null)) = self.cursor.next()? {
+            let field_id = self
+                .cursor
+                .field_id()
+                .expect("No field ID found inside $ion_symbol_table struct.");
+            match (field_id, ion_type, is_null) {
+                // TODO: This implementation only supports local symbol table imports and appends.
+                (system_symbol_ids::IMPORTS, IonType::Symbol, false) => {
+                    if self.cursor.read_symbol_id()?.unwrap() != 3 {
+                        unimplemented!("Can't handle non-$ion_symbol_table imports value.");
+                    }
+                    is_append = true;
+                }
+                (system_symbol_ids::SYMBOLS, IonType::List, false) => {
+                    self.cursor.step_in()?;
+                    while let Some(Value(IonType::String, false)) = self.cursor.next()? {
+                        let text = self.cursor.read_string()?.unwrap();
+                        new_symbols.push(text);
+                    }
+                    self.cursor.step_out()?;
+                }
+                something_else => {
+                    unimplemented!("No support for {:?}", something_else);
+                }
+            }
+        }
+
+        if is_append {
+            // We're adding new symbols to the end of the symbol table.
+            let new_ids_start = self.symbol_table.len();
+            for new_symbol in new_symbols.drain(..) {
+                let _id = self.symbol_table.intern(new_symbol);
+            }
+            // If a symtab event handler is defined, pass it an immutable reference to the symbol
+            // table and the ID of the first new symbol that was added.
+            self.invoke_on_append_handler(new_ids_start);
+        } else {
+            // The symbol table has been set by defining new symbols without importing the current
+            // symbol table.
+            self.symbol_table.reset();
+            for new_symbol in new_symbols.drain(..) {
+                let _id = self.symbol_table.intern(new_symbol);
+            }
+            // If a symtab event handler is defined, pass it an immutable reference to the symbol
+            // table so it can be inspected.
+            self.invoke_on_reset_handler();
+        }
+
+        self.cursor.step_out()?;
+        Ok(())
+    }
+
+    fn invoke_on_reset_handler(&mut self) {
+        // Temporarily break apart 'self' to get simultaneous references to the symbol table
+        // and the symtab event handler.
+        let Reader {
+            symtab_event_handler,
+            symbol_table,
+            ..
+        } = self;
+        symtab_event_handler
+            .as_mut()
+            .map(|h| h.on_reset(symbol_table));
+    }
+
+    fn invoke_on_append_handler(&mut self, new_ids_start: usize) {
+        // Temporarily break apart 'self' to get simultaneous references to the symbol table
+        // and the symtab event handler.
+        let Reader {
+            symtab_event_handler,
+            symbol_table,
+            ..
+        } = self;
+        symtab_event_handler
+            .as_mut()
+            .map(|h| h.on_append(symbol_table, new_ids_start));
+    }
+
+    pub fn field_name(&self) -> Option<&str> {
+        if let Some(id) = self.cursor.field_id() {
+            return self.symbol_table.text_for(id);
+        }
+        None
+    }
+
+    pub fn annotations(&self) -> impl Iterator<Item=&str> {
+        self.cursor
+            .annotation_ids()
+            .iter()
+            .map(move |sid| self.symbol_table.text_for(sid.clone()).unwrap())
+    }
+
+    pub fn symbol_table(&self) -> &SymbolTable {
+        &self.symbol_table
+    }
+
+    // The Reader needs to expose many of the same functions as the Cursor, but only some of those
+    // need to be re-defined to allow for system value processing. Any method listed here will be
+    // delegated to self.cursor directly.
+    delegate! {
+        to self.cursor {
+            pub fn ion_version(&self) -> (u8, u8);
+            pub fn ion_type(&self) -> Option<IonType>;
+            pub fn annotation_ids(&self) -> &[SymbolId];
+            pub fn field_id(&self) -> Option<SymbolId>;
+            pub fn read_null(&mut self) -> IonResult<Option<IonType>>;
+            pub fn read_bool(&mut self) -> IonResult<Option<bool>>;
+            pub fn read_i64(&mut self) -> IonResult<Option<i64>>;
+            pub fn read_f32(&mut self) -> IonResult<Option<f32>>;
+            pub fn read_f64(&mut self) -> IonResult<Option<f64>>;
+            pub fn read_big_decimal(&mut self) -> IonResult<Option<BigDecimal>>;
+            pub fn read_string(&mut self) -> IonResult<Option<String>>;
+            pub fn string_ref_map<F, T>(&mut self, f: F) -> IonResult<Option<T>> where F: FnOnce(&str) -> T;
+            pub fn string_bytes_map<F, T>(&mut self, f: F) -> IonResult<Option<T>> where F: FnOnce(&[u8]) -> T;
+            pub fn read_symbol_id(&mut self) -> IonResult<Option<SymbolId>>;
+            pub fn read_blob_bytes(&mut self) -> IonResult<Option<Vec<u8>>>;
+            pub fn read_clob_bytes(&mut self) -> IonResult<Option<Vec<u8>>>;
+            pub fn read_datetime(&mut self) -> IonResult<Option<DateTime<FixedOffset>>>;
+            pub fn step_in(&mut self) -> IonResult<()>;
+            pub fn step_out(&mut self) -> IonResult<()>;
+            pub fn depth(&self) -> usize;
+        }
+    }
+}
+
+/// Functionality that is only available if the data source we're reading from is in-memory, like
+/// a Vec<u8> or &[u8].
+impl<T: AsRef<[u8]>> Reader<io::Cursor<T>, BinaryIonCursor<io::Cursor<T>>> {
+    #[inline(always)]
+    pub fn raw_value_bytes(&self) -> Option<&[u8]> {
+        self.cursor.raw_value_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use bigdecimal::BigDecimal;
+    use chrono::{FixedOffset, NaiveDate, TimeZone};
+
+    use crate::binary::constants::v1_0::IVM;
+    use crate::binary::cursor::BinaryIonCursor;
+    use crate::cursor::{Cursor, StreamItem::*, StreamItem};
+    use crate::result::IonResult;
+    use crate::types::IonType;
+    use crate::{Reader, SymbolTableEventHandler, SymbolTable};
+
+    type TestDataSource = io::Cursor<Vec<u8>>;
+
+    // Create a growable byte vector that starts with the Ion 1.0 version marker
+    fn ion_data(bytes: &[u8]) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&IVM);
+        data.extend_from_slice(bytes);
+        data
+    }
+
+    // Creates an io::Cursor over the provided data
+    fn data_source_for(bytes: &[u8]) -> TestDataSource {
+        let data = ion_data(bytes);
+        io::Cursor::new(data)
+    }
+
+    // Prepends an Ion 1.0 IVM to the provided data and then creates a BinaryIonCursor over it
+    fn ion_cursor_for(bytes: &[u8]) -> BinaryIonCursor<TestDataSource> {
+        let mut binary_cursor = BinaryIonCursor::new(data_source_for(bytes));
+        assert_eq!(binary_cursor.ion_type(), None);
+        assert_eq!(binary_cursor.next(), Ok(Some(VersionMarker)));
+        assert_eq!(binary_cursor.ion_version(), (1u8, 0u8));
+        binary_cursor
+    }
+
+    fn ion_reader_for(bytes: &[u8]) -> Reader<TestDataSource, BinaryIonCursor<TestDataSource>> {
+        Reader::new(ion_cursor_for(bytes))
+    }
+
+    const EXAMPLE_STREAM: &[u8] = &[
+
+        // $ion_symbol_table::{imports: $ion_symbol_table, symbols: ["foo", "bar", "baz"]}
+
+        0xEE, // Var len annotations
+        0x94, // Annotations + Value length: 20 bytes
+        0x81, // Annotations length: 1
+        0x83, // Annotation 3 ('$ion_symbol_table')
+
+        0xDE, // Var len struct
+        0x91, // Length: 17 bytes
+
+        0x86, // Field ID 6 ('imports')
+        0x71, 0x03, // Symbol 3 ('$ion_symbol_table')
+
+        0x87, // Field ID 7 ('symbols')
+        0xBC, // 12-byte List
+        0x83, 0x66, 0x6f, 0x6f, // "foo"
+        0x83, 0x62, 0x61, 0x72, // "bar"
+        0x83, 0x62, 0x61, 0x7a, // "baz"
+
+        // System: {$10: 1, $11: 2, $12: 3}
+        // User: {foo: 1, bar: 1, baz: 1}
+
+        0xD9, // 9-byte struct
+        0x8A, // Field ID 10
+        0x21, 0x01, // Integer 1
+        0x8B, // Field ID 11
+        0x21, 0x02, // Integer 2
+        0x8C, // Field ID 12
+        0x21, 0x03, // Integer 3
+    ];
+
+    #[test]
+    fn test_read_struct() -> IonResult<()> {
+        let mut reader = ion_reader_for(EXAMPLE_STREAM);
+        let handler = Handler {append_occurred: false};
+        reader.set_symtab_event_handler(handler);
+
+        assert_eq!(Some((IonType::Struct, false)), reader.next()?);
+        reader.step_in()?;
+
+        assert_eq!(reader.next()?, Some((IonType::Integer, false)));
+        assert_eq!(reader.field_name(), Some("foo"));
+
+        assert_eq!(reader.next()?, Some((IonType::Integer, false)));
+        assert_eq!(reader.field_name(), Some("bar"));
+
+        assert_eq!(reader.next()?, Some((IonType::Integer, false)));
+        assert_eq!(reader.field_name(), Some("baz"));
+
+        Ok(())
+    }
+
+    struct Handler {
+        append_occurred: bool
+    }
+
+    impl SymbolTableEventHandler for Handler {
+        fn on_append<'a>(&'a mut self, symbol_table: &'a SymbolTable, starting_id: usize) {
+            let new_symbols = symbol_table.symbols_tail(starting_id);
+            assert_eq!(3, new_symbols.len());
+            assert_eq!("foo", new_symbols[0].as_str());
+            assert_eq!("bar", new_symbols[1].as_str());
+            assert_eq!("baz", new_symbols[2].as_str());
+        }
+
+        fn on_reset<'a>(&'a mut self, symbol_table: &'a SymbolTable) {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn test_symbol_table_on_append_event_handler() -> IonResult<()> {
+        let mut reader = ion_reader_for(EXAMPLE_STREAM);
+
+        assert_eq!(Some((IonType::Struct, false)), reader.next()?);
+
+        Ok(())
+    }
+}

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -1,0 +1,85 @@
+use std::collections::HashMap;
+
+use crate::constants::v1_0;
+use crate::types::SymbolId;
+
+/// Stores mappings from Symbol IDs to text and vice-versa.
+pub struct SymbolTable {
+    symbols_by_id: Vec<String>,
+    ids_by_text: HashMap<String, SymbolId>,
+}
+
+impl SymbolTable {
+    /// Constructs a new symbol table pre-populated with the system symbols defined in the spec.
+    pub fn new() -> SymbolTable {
+        let mut symbol_table = SymbolTable {
+            symbols_by_id: Vec::with_capacity(v1_0::SYSTEM_SYMBOLS.len()),
+            ids_by_text: HashMap::new(),
+        };
+        symbol_table.initialize();
+        symbol_table
+    }
+
+    // Interns the v1.0 system symbols
+    fn initialize(&mut self) {
+        for (id, text) in v1_0::SYSTEM_SYMBOLS.iter().enumerate() {
+            self.symbols_by_id.push(text.to_string());
+            self.ids_by_text.insert(text.to_string(), id);
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.symbols_by_id.clear();
+        self.ids_by_text.clear();
+        self.initialize();
+    }
+
+    pub fn intern(&mut self, text: String) -> SymbolId {
+        // If the text is already in the symbol table, return the ID associated with it.
+        if let Some(id) = self.ids_by_text.get(&text) {
+            return *id;
+        }
+
+        // Otherwise, intern it and return the new ID.
+        let id = self.symbols_by_id.len();
+        self.symbols_by_id.push(text.to_string());
+        self.ids_by_text.insert(text, id);
+        id
+    }
+
+    /// If defined, returns the Symbol ID associated with the provided text.
+    pub fn sid_for<A: AsRef<str>>(&self, text: &A) -> Option<SymbolId> {
+        self.ids_by_text.get(text.as_ref()).copied()
+    }
+
+    /// If defined, returns the text associated with the provided Symbol ID.
+    pub fn text_for(&self, sid: usize) -> Option<&str> {
+        self.symbols_by_id.get(sid).map(|text| text.as_str())
+    }
+
+    // Returns a slice of references to the symbol text stored in the table.
+    pub fn symbols(&self) -> &[String] {
+        &self.symbols_by_id
+    }
+
+    // Returns a slice of references to the symbol text stored in the table starting at the given
+    // symbol ID. If a symbol table append occurs during reading, this function can be used to
+    // easily view the new symbols that has been added to the table.
+    pub fn symbols_tail(&self, start: usize) -> &[String] {
+        &self.symbols_by_id[start..]
+    }
+
+    // The number of symbols defined in the table.
+    pub fn len(&self) -> usize {
+        self.symbols_by_id.len()
+    }
+}
+
+/// Functions that will be called when the reader handles system-level events that would otherwise
+/// not be surfaced to the user level.
+pub trait SymbolTableEventHandler {
+    /// Invoked when new symbols are added to the end of the existing table.
+    fn on_append<'a>(&'a mut self, symbol_table: &'a SymbolTable, starting_id: usize);
+    /// Invoked when the active symbol table is reset, potentially defining new symbols.
+    fn on_reset<'a>(&'a mut self, symbol_table: &'a SymbolTable);
+}


### PR DESCRIPTION
*Description of changes:*

Added:
* SymbolTable
* Format-agnostic impl of Reader
* SymbolTableEventHandler trait
* New cursor function `raw_value_bytes()`, which allows safe access to a value's unparsed bytes without advancing the cursor. This is helpful for performance-sensitive searching/filtering and is only available for cursors over in-memory data sources like byte arrays.

Moved some functions from `BinaryIonCursor` into the `Cursor` trait itself:
* `depth()`
* `string_ref_map()`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
