### PR TITLE
Adds reader/writer modules.

### DIFF
--- a/ion-c-sys/src/lib.rs
+++ b/ion-c-sys/src/lib.rs
@@ -16,59 +16,50 @@
 //! use std::ptr;
 //! use std::slice;
 //! use std::str;
+//! 
+//! use std::convert::TryFrom;
 //!
 //! use ion_c_sys::*;
+//! use ion_c_sys::reader::*;
 //! use ion_c_sys::result::*;
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //!
-//! use std::error::Error;
 //! let mut input = String::from("{a:2}");
 //!
-//! let mut ion_reader: hREADER = ptr::null_mut();
-//! let mut ion_type: ION_TYPE = ptr::null_mut();
-//!
-//! // open the reader over a buffer
-//! ionc!(ion_reader_open_buffer(
-//!     &mut ion_reader,
-//!     input.as_mut_ptr(),
-//!     input.len() as i32,
-//!     ptr::null_mut() // default options
-//! ))?;
+//! let reader: IonCReaderHandle = IonCReaderHandle::try_from(input.as_mut_str())?;
+//! let mut tid: ION_TYPE = ptr::null_mut();
 //!
 //! // step to the struct
-//! ionc!(ion_reader_next(ion_reader, &mut ion_type))?;
-//! assert_eq!(ion_type, ION_TYPE_STRUCT);
+//! ionc!(ion_reader_next(*reader, &mut tid))?;
+//! assert_eq!(tid, ION_TYPE_STRUCT);
 //!
 //! // step into the struct
-//! ionc!(ion_reader_step_in(ion_reader))?;
+//! ionc!(ion_reader_step_in(*reader))?;
 //!
 //! // step to the field
-//! ionc!(ion_reader_next(ion_reader, &mut ion_type))?;
-//! assert_eq!(ion_type, ION_TYPE_INT);
+//! ionc!(ion_reader_next(*reader, &mut tid))?;
+//! assert_eq!(tid, ION_TYPE_INT);
 //!
 //! // retrieve the field name--which is 'borrowed' while we don't move the reader
 //! let mut ion_str = ION_STRING::default();
-//! ionc!(ion_reader_get_field_name(ion_reader, &mut ion_str))?;
+//! ionc!(ion_reader_get_field_name(*reader, &mut ion_str))?;
 //! assert_eq!(ion_str.as_str()?, "a");
 //!
 //! // read the integer value
 //! let mut int_value: i64 = 0;
-//! ionc!(ion_reader_read_int64(ion_reader, &mut int_value))?;
+//! ionc!(ion_reader_read_int64(*reader, &mut int_value))?;
 //! assert_eq!(int_value, 2);
 //!
 //! // step to the end of the struct
-//! ionc!(ion_reader_next(ion_reader, &mut ion_type))?;
-//! assert_eq!(ion_type, ION_TYPE_EOF);
+//! ionc!(ion_reader_next(*reader, &mut tid))?;
+//! assert_eq!(tid, ION_TYPE_EOF);
 //!
 //! // step out of the struct
-//! ionc!(ion_reader_step_out(ion_reader))?;
+//! ionc!(ion_reader_step_out(*reader))?;
 //!
 //! // step to the end of the stream
-//! ionc!(ion_reader_next(ion_reader, &mut ion_type))?;
-//! assert_eq!(ion_type, ION_TYPE_EOF);
-//!
-//! // close the reader
-//! ionc!(ion_reader_close(ion_reader));
+//! ionc!(ion_reader_next(*reader, &mut tid))?;
+//! assert_eq!(tid, ION_TYPE_EOF);
 //!
 //! # Ok(())
 //! # }
@@ -79,51 +70,48 @@
 //!
 //! ```
 //! use std::ptr;
+//! use std::convert::TryInto;
 //!
 //! use ion_c_sys::*;
 //! use ion_c_sys::result::*;
+//! use ion_c_sys::writer::*;
 //! # fn main() -> IonCResult {
 //!
 //! // output buffer
 //! let mut buf: Vec<u8> = vec![0; 128];
 //!
 //! // writer options--emit binary
