### PR TITLE
Cleans up the code with cargo fmt.

### DIFF
--- a/ion-c-sys/src/reader.rs
+++ b/ion-c-sys/src/reader.rs
@@ -4,8 +4,8 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 
 use crate::result::*;
+use crate::string::*;
 use crate::*;
-use crate::string::IonCStringRef;
 
 // NB that this cannot be made generic with respect to IonCWriterHandle because
 // Rust does not support specialization of Drop.

--- a/ion-c-sys/src/result.rs
+++ b/ion-c-sys/src/result.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
-use std::ffi::CStr;
 use std::error::Error;
+use std::ffi::CStr;
 use std::fmt;
 use std::num::TryFromIntError;
 
@@ -9,7 +9,7 @@ use std::num::TryFromIntError;
 #[derive(Copy, Clone, Debug)]
 pub struct IonCError {
     pub code: i32,
-    pub message:  &'static str,
+    pub message: &'static str,
 }
 
 impl IonCError {
@@ -25,7 +25,10 @@ impl IonCError {
                     IonCError { code, message }
                 }
             }
-            _ => IonCError { code, message: "Unknown Ion C Error Code" },
+            _ => IonCError {
+                code,
+                message: "Unknown Ion C Error Code",
+            },
         }
     }
 }
@@ -64,7 +67,7 @@ pub type IonCResult<T> = Result<T, IonCError>;
 /// or the like.
 ///
 /// NB: `ionc!` implies `unsafe` code.
-/// 
+///
 /// ## Usage
 ///
 /// ```
@@ -104,5 +107,5 @@ macro_rules! ionc {
                 code => Err($crate::result::IonCError::from(code)),
             }
         }
-    }
+    };
 }

--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -119,7 +119,7 @@ impl<'a> IonCWriterHandle<'a> {
     pub fn new_buf_mode(buf: &'a mut [u8], mode: WriterMode) -> Result<Self, IonCError> {
         let mut options = ION_WRITER_OPTIONS {
             output_as_binary: mode as i32,
-            .. Default::default()
+            ..Default::default()
         };
         Self::new_buf(buf, &mut options)
     }
@@ -339,7 +339,11 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
     #[inline]
     fn write_clob(&mut self, value: &[u8]) -> IonCResult<()> {
         // Ion C promises that it won't mutate the buffer for this call!
-        ionc!(ion_writer_write_clob(self.writer, value.as_ptr() as *mut u8, value.len().try_into()?))
+        ionc!(ion_writer_write_clob(
+            self.writer,
+            value.as_ptr() as *mut u8,
+            value.len().try_into()?
+        ))
     }
 
     /// Writes a `blob` value.
@@ -364,7 +368,11 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
     #[inline]
     fn write_blob(&mut self, value: &[u8]) -> IonCResult<()> {
         // Ion C promises that it won't mutate the buffer for this call!
-        ionc!(ion_writer_write_blob(self.writer, value.as_ptr() as *mut u8, value.len().try_into()?))
+        ionc!(ion_writer_write_blob(
+            self.writer,
+            value.as_ptr() as *mut u8,
+            value.len().try_into()?
+        ))
     }
 
     /// Starts a container.
@@ -445,10 +453,7 @@ pub struct IonCFieldWriterContext<'a, 'b, 'c> {
 
 impl<'a, 'b, 'c> IonCFieldWriterContext<'a, 'b, 'c> {
     fn new(handle: &'b mut IonCWriterHandle<'a>, field: &'c str) -> Self {
-        Self {
-            handle,
-            field,
-        }
+        Self { handle, field }
     }
 }
 
@@ -456,8 +461,11 @@ macro_rules! write_field {
     ($i:ident) => {
         // Ion C promises that it won't do mutation!
         let mut field_str = ION_STRING::from_str($i.field);
-        ionc!(ion_writer_write_field_name($i.handle.writer, &mut field_str))?;
-    }
+        ionc!(ion_writer_write_field_name(
+            $i.handle.writer,
+            &mut field_str
+        ))?;
+    };
 }
 
 impl IonCValueWriter for IonCFieldWriterContext<'_, '_, '_> {


### PR DESCRIPTION
Did a cleanup run of `cargo fmt` just to make the code follow idiomatic code conventions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
