### PR TITLE
Adds Github Action configurations for macOS and Windows.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,15 +3,41 @@ name: Rust
 on: [push]
 
 jobs:
-  build:
-
+  linux:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@master
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests (ion-rust)
+        run: cargo test --verbose
+
+  macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests (ion-rust)
+        run: cargo test --verbose
+
+  windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests (ion-rust)
+        run: cargo test --verbose


### PR DESCRIPTION
Also Updates `actions/checkout@v2` to use recursive submodule checkout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