-//! let mut writer_options = ION_WRITER_OPTIONS::default();
-//! writer_options.output_as_binary = 1;
+//! let mut options = ION_WRITER_OPTIONS {
+//!     output_as_binary: 1,
+//!     .. ION_WRITER_OPTIONS::default()
+//! };
 //!
-//! let mut ion_writer: hWRITER = ptr::null_mut();
+//! let mut len = 0;
+//! {
+//!     let writer = IonCWriterHandle::new_buf(buf.as_mut(), &mut options)?;
 //!
-//! // construct a writer
-//! ionc!(ion_writer_open_buffer(
-//!     &mut ion_writer,
-//!     buf.as_mut_ptr(),
-//!     buf.len() as i32,
-//!     &mut writer_options
-//! ))?;
+//!     // start a list
+//!     ionc!(ion_writer_start_container(*writer, ION_TYPE_LIST))?;
 //!
-//! // start a list
-//! ionc!(ion_writer_start_container(ion_writer, ION_TYPE_LIST))?;
+//!     // write some integers
+//!     for n in 0..4 {
+//!         ionc!(ion_writer_write_int64(*writer, n * 2))?;
+//!     }
 //!
-//! // write some integers
-//! for n in 0..4 {
-//!     ionc!(ion_writer_write_int64(ion_writer, n * 2))?;
+//!     // end the list
+//!     ionc!(ion_writer_finish_container(*writer))?;
+//!
+//!     // write a string--note that we have to make a ION_STRING to 'borrow' a reference to
+//!     let mut value = String::from("💩");
+//!     let mut ion_str = ION_STRING::from(value.as_mut());
+//!     ionc!(ion_writer_write_string(*writer, &mut ion_str))?;
+//!
+//!     // finish writing
+//!     ionc!(ion_writer_finish(*writer, &mut len))?;
 //! }
 //!
-//! // end the list
-//! ionc!(ion_writer_finish_container(ion_writer))?;
-//!
-//! // write a string--note that we have to make a ION_STRING to 'borrow' a reference to
-//! let mut value = String::from("💩");
-//! let mut ion_str = ION_STRING::from(value.as_mut_str());
-//! ionc!(ion_writer_write_string(ion_writer, &mut ion_str))?;
-//!
-//! // finish writing
-//! let mut bytes_written = 0;
-//! ionc!(ion_writer_finish(ion_writer, &mut bytes_written))?;
-//!
 //! // make sure the bytes match what we expect
-//! assert_eq!(bytes_written, 17);
-//! buf.truncate(bytes_written as usize);
+//! assert_eq!(len, 17);
 //! let expected: Vec<u8> = vec![
 //!     0xE0, 0x01, 0x00, 0xEA,         // IVM
 //!     0xB7,                           // LIST size 7
@@ -133,7 +121,8 @@
 //!     0x21, 0x06,                     // INT 6
 //!     0x84, 0xF0, 0x9F, 0x92, 0xA9,   // STRING 💩
 //! ];
-//! assert_eq!(&buf, &expected);
+//! assert_eq!(&buf[0..len.try_into()?], expected.as_slice());
+//!
 //! # Ok(())
 //! # }
 //! ```

--- a/ion-c-sys/src/lib.rs
+++ b/ion-c-sys/src/lib.rs
@@ -143,6 +143,8 @@
 #![allow(non_snake_case)]
 
 pub mod result;
+pub mod reader;
+pub mod writer;
 
 include!(concat!(env!("OUT_DIR"), "/ionc_bindings.rs"));
 

