### PR TITLE
ci: refactors and adds codecoverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,9 +51,9 @@ jobs:
           toolchain: nightly
           override: true
       - name: Rust Cargo Tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+        eses: actions-rs/tarpaulin@v0.1
         with:
-          args: '-v --run-types AllTargets --run-types Doctests  --out Html --workspace -- --test-threads=1'
+          args: '--release -v --run-types AllTargets --run-types Doctests  --out Html --workspace -- --test-threads=1'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    name: Build and Test
+    name: CI Build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -48,12 +48,12 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
       - name: Rust Cargo Tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--release --out Html --workspace'
+          args: '-v --run-types AllTests --run-types Doctests  --out Html --workspace -- --test-threads=1'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Rust Cargo Tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--release -v --run-types AllTargets --run-types Doctests  --out Html --workspace -- --test-threads=1'
+          args: '-v --run-types AllTargets --run-types Doctests  --out Html --workspace'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,46 +1,67 @@
-name: Build
+name: ion-rust CI Build
 
 on: [push]
 
 jobs:
-  linux:
+  build:
+    name: Build and Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Env Variable Setup 
+        if: matrix.os == 'windows-latest'
+        run: | 
+          echo '::set-env name=LIBCLANG_PATH::C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin'
+      - name: Git Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cargo Build 
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --workspace
+      - name: Cargo Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --workspace
+
+  reports:
+    name: Code Coverage 
     runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
+    steps: 
+      - name: Git Checkout
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Build
-        run: cargo build --verbose --workspace
-      - name: Tests
-        run: cargo test --verbose --workspace
-
-  macos:
-    runs-on: macos-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          submodules: recursive
-      - name: Build
-        run: cargo build --verbose --workspace
-      - name: Tests
-        run: cargo test --verbose --workspace
-
-  windows:
-    runs-on: windows-latest
-    env:
-      # needed for bindgen
-      LIBCLANG_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Rust Cargo Tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
         with:
-          submodules: recursive
-      - name: Build
-        run: cargo build --verbose --workspace
-      - name: Tests
-        run: cargo test --verbose --workspace
+          args: '--release --out Html --workspace'
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v1.0.2
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v1
+        with:
+          name: code-coverage-report
+          path: tarpaulin-report.html
+
+ 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Rust Cargo Tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '-v --run-types AllTests --run-types Doctests  --out Html --workspace -- --test-threads=1'
+          args: '-v --run-types AllTargets --run-types Doctests  --out Html --workspace -- --test-threads=1'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
           toolchain: nightly
           override: true
       - name: Rust Cargo Tarpaulin
-        eses: actions-rs/tarpaulin@v0.1
+        uses: actions-rs/tarpaulin@v0.1
         with:
           args: '--release -v --run-types AllTargets --run-types Doctests  --out Html --workspace -- --test-threads=1'
       - name: Upload to codecov.io


### PR DESCRIPTION

*Description of changes:*

* refactors rust.yml to use os matrix and rust stable 
* adds codecoverage as a separate task using tarpaulin
    * I did try [grcov](https://github.com/actions-rs/grcov), but it requires compiler flags that treat certain ion-c warnings as errors. Did not spend too much time debugging.

See  

* https://github.com/therapon/ion-rust-1/runs/966113292?check_suite_focus=true
* https://codecov.io/gh/therapon/ion-rust-1/branch/ts-ci-codecov


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
