### PR TITLE
Minor cleanup to README.md

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Build
 
 on: [push]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Amazon Ion Rust
 
+[![build](https://github.com/amzn/ion-rust/workflows/Build/badge.svg)](https://github.com/amzn/ion-rust/actions)
+
 A Rust implementation of the [Amazon Ion][spec] data format.
 
 ***This package is considered experimental, under active/early development, and the API is subject to change.***
@@ -34,6 +36,7 @@ Running all tests for `ion-rust` and `ion-c-sys`:
 $ cargo test --workspace
 ```
 
+[spec]: https://amzn.github.io/ion-docs/docs/spec.html
 [ion-c]: https://github.com/amzn/ion-c
 [ion-tests]: https://github.com/amzn/ion-tests
 [bindgen-req]: https://rust-lang.github.io/rust-bindgen/requirements.html

--- a/ion-c-sys/README.md
+++ b/ion-c-sys/README.md
@@ -1,0 +1,21 @@
+# `ion-c-sys`
+
+[![build](https://github.com/amzn/ion-rust/workflows/Build/badge.svg)](https://github.com/amzn/ion-rust/actions)
+
+A Rust binding to [Ion C][ion-c] which implements the [Amazon Ion][spec] data format.
+
+***This package is considered experimental, under active/early development, and the API is subject to change.***
+
+## Development
+
+See [Ion Rust][ion-rust] for details.  This crate is currently developed in concert with Ion Rust
+as a [Cargo workspace][cargo-workspace].
+
+Notably, building this crate requires [pre-requisites for `bindgen`][bindgen-req], a modern C/C++ compiler,
+and [`cmake`][cmake].
+
+[ion-rust]: https://github.com/amzn/ion-rust
+[spec]: https://amzn.github.io/ion-docs/docs/spec.html
+[ion-c]: https://github.com/amzn/ion-c
+[bindgen-req]: https://rust-lang.github.io/rust-bindgen/requirements.html
+[cargo-workspace]: https://doc.rust-lang.org/cargo/reference/workspaces.html


### PR DESCRIPTION
* Adds a README.md for `ion-c-sys` crate.
* Changes the Github Action CI workflow name to `Build`
  to make a prettier badge.
* Adds badge URL to our master CI build workflow in READMEs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