--- a/ion-c-sys/src/reader.rs
+++ b/ion-c-sys/src/reader.rs
@@ -1,0 +1,99 @@
+use std::convert::{TryFrom, TryInto};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::ptr;
+
+use crate::result::*;
+use crate::*;
+
+// NB that this cannot be made generic with respect to IonCWriterHandle because
+// Rust does not support specialization of Drop.
+
+/// Wrapper over `hREADER` to make it easier to use readers in IonC correctly.
+///
+/// Specifically supports the `Drop` trait to make sure `ion_reader_close` is run.
+/// Access to the underlying `hREADER` pointer is done by de-referencing the handle.
+///
+/// ## Usage
+/// ```
+/// # use ion_c_sys::*;
+/// # use ion_c_sys::reader::*;
+/// # use ion_c_sys::result::*;
+/// # use std::convert::*;
+/// # use std::ptr;
+/// # fn main() -> IonCResult {
+/// let mut buf = String::from("hello");
+/// let reader_handle = IonCReaderHandle::try_from(buf.as_mut_str())?;
+///
+/// let mut ion_type = ptr::null_mut();
+/// ionc!(ion_reader_next(*reader_handle, &mut ion_type))?;
+/// assert_eq!(ION_TYPE_SYMBOL, ion_type);
+///
+/// // reader_handle implements Drop, so we're good to go!
+/// # Ok(())
+/// # }
+/// ```
+pub struct IonCReaderHandle<'a> {
+    reader: hREADER,
+    /// Placeholder to tie our lifecycle back to the source of the data--which might not
+    /// actually be a byte slice (if we constructed this from a file or Ion C stream callback)
+    referent: PhantomData<&'a mut [u8]>,
+}
+
+impl<'a> IonCReaderHandle<'a> {
+    /// Constructs a reader handle from a mutable slice and given options.
+    pub fn new_buf(src: &'a mut [u8], options: &mut ION_READER_OPTIONS) -> Result<Self, IonCError> {
+        let mut reader = ptr::null_mut();
+        ionc!(ion_reader_open_buffer(
+            &mut reader,
+            src.as_mut_ptr(),
+            src.len().try_into()?,
+            options,
+        ))?;
+        Ok(IonCReaderHandle {
+            reader,
+            referent: PhantomData::default(),
+        })
+    }
+}
+
+impl<'a> TryFrom<&'a mut [u8]> for IonCReaderHandle<'a> {
+    type Error = IonCError;
+
+    /// Constructs a reader from a mutable slice with the default options.
+    #[inline]
+    fn try_from(src: &'a mut [u8]) -> Result<Self, Self::Error> {
+        Self::new_buf(src, &mut ION_READER_OPTIONS::default())
+    }
+}
+
+impl<'a> TryFrom<&'a mut str> for IonCReaderHandle<'a> {
+    type Error = IonCError;
+    /// Constructs a reader from a mutable str with the default options.
+    #[inline]
+    fn try_from(src: &'a mut str) -> Result<Self, Self::Error> {
+        unsafe { Self::try_from(src.as_bytes_mut()) }
+    }
+}
+
+impl Deref for IonCReaderHandle<'_> {
+    type Target = hREADER;
+
+    fn deref(&self) -> &Self::Target {
+        &self.reader
+    }
+}
+
+impl DerefMut for IonCReaderHandle<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.reader
+    }
+}
+
+impl Drop for IonCReaderHandle<'_> {
+    fn drop(&mut self) {
+        if !self.reader.is_null() {
+            ionc!(ion_reader_close(self.reader)).unwrap()
+        }
+    }
+}

--- a/ion-c-sys/src/result.rs
+++ b/ion-c-sys/src/result.rs
@@ -3,6 +3,7 @@ use crate::*;
 use std::ffi::CStr;
 use std::error::Error;
 use std::fmt;
+use std::num::TryFromIntError;
 
 /// IonC Error code and its associated error message.
 #[derive(Copy, Clone, Debug)]
@@ -36,6 +37,14 @@ impl fmt::Display for IonCError {
 }
 
 impl Error for IonCError {}
+
+impl From<TryFromIntError> for IonCError {
+    /// Due to the way Ion C works with sizes as i32, it is convenient to be able to coerce
+    /// a TryFromIntError to `IonCError`.
+    fn from(_: TryFromIntError) -> Self {
+        IonCError::from(ion_error_code_IERR_NUMERIC_OVERFLOW)
+    }
+}
 
 /// A type alias to results from Ion C functions, the result value is `()` to signify
 /// `ion_error_code_IERR_OK` since Ion C doesn't return results but generally takes

--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -33,7 +33,7 @@ use crate::*;
 ///         output_as_binary: 1,
 ///         .. Default::default()
 ///     };
