### PR TITLE
Renames ion-rust to ion-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ failure_derive = "~0.1"
 # NB: We use the tree dependency here for development and CI.
 #     Note that when publishing you should update the version
 #     so that users can get the correct underlying ion-c-sys version.
-ion-c-sys = { path = "./ion-c-sys", version = "0.1.0" }
+ion-c-sys = { path = "./ion-c-sys", version = "0.2.0" }
 
 [dev-dependencies]
 # Used by ion-tests integration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ion-rust"
+name = "ion-rs"
 authors = ["Amazon Ion Team <ion-team@amazon.com>"]
 description = "Implementation of Amazon Ion"
 homepage = "https://github.com/amzn/ion-rust"
@@ -33,9 +33,9 @@ failure = "~0.1"
 failure_derive = "~0.1"
 
 # NB: We use the tree dependency here for development and CI.
-#     When publishing, this needs to be temporarily with the
-#     current version.
-ion-c-sys = { path = "./ion-c-sys" }
+#     Note that when publishing you should update the version
+#     so that users can get the correct underlying ion-c-sys version.
+ion-c-sys = { path = "./ion-c-sys", version = "0.1.0" }
 
 [dev-dependencies]
 # Used by ion-tests integration
@@ -44,4 +44,3 @@ walkdir = "~2.3"
 [profile.release]
 lto = true
 codegen-units = 1
-

--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -1,8 +1,6 @@
-extern crate ion_rust;
-
-use ion_rust::cursor::StreamItem;
-use ion_rust::result::IonResult;
-use ion_rust::{BinaryIonCursor, Cursor, IonDataSource, IonType};
+use ion_rs::cursor::StreamItem;
+use ion_rs::result::IonResult;
+use ion_rs::{BinaryIonCursor, Cursor, IonDataSource, IonType};
 use std::fs::File;
 use std::process::exit;
 

--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]

--- a/tests/good.rs
+++ b/tests/good.rs
@@ -8,8 +8,8 @@ use std::str::FromStr;
 
 use walkdir::WalkDir;
 
-use ion_rust::result::{decoding_error, IonResult};
-use ion_rust::{BinaryIonCursor, IonType, Reader};
+use ion_rs::result::{decoding_error, IonResult};
+use ion_rs::{BinaryIonCursor, IonType, Reader};
 
 const GOOD_TEST_FILES_PATH: &str = "ion-tests/iontestdata/good/";
 


### PR DESCRIPTION
The original name is taken on crates.io.

* Updates `ion-c-sys` to 0.2.0 (adds big integer support).
* Adds version dependency on `ion-c-sys` from `ion-rs`.
* Updates examples/integration tests to use `ion_rs`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
