### PR TITLE
Implementation of IonCReaderHandle get_annotations.

### DIFF
--- a/ion-c-sys/src/result.rs
+++ b/ion-c-sys/src/result.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::num::TryFromIntError;
 
 /// IonC Error code and its associated error message.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct IonCError {
     pub code: i32,
     pub message: &'static str,

--- a/ion-c-sys/src/string.rs
+++ b/ion-c-sys/src/string.rs
@@ -1,41 +1,82 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
 use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 
 use crate::*;
 
-/// Represents a borrowed reference `ION_STRING`.
+/// Represents a `str` slice that is borrowed from some source.
 ///
-/// Ion C's `ION_STRING` type is essentially a `str` slice.  This struct provides
-/// the mutable borrowing context for a given `ION_STRING`.
-pub struct IonCStringRef<'a> {
-    string: ION_STRING,
-    /// Placeholder to tie our lifecycle back to the source of the data.
+/// This struct provides the mutable borrowing context for the given slice to avoid
+/// destructive APIs from being called from the referent.
+#[derive(Debug, Copy, Clone)]
+pub struct StrSliceRef<'a> {
+    string: &'a str,
+    /// Placeholder to tie our lifetime back to the source of the data as a mutable borrow.
     referent: PhantomData<&'a mut u8>,
 }
 
-impl<'a> IonCStringRef<'a> {
+impl<'a> StrSliceRef<'a> {
     /// Creates a new reference to an `ION_STRING` mutably borrowed from `src`.
     #[inline]
-    pub fn new<T>(_src: &'a mut T, value: ION_STRING) -> Self {
-        IonCStringRef {
-            string: value,
+    pub fn new<T>(_src: &'a mut T, string: &'a str) -> Self {
+        StrSliceRef {
+            string,
             referent: PhantomData::default(),
         }
     }
-}
 
-impl Deref for IonCStringRef<'_> {
-    type Target = ION_STRING;
-
-    fn deref(&self) -> &Self::Target {
-        &self.string
+    /// Convenience method to get the underlying `&str`.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.string
     }
 }
 
-impl DerefMut for IonCStringRef<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.string
+impl Deref for StrSliceRef<'_> {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.string
+    }
+}
+
+/// Represents a slice of `str` slices that are borrowed from some source.
+///
+/// This struct provides the mutable borrowing context for the given slice to avoid
+/// destructive APIs from being called from the referent.
+#[derive(Debug, Clone)]
+pub struct StrSlicesRef<'a> {
+    /// holder for the slices--we don't currently have built in storage for the array itself
+    /// from Ion C, so we hold it here in a `Vec`.
+    strs: Vec<&'a str>,
+
+    /// Placeholder to tie our lifetime back to the source of the data.
+    referent: PhantomData<&'a mut u8>,
+}
+
+impl<'a> StrSlicesRef<'a> {
+    #[inline]
+    pub fn new<T>(_src: &'a mut T, strs: Vec<&'a str>) -> Self {
+        Self {
+            strs,
+            referent: Default::default(),
+        }
+    }
+
+    /// Convenience method to get the underlying slice of `&str`.
+    #[inline]
+    pub fn as_slice(&self) -> &[&str] {
+        self.strs.as_slice()
+    }
+}
+
+impl<'a> Deref for StrSlicesRef<'a> {
+    type Target = [&'a str];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.strs.as_slice()
     }
 }

--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -8,9 +8,6 @@ use std::ptr;
 use crate::result::*;
 use crate::*;
 
-// NB that this cannot be made generic with respect to IonCReaderHandle because
-// Rust does not support specialization of Drop.
-
 /// Indicates at a high-level what type of writer to use.
 pub enum WriterMode {
     Text = 0,
@@ -289,7 +286,7 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
     #[inline]
     fn write_symbol(&mut self, value: &str) -> IonCResult<()> {
         // Ion C promises that it won't do mutation for this call!
-        let mut ion_str = ION_STRING::from_str(value);
+        let mut ion_str = ION_STRING::try_from_str(value)?;
         ionc!(ion_writer_write_symbol(self.writer, &mut ion_str))
     }
 
@@ -315,7 +312,7 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
     #[inline]
     fn write_string(&mut self, value: &str) -> IonCResult<()> {
         // Ion C promises that it won't do mutation for this call!
-        let mut ion_str = ION_STRING::from_str(value);
+        let mut ion_str = ION_STRING::try_from_str(value)?;
         ionc!(ion_writer_write_string(self.writer, &mut ion_str))
     }
 
@@ -462,7 +459,7 @@ impl<'a, 'b, 'c> IonCFieldWriterContext<'a, 'b, 'c> {
 macro_rules! write_field {
     ($i:ident) => {
         // Ion C promises that it won't do mutation!
-        let mut field_str = ION_STRING::from_str($i.field);
+        let mut field_str = ION_STRING::try_from_str($i.field)?;
         ionc!(ion_writer_write_field_name(
             $i.handle.writer,
             &mut field_str


### PR DESCRIPTION
Also:
* Adds `Derive(PartialEq)` to `IonCError`.
* Removes duplication comment around `IonCReaderHandle` and `IonCWriterHandle`.
  At this point they are both so different that it doesn't matter.
* Refactors `IonCStringRef` to `StrSliceRef` and makes it just over a `&str`
  versus `ION_STRING`. The use casees in the library are all UTF-8 results
  from the reader. This tightens up the implementation and makes it
  marginally easier to use.
  - Removes `DerefMut` implementation.
* Adds `StrSlicesRef` for APIs that return multiple `&str` (e.g. annotations).
* Adds low-level APIs to `ION_STRING` to manage lifetimes of references generated.
* Various cleanup of the `ION_STRING` APIs to make them safer.
* Changes `get_field_name` and `read_string` to use `StrRef`.
* Changes `get_annotations` to return `StrSlicesRef`.
* Updates doc tests to use new APIs.

Resolves #48.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