-///     let writer = IonCWriterHandle::new_buf(buf.as_mut_slice(), &mut options)?;
+///     let writer = IonCWriterHandle::new_buf(buf.as_mut(), &mut options)?;
 ///
 ///     // write something
 ///     ionc!(ion_writer_write_int64(*writer, 4))?;

--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -57,7 +57,7 @@ pub struct IonCWriterHandle<'a> {
 }
 
 impl<'a> IonCWriterHandle<'a> {
-    /// Construct
+    /// Construct a writer to a given mutable slice with options.
     pub fn new_buf(buf: &'a mut [u8], options: &mut ION_WRITER_OPTIONS) -> Result<Self, IonCError> {
         let mut writer = ptr::null_mut();
         ionc!(ion_writer_open_buffer(

--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -1,0 +1,97 @@
+use std::convert::TryInto;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::ptr;
+
+use crate::result::*;
+use crate::*;
+
+// NB that this cannot be made generic with respect to IonCReaderHandle because
+// Rust does not support specialization of Drop.
+
+/// Wrapper over `hWRITER` to make it easier to writers in IonC correctly.
+///
+/// Specifically supports the `Drop` trait to make sure `ion_writer_close` is run.
+/// Access to the underlying `hWRITER` pointer is done by de-referencing the handle.
+///
+/// ## Usage
+/// ```
+/// # use ion_c_sys::*;
+/// # use ion_c_sys::writer::*;
+/// # use ion_c_sys::result::*;
+/// # use std::convert::*;
+/// # use std::ptr;
+/// # fn main() -> IonCResult {
+/// // a buffer to write to
+/// let mut buf = vec![0u8; 12usize];
+/// let mut len = 0;
+///
+/// // borrow the buffer for writing!
+/// {
+///     // write in binary
+///     let mut options = ION_WRITER_OPTIONS {
+///         output_as_binary: 1,
+///         .. Default::default()
+///     };
+///     let writer = IonCWriterHandle::new_buf(buf.as_mut_slice(), &mut options)?;
+///
+///     // write something
+///     ionc!(ion_writer_write_int64(*writer, 4))?;
+///
+///     // finish up the writing
+///     ionc!(ion_writer_finish(*writer, &mut len))?;
+///
+///     // handle implements Drop, so we're good to go!
+/// }
+///
+/// let written = &buf[0..len.try_into()?];
+/// assert_eq!(b"\xE0\x01\x00\xEA\x21\x04", written);
+/// # Ok(())
+/// # }
+/// ```
+pub struct IonCWriterHandle<'a> {
+    writer: hWRITER,
+    /// Placeholder to tie our lifecycle back to the source of the data--which might not
+    /// actually be a byte slice (if we constructed this from a file or Ion C stream callback)
+    referent: PhantomData<&'a mut [u8]>,
+}
+
+impl<'a> IonCWriterHandle<'a> {
+    /// Construct
+    pub fn new_buf(buf: &'a mut [u8], options: &mut ION_WRITER_OPTIONS) -> Result<Self, IonCError> {
+        let mut writer = ptr::null_mut();
+        ionc!(ion_writer_open_buffer(
+            &mut writer,
+            buf.as_mut_ptr(),
+            buf.len().try_into()?,
+            options
+        ))?;
+
+        Ok(IonCWriterHandle {
+            writer,
+            referent: PhantomData::default(),
+        })
+    }
+}
+
+impl Deref for IonCWriterHandle<'_> {
+    type Target = hWRITER;
+
+    fn deref(&self) -> &Self::Target {
+        &self.writer
+    }
+}
+
+impl DerefMut for IonCWriterHandle<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.writer
+    }
+}
+
+impl Drop for IonCWriterHandle<'_> {
+    fn drop(&mut self) {
+        if !self.writer.is_null() {
+            ionc!(ion_writer_close(self.writer)).unwrap()
+        }
+    }
+}


### PR DESCRIPTION
* Adds `IonCReaderHandle` and `IonCWriterHandle` which are smart pointer
  types over `hREADER` and `hWRITER` respectively that ensure that the
  Ion C close methods get invoked in RAII style code.
* Adds TryFromIntError to make doing safe coercions from things like
  `usize` to `i32` easier within the context of `IonCError`.

More progress on #37.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
