### PR TITLE
Adds a high-level facade on IonCReaderHandle.

### DIFF
--- a/ion-c-sys/src/lib.rs
+++ b/ion-c-sys/src/lib.rs
@@ -166,7 +166,7 @@ impl ION_STRING {
         }
     }
 
-    /// Constructs an `ION_STRING` from a `&mut [u8]]`.
+    /// Constructs an `ION_STRING` from a `&mut [u8]`.
     ///
     /// Note that this is effectively Ion C's `&mut [u8]` type so lifetime is managed
     /// manually by the caller.

--- a/ion-c-sys/src/reader.rs
+++ b/ion-c-sys/src/reader.rs
@@ -134,7 +134,7 @@ impl<'a> IonCReaderHandle<'a> {
         Ok(depth)
     }
 
-    /// Returns if the reader positioned on a `null` value.
+    /// Returns if the reader is positioned on a `null` value.
     ///
     /// ## Usage
     /// ```
@@ -161,7 +161,7 @@ impl<'a> IonCReaderHandle<'a> {
         Ok(is_null != 0)
     }
 
-    /// Returns if the reader positioned within a `struct` value.
+    /// Returns if the reader is positioned within a `struct` value.
     /// ## Usage
     /// ```
     /// # use std::convert::*;
@@ -187,7 +187,7 @@ impl<'a> IonCReaderHandle<'a> {
         Ok(is_in_struct != 0)
     }
 
-    /// Returns the field name of the reader positioned within a structure.
+    /// Returns the field name if the reader positioned within a structure.
     ///
     /// ## Usage
     /// ```

--- a/ion-c-sys/src/reader.rs
+++ b/ion-c-sys/src/reader.rs
@@ -5,6 +5,7 @@ use std::ptr;
 
 use crate::result::*;
 use crate::*;
+use crate::string::IonCStringRef;
 
 // NB that this cannot be made generic with respect to IonCWriterHandle because
 // Rust does not support specialization of Drop.
@@ -21,13 +22,12 @@ use crate::*;
 /// # use ion_c_sys::result::*;
 /// # use std::convert::*;
 /// # use std::ptr;
-/// # fn main() -> IonCResult {
-/// let mut buf = String::from("hello");
-/// let reader_handle = IonCReaderHandle::try_from(buf.as_mut_str())?;
+/// # fn main() -> IonCResult<()> {
+/// let mut buf = b"hello".to_vec();
+/// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
 ///
-/// let mut ion_type = ptr::null_mut();
-/// ionc!(ion_reader_next(*reader_handle, &mut ion_type))?;
-/// assert_eq!(ION_TYPE_SYMBOL, ion_type);
+/// let tid = reader.next()?;
+/// assert_eq!(ION_TYPE_SYMBOL, tid);
 ///
 /// // reader_handle implements Drop, so we're good to go!
 /// # Ok(())
@@ -55,6 +55,317 @@ impl<'a> IonCReaderHandle<'a> {
             referent: PhantomData::default(),
         })
     }
