### PR TITLE
Adds ion-c-sys crate example doc tests.

### DIFF
--- a/ion-c-sys/build.rs
+++ b/ion-c-sys/build.rs
@@ -34,6 +34,7 @@ fn main() {
         .clang_arg("-DDECNUMDIGITS=34")
         // invalidate the build whenever underlying headers change
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .derive_default(true)
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
Adds some full cookbook style API documentation for direct Ion C API interaction.

* Adds `Default` derivation for `bindgen` APIs.
* Implements examples directly against the low-level API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
