### PR TITLE
[ion-c-sys] Adds Big Integer Support.

### DIFF
--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -5,10 +5,12 @@ edition = "2018"
 
 [dependencies]
 paste = "1.0.0"
+num-bigint = "0.3.0"
 
 [build-dependencies]
-cmake = "0.1"
-bindgen = "0.54"
+cmake = "0.1.44"
+bindgen = "0.54.1"
 
 [dev-dependencies]
 rstest = "0.6.4"
+rstest_reuse = "0.1.0"

--- a/ion-c-sys/src/int.rs
+++ b/ion-c-sys/src/int.rs
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+//! Provides higher-level APIs for `ION_INT`
+
+use crate::result::*;
+use crate::*;
+
+use std::ops::{Deref, DerefMut};
+use std::ptr;
+
+/// Smart Pointer over `ION_INT` to ensure that `ion_int_free` is invoked on the instance.
+#[derive(Debug)]
+pub struct IonIntPtr {
+    value: *mut ION_INT,
+}
+
+impl IonIntPtr {
+    /// Allocates a new `ION_INT` to zero.
+    pub fn try_new() -> IonCResult<Self> {
+        let mut value = ptr::null_mut();
+        ionc!(ion_int_alloc(ptr::null_mut(), &mut value))?;
+        ionc!(ion_int_init(
+            value,
+            ptr::null_mut(), // no owner - defers to normal Ion C xalloc/xfree
+        ))?;
+
+        Ok(Self { value })
+    }
+
+    /// Allocates a new `ION_INT` from a `BigInt`.
+    pub fn try_from_bigint(value: &BigInt) -> IonCResult<Self> {
+        let mut ion_int = IonIntPtr::try_new()?;
+        ion_int.assign_from_bigint(&value)?;
+
+        Ok(ion_int)
+    }
+
+    /// Returns the underlying `ION_INT` as a mutable pointer.
+    pub fn as_mut_ptr(&mut self) -> *mut ION_INT {
+        self.value
+    }
+}
+
+impl Deref for IonIntPtr {
+    type Target = ION_INT;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(self.value) }
+    }
+}
+
+impl DerefMut for IonIntPtr {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(self.value) }
+    }
+}
+
+impl Drop for IonIntPtr {
+    fn drop(&mut self) {
+        unsafe {
+            ion_int_free(self.value);
+        }
+    }
+}

--- a/ion-c-sys/src/reader.rs
+++ b/ion-c-sys/src/reader.rs
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
+//! Provides higher-level APIs for Ion C's `hREADER`.
+
 use std::convert::{TryFrom, TryInto};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
@@ -295,7 +297,32 @@ impl<'a> IonCReaderHandle<'a> {
         Ok(value)
     }
 
-    // TODO ion-rust/#50 - support ION_INT (arbitrary large integer) reads
+    /// Reads an `int` value from the reader as a `BigInt`.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # use num_bigint::BigInt;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut reader = IonCReaderHandle::try_from("0x5195a4b154400e07dee3a7378c403b2d5dd6dd58735")?;
+    /// assert_eq!(ION_TYPE_INT, reader.next()?);
+    /// assert_eq!(
+    ///   BigInt::parse_bytes(b"1907775120294590714755986204580814176547217067050805", 10).unwrap(),
+    ///   reader.read_bigint()?
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn read_bigint(&mut self) -> IonCResult<BigInt> {
+        let mut value = ION_INT::default();
+        ionc!(ion_reader_read_ion_int(self.reader, &mut value))?;
+
+        Ok(value.try_to_bigint()?)
+    }
 
     /// Reads a `float` value from the reader.
     ///

--- a/ion-c-sys/src/result.rs
+++ b/ion-c-sys/src/result.rs
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
+//! Provides convenient integration with `Error` and `Result` for Ion C.
+
 use crate::*;
 
 use std::error::Error;

--- a/ion-c-sys/src/string.rs
+++ b/ion-c-sys/src/string.rs
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
+//! Provides higher-level APIs for borrowing `str` slices safely from Ion C.
+
 use std::marker::PhantomData;
 use std::ops::Deref;
 


### PR DESCRIPTION
Adds support for converting to/from `num_bigint::BigInt`
and `ION_INT` and reader/writer support.

* Adds `IonIntPtr` as safe pointer to `ION_INT`.
* Adds some module documentation.
* Updates Cargo.toml to have more explicit version
requirements.
* Adds `rstest_reuse` crate for reusing test tables.

Resolves #50.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