+
+    /// Advances the reader to the next value and returns the type.
+    #[inline]
+    pub fn next(&mut self) -> IonCResult<ION_TYPE> {
+        let mut tid = ptr::null_mut();
+        ionc!(ion_reader_next(self.reader, &mut tid))?;
+
+        Ok(tid)
+    }
+
+    /// Returns the type of the current position.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = b"'''hello!'''".to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_NONE, reader.get_type()?);
+    /// assert_eq!(ION_TYPE_STRING, reader.next()?);
+    /// assert_eq!(ION_TYPE_STRING, reader.get_type()?);
+    /// assert_eq!(ION_TYPE_EOF, reader.next()?);
+    /// assert_eq!(ION_TYPE_EOF, reader.get_type()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn get_type(&self) -> IonCResult<ION_TYPE> {
+        let mut tid = ptr::null_mut();
+        ionc!(ion_reader_get_type(self.reader, &mut tid))?;
+
+        Ok(tid)
+    }
+
+    /// Steps in to the current container.
+    #[inline]
+    pub fn step_in(&mut self) -> IonCResult<()> {
+        ionc!(ion_reader_step_in(self.reader))
+    }
+
+    /// Steps out of the current container.
+    #[inline]
+    pub fn step_out(&mut self) -> IonCResult<()> {
+        ionc!(ion_reader_step_out(self.reader))
+    }
+
+    /// Returns the current container depth.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = b"[[]]".to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_LIST, reader.next()?);
+    /// reader.step_in()?;
+    /// assert_eq!(1, reader.depth()?);
+    /// assert_eq!(ION_TYPE_LIST, reader.next()?);
+    /// reader.step_in()?;
+    /// assert_eq!(2, reader.depth()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn depth(&self) -> IonCResult<i32> {
+        let mut depth = 0;
+        ionc!(ion_reader_get_depth(self.reader, &mut depth))?;
+
+        Ok(depth)
+    }
+
+    /// Returns if the reader positioned on a `null` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = b"null.int 4".to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_INT, reader.next()?);
+    /// assert!(reader.is_null()?);
+    /// assert_eq!(ION_TYPE_INT, reader.next()?);
+    /// assert!(!reader.is_null()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn is_null(&self) -> IonCResult<bool> {
+        let mut is_null = 0;
+        ionc!(ion_reader_is_null(self.reader, &mut is_null))?;
+
+        Ok(is_null != 0)
+    }
+
+    /// Returns if the reader positioned within a `struct` value.
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = b"{}".to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_STRUCT, reader.next()?);
+    /// assert!(!reader.is_in_struct()?);
+    /// reader.step_in()?;
+    /// assert!(reader.is_in_struct()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn is_in_struct(&self) -> IonCResult<bool> {
+        let mut is_in_struct = 0;
+        ionc!(ion_reader_is_in_struct(self.reader, &mut is_in_struct))?;
+
+        Ok(is_in_struct != 0)
+    }
+
+    /// Returns the field name of the reader positioned within a structure.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # use ion_c_sys::string::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = b"{a:5}".to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_STRUCT, reader.next()?);
+    /// assert!(reader.get_field_name()?.value.is_null());
+    /// reader.step_in()?;
+    /// assert!(reader.get_field_name()?.value.is_null());
+    /// assert_eq!(ION_TYPE_INT, reader.next()?);
+    /// assert_eq!("a", reader.get_field_name()?.try_as_str()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn get_field_name(&mut self) -> IonCResult<IonCStringRef> {
+        let mut field = ION_STRING::default();
+        ionc!(ion_reader_get_field_name(self.reader, &mut field))?;
+
+        Ok(IonCStringRef::new(self, field))
+    }
+
+    // TODO annotation support
+
+    /// Reads a `bool` value from the reader.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = b"true".to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_BOOL, reader.next()?);
+    /// assert!(reader.read_bool()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn read_bool(&mut self) -> IonCResult<bool> {
+        let mut value = 0;
+        ionc!(ion_reader_read_bool(self.reader, &mut value))?;
+
+        Ok(value != 0)
+    }
+
+    /// Reads an `int` value from the reader.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = b"42".to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_INT, reader.next()?);
+    /// assert_eq!(42, reader.read_i64()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn read_i64(&mut self) -> IonCResult<i64> {
+        let mut value = 0;
+        ionc!(ion_reader_read_int64(self.reader, &mut value))?;
+
+        Ok(value)
+    }
+
+    /// Reads a `float` value from the reader.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = b"3.0e0".to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_FLOAT, reader.next()?);
+    /// assert_eq!(3.0, reader.read_f64()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn read_f64(&mut self) -> IonCResult<f64> {
+        let mut value = 0.0;
+        ionc!(ion_reader_read_double(self.reader, &mut value))?;
+
+        Ok(value)
+    }
+
+    // TODO support ION_INT (arbitrary large integer) reads
+    // TODO support decimal reads
+    // TODO support timestamp reads
+
+    /// Reads a `string`/`symbol` value from the reader.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = "\"🦄\" '✨'".as_bytes().to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_STRING, reader.next()?);
+    /// assert_eq!("🦄", reader.read_string()?.try_as_str()?);
+    /// assert_eq!(ION_TYPE_SYMBOL, reader.next()?);
+    /// assert_eq!("✨", reader.read_string()?.try_as_str()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn read_string(&mut self) -> IonCResult<IonCStringRef> {
+        let mut value = ION_STRING::default();
+        ionc!(ion_reader_read_string(self.reader, &mut value))?;
+
+        Ok(IonCStringRef::new(self, value))
+    }
+
+    /// Reads a `clob`/`blob` value from the reader.
+    ///
+    /// This method implements a vector on the heap to store a copy of the LOB.
+    /// If this is not desired, use the low-level length and read methods directly.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = "{{\"hello\"}} {{d29ybGQ=}}".as_bytes().to_vec();
+    /// let mut reader = IonCReaderHandle::try_from(buf.as_mut_slice())?;
+    ///
+    /// assert_eq!(ION_TYPE_CLOB, reader.next()?);
+    /// assert_eq!(b"hello", reader.read_bytes()?.as_slice());
+    /// assert_eq!(ION_TYPE_BLOB, reader.next()?);
+    /// assert_eq!(b"world", reader.read_bytes()?.as_slice());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn read_bytes(&mut self) -> IonCResult<Vec<u8>> {
+        let mut len = 0;
+        ionc!(ion_reader_get_lob_size(self.reader, &mut len))?;
+
+        let mut read_len = 0;
+        let mut buf = vec![0; len.try_into()?];
+        ionc!(ion_reader_read_lob_bytes(
+            self.reader,
+            buf.as_mut_ptr(),
+            buf.len().try_into()?,
+            &mut read_len
+        ))?;
+        if len != read_len {
+            Err(IonCError::from(ion_error_code_IERR_INVALID_STATE))
+        } else {
+            Ok(buf)
+        }
+    }
 }
 
 impl<'a> TryFrom<&'a mut [u8]> for IonCReaderHandle<'a> {
