### PR TITLE
[ion-c-sys] Ion binary reader API tests.

### DIFF
--- a/ion-c-sys/tests/value.rs
+++ b/ion-c-sys/tests/value.rs
@@ -57,116 +57,157 @@ use Val::*;
 #[derive(Debug)]
 struct TestCase {
     lit: &'static str,
+    bin: &'static [u8],
     elem: Elem,
+}
+
+enum TestMode {
+    Text,
+    Binary,
 }
 
 #[rstest(c,
     case::null(TestCase {
         lit: "null",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x0F],
         elem: Elem::new(Null(ION_TYPE_NULL)),
     }),
     case::null_bool(TestCase {
         lit: "null.bool",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x1F],
         elem: Elem::new(Null(ION_TYPE_BOOL)),
     }),
     case::null_int(TestCase {
         lit: "null.int",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x2F],
         elem: Elem::new(Null(ION_TYPE_INT)),
     }),
     case::null_float(TestCase {
         lit: "null.float",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x4F],
         elem: Elem::new(Null(ION_TYPE_FLOAT)),
     }),
     case::null_decimal(TestCase {
         lit: "null.decimal",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x5F],
         elem: Elem::new(Null(ION_TYPE_DECIMAL)),
     }),
     case::null_timestamp(TestCase {
         lit: "null.timestamp",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x6F],
         elem: Elem::new(Null(ION_TYPE_TIMESTAMP)),
     }),
     case::null_symbol(TestCase {
         lit: "null.symbol",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x7F],
         elem: Elem::new(Null(ION_TYPE_SYMBOL)),
     }),
     case::null_string(TestCase {
         lit: "null.string",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x8F],
         elem: Elem::new(Null(ION_TYPE_STRING)),
     }),
     case::null_clob(TestCase {
         lit: "null.clob",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x9F],
         elem: Elem::new(Null(ION_TYPE_CLOB)),
     }),
     case::null_blob(TestCase {
         lit: "null.blob",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xAF],
         elem: Elem::new(Null(ION_TYPE_BLOB)),
     }),
     case::null_list(TestCase {
         lit: "null.list",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xBF],
         elem: Elem::new(Null(ION_TYPE_LIST)),
     }),
     case::null_sexp(TestCase {
         lit: "null.sexp",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xCF],
         elem: Elem::new(Null(ION_TYPE_SEXP)),
     }),
     case::null_struct(TestCase {
         lit: "null.struct",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xDF],
         elem: Elem::new(Null(ION_TYPE_STRUCT)),
     }),
     case::bool_true(TestCase {
         lit: "a::b::c::true",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xEC, 0x81, 0x83, 0xDE, 0x88, 0x87, 0xB6,
+               0x81, 0x61, 0x81, 0x62, 0x81, 0x63, 0xE5, 0x83, 0x8A, 0x8B, 0x8C,
+               0x11],
         elem: Elem::new_a(Bool(true), vec!["a", "b", "c"]),
     }),
     case::bool_false(TestCase {
         lit: "abcdefghijklmnop::false",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xEE, 0x99, 0x81, 0x83, 0xDE, 0x95, 0x87,
+               0xBE, 0x92, 0x8E, 0x90, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67,
+               0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0xE3, 0x81,
+               0x8A, 0x10],
         elem: Elem::new_a(Bool(false), vec!["abcdefghijklmnop"]),
     }),
     case::int_positive(TestCase {
         lit: "42",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x21, 0x2A],
         elem: Elem::new(Int(42)),
     }),
     case::int_negative(TestCase {
         lit: "-10",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x31, 0x0A],
         elem: Elem::new(Int(-10)),
     }),
     case::int_maxi64(TestCase {
         lit: "0x7fffffffffffffff",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x28, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
         elem: Elem::new(Int(0x7fffffffffffffff)),
     }),
     case::float(TestCase {
         lit: "3e0",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x48, 0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
         elem: Elem::new(Float(3.0)),
     }),
     case::float_nan(TestCase {
         lit: "nan",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x48, 0x7F, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
         elem: Elem::new(Float(f64::NAN)),
     }),
     case::float_ninf(TestCase {
         lit: "-inf",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x48, 0xFF, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
         elem: Elem::new(Float(f64::NEG_INFINITY)),
     }),
     case::float_pinf(TestCase {
         lit: "+inf",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x48, 0x7F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
         elem: Elem::new(Float(f64::INFINITY)),
     }),
     case::symbol(TestCase {
-        lit: "\'hello 👾!\'",
+        lit: "'hello 👾!'",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xEE, 0x92, 0x81, 0x83, 0xDE, 0x8E, 0x87,
+               0xBC, 0x8B, 0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0xF0, 0x9F, 0x91,
+               0xBE, 0x21, 0x71, 0x0A],
         elem: Elem::new(Sym("hello 👾!")),
     }),
     case::string(TestCase {
         lit: "\"hello 💩!\"",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x8B, 0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x20,
+               0xF0, 0x9F, 0x92, 0xA9, 0x21],
         elem: Elem::new(Str("hello 💩!")),
     }),
     case::clob(TestCase {
         lit: "{{\"hello\"}}",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x95, 0x68, 0x65, 0x6C, 0x6C, 0x6F],
         elem: Elem::new(Clob(b"hello")),
     }),
     case::blob(TestCase {
         lit: "{{d29ybGQ=}}",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xA5, 0x77, 0x6F, 0x72, 0x6C, 0x64],
         elem: Elem::new(Blob(b"world")),
     }),
     case::list(TestCase {
         lit: "[false, 0, 0e0]",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xB3, 0x10, 0x20, 0x40],
         elem: Elem::new(List(vec![
             Elem::new(Bool(false)),
             Elem::new(Int(0)),
@@ -175,6 +216,8 @@ struct TestCase {
     }),
     case::sexp(TestCase {
         lit: "(+ 1 2 3)",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xE8, 0x81, 0x83, 0xDE, 0x84, 0x87, 0xB2,
+               0x81, 0x2B, 0xC8, 0x71, 0x0A, 0x21, 0x01, 0x21, 0x02, 0x21, 0x03],
         elem: Elem::new(Sexp(vec![
             Elem::new(Sym("+")),
             Elem::new(Int(1)),
@@ -183,18 +226,27 @@ struct TestCase {
     }),
     case::structure(TestCase {
         lit: "{a:1, b:2, c:3}",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0xEC, 0x81, 0x83, 0xDE, 0x88, 0x87, 0xB6,
+               0x81, 0x61, 0x81, 0x62, 0x81, 0x63, 0xDE, 0x89, 0x8A, 0x21, 0x01,
+               0x8B, 0x21, 0x02, 0x8C, 0x21, 0x03],
         elem: Elem::new(Struct(vec![
             ("a", Elem::new(Int(1))),
             ("b", Elem::new(Int(2))),
             ("c", Elem::new(Int(3))),
         ])),
     }),
+    mode => [TestMode::Text, TestMode::Binary],
 )]
-fn test_read_single(c: TestCase) -> TestResult {
+fn test_read_single(c: TestCase, mode: TestMode) -> TestResult {
     // copy into a mutable buffer as a defensive measure
-    let mut reader = IonCReaderHandle::try_from(c.lit)?;
+    let mut reader = match mode {
+        TestMode::Text => IonCReaderHandle::try_from(c.lit)?,
+        TestMode::Binary => IonCReaderHandle::try_from(c.bin)?,
+    };
 
-    assert_eq!(ION_TYPE_NONE, reader.get_type()?);
+    // TODO a bug in Ion C (amzn/ion-c#186) makes this fail on binary cases
+    //assert_eq!(ION_TYPE_NONE, reader.get_type()?);
+
     // assert the that we read what was expected
     assert_single_value(&mut reader, &c.elem, 0)?;
 


### PR DESCRIPTION
* Adds `bin` field for test cases.
* Adds Ion binary equivalent `u8` array constants for each test.
* Adds a `TestMode` to create a binary/text testing matrix.
* Removes `reader.get_type()` before `next()` assertion because of
  an Ion C bug (amzn/ion-c#186).

Resolves #63. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
