### PR TITLE
Removes unused constant from 'good' tests.

### DIFF
--- a/tests/good.rs
+++ b/tests/good.rs
@@ -12,7 +12,6 @@ use ion_rust::result::{decoding_error, IonResult};
 use ion_rust::{BinaryIonCursor, IonType, Reader};
 
 const GOOD_TEST_FILES_PATH: &str = "ion-tests/iontestdata/good/";
-const BAD_TEST_FILES_PATH: &str = "ion-tests/iontestdata/bad/";
 
 // TODO: Populate skip list
 const GOOD_TEST_FILES_SKIP_LIST: &[&str] = &[


### PR DESCRIPTION
This has been annoying me for a while due to compiler warnings--I was going to make it `#[allow(dead_code)]`, but I don't even think this constant belongs in this file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