@@ -79,12 +390,14 @@ impl<'a> TryFrom<&'a mut str> for IonCReaderHandle<'a> {
 impl Deref for IonCReaderHandle<'_> {
     type Target = hREADER;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.reader
     }
 }
 
 impl DerefMut for IonCReaderHandle<'_> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.reader
     }

--- a/ion-c-sys/src/reader.rs
+++ b/ion-c-sys/src/reader.rs
@@ -217,7 +217,7 @@ impl<'a> IonCReaderHandle<'a> {
         Ok(IonCStringRef::new(self, field))
     }
 
-    // TODO annotation support
+    // TODO ion-rust/#48 - annotation support
 
     /// Reads a `bool` value from the reader.
     ///
@@ -294,9 +294,9 @@ impl<'a> IonCReaderHandle<'a> {
         Ok(value)
     }
 
-    // TODO support ION_INT (arbitrary large integer) reads
-    // TODO support decimal reads
-    // TODO support timestamp reads
+    // TODO ion-rust/#50 - support ION_INT (arbitrary large integer) reads
+    // TODO ion-rust/#42 - support decimal reads
+    // TODO ion-rust/#43 - support timestamp reads
 
     /// Reads a `string`/`symbol` value from the reader.
     ///

--- a/ion-c-sys/src/string.rs
+++ b/ion-c-sys/src/string.rs
@@ -1,0 +1,39 @@
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+use crate::*;
+
+/// Represents a borrowed reference `ION_STRING`.
+///
+/// Ion C's `ION_STRING` type is essentially a `str` slice.  This struct provides
+/// the mutable borrowing context for a given `ION_STRING`.
+pub struct IonCStringRef<'a> {
+    string: ION_STRING,
+    /// Placeholder to tie our lifecycle back to the source of the data.
+    referent: PhantomData<&'a mut u8>,
+}
+
+impl<'a> IonCStringRef<'a> {
+    /// Creates a new reference to an `ION_STRING` mutably borrowed from `src`.
+    #[inline]
+    pub fn new<T>(_src: &'a mut T, value: ION_STRING) -> Self {
+        IonCStringRef {
+            string: value,
+            referent: PhantomData::default(),
+        }
+    }
+}
+
+impl Deref for IonCStringRef<'_> {
+    type Target = ION_STRING;
+
+    fn deref(&self) -> &Self::Target {
+        &self.string
+    }
+}
+
+impl DerefMut for IonCStringRef<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.string
+    }
+}

--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -21,7 +21,7 @@ use crate::*;
 /// # use ion_c_sys::result::*;
 /// # use std::convert::*;
 /// # use std::ptr;
-/// # fn main() -> IonCResult {
+/// # fn main() -> IonCResult<()> {
 /// // a buffer to write to
 /// let mut buf = vec![0u8; 12usize];
 /// let mut len = 0;


### PR DESCRIPTION
Pushes the most commonly used Ion C reader APIs as safer, easier to use
APIs in `IonCReaderHandle`.

Also:
* Changes `IonCResult` from `()` value to  `IonCResult<T>` to be more
  useful for these new APIs.
* Adds `From` trait support for `Utf8Error` to `IonCError`.
* Adds `IonCStringRef` to provide lifetime safe borrows to `ION_STRING`.
* Makes `IonCError` fields public.
* Adds from_bytes`/`try_as_bytes` to `ION_STRING` and adds
  doc tests.
  - Renames `from` to `from_str` and `as_str` to `try_as_str`.
* Makes various small functions inline.
* Updates top-level doc test reader example to use new APIs.

More progress on #37.

**Note**: I did not port the unit tests to the new APIs because I am still refactoring those to be parameterized in another branch.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
