### PR TITLE
[ion-c-sys] Adds support for BigDecimal.

### DIFF
--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -21,7 +21,8 @@ edition = "2018"
 
 [dependencies]
 paste = "1.0.0"
-num-bigint = "0.3.0"
+num-bigint = "0.2.6"
+bigdecimal = "0.1.2"
 
 [build-dependencies]
 cmake = "0.1.44"

--- a/ion-c-sys/bindings.h
+++ b/ion-c-sys/bindings.h
@@ -1,0 +1,4 @@
+#include <ionc/ion.h>
+
+// we need access to low-level decimal routines
+#include <ion_decimal_impl.h>

--- a/ion-c-sys/build.rs
+++ b/ion-c-sys/build.rs
@@ -34,7 +34,9 @@ fn main() {
         // make sure we can find all the relevant headers
         .clang_arg(format!("-I{}", ionc_inc_path.display()))
         .clang_arg(format!("-I{}", ionc_internal_inc_path.display()))
-        // defined in IonC's CMake configuration
+        // defined in IonC's CMake configuration.
+        // See https://github.com/amzn/ion-c/blob/1e911eb689a879427aa8842fe2ca7c78546aeed1/CMakeLists.txt#L22-L26
+        // for details.
         .clang_arg("-DDECNUMDIGITS=34")
         // invalidate the build whenever underlying headers change
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/ion-c-sys/build.rs
+++ b/ion-c-sys/build.rs
@@ -26,12 +26,14 @@ fn main() {
     println!("cargo:rustc-link-lib=static=ionc_static");
 
     let ionc_inc_path = mkpath!(&ionc_path, "include");
-    let ionc_main_header_path = mkpath!(&ionc_inc_path, "ionc", "ion.h");
+    let ionc_internal_inc_path = mkpath!("ion-c/ionc");
+    let ionc_main_header_path = mkpath!("bindings.h");
 
     let bindings = bindgen::Builder::default()
         .header(ionc_main_header_path.to_str().unwrap())
         // make sure we can find all the relevant headers
         .clang_arg(format!("-I{}", ionc_inc_path.display()))
+        .clang_arg(format!("-I{}", ionc_internal_inc_path.display()))
         // defined in IonC's CMake configuration
         .clang_arg("-DDECNUMDIGITS=34")
         // invalidate the build whenever underlying headers change

--- a/ion-c-sys/src/decimal.rs
+++ b/ion-c-sys/src/decimal.rs
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+//! Provides higher-level APIs for `ION_DECIMAL`
+
+use crate::result::*;
+use crate::*;
+
+use std::ops::{Deref, DerefMut};
+
+/// Smart Pointer over `ION_DECIMAL` to ensure that `ion_decimal_free` is invoked on the instance.
+pub struct IonDecimalPtr {
+    /// Unlike `ION_INT`, we can own the memory of the `ION_DECIMAL` structure itself, but its
+    /// underlying components are managed by `ion_decimal_free`.
+    value: ION_DECIMAL,
+}
+
+impl IonDecimalPtr {
+    /// Creates an `ION_DECIMAL` from an `i32`.
+    pub fn try_from_i32(value: i32) -> IonCResult<Self> {
+        let mut decimal = Self::try_from_existing(ION_DECIMAL::default())?;
+        ionc!(ion_decimal_from_int32(decimal.as_mut_ptr(), value))?;
+        Ok(decimal)
+    }
+
+    /// Creates an `ION_DECIMAL` from a `BigDecimal`.
+    pub fn try_from_bigdecimal(value: &BigDecimal) -> IonCResult<Self> {
+        let mut decimal = Self::try_from_existing(ION_DECIMAL::default())?;
+        decimal.try_assign_bigdecimal(value)?;
+        Ok(decimal)
+    }
+
+    /// Binds an existing `ION_DECIMAL` to a pointer.
+    pub fn try_from_existing(value: ION_DECIMAL) -> IonCResult<Self> {
+        Ok(Self { value })
+    }
+
+    /// Returns the underlying `ION_DECIMAL` as a mutable pointer.
+    pub fn as_mut_ptr(&mut self) -> *mut ION_DECIMAL {
+        &mut self.value
+    }
+}
+
+impl Deref for IonDecimalPtr {
+    type Target = ION_DECIMAL;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl DerefMut for IonDecimalPtr {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl Drop for IonDecimalPtr {
+    fn drop(&mut self) {
+        unsafe {
+            ion_decimal_free(&mut self.value);
+        }
+    }
+}

--- a/ion-c-sys/src/int.rs
+++ b/ion-c-sys/src/int.rs
@@ -30,7 +30,7 @@ impl IonIntPtr {
     /// Allocates a new `ION_INT` from a `BigInt`.
     pub fn try_from_bigint(value: &BigInt) -> IonCResult<Self> {
         let mut ion_int = IonIntPtr::try_new()?;
-        ion_int.assign_from_bigint(&value)?;
+        ion_int.try_assign_bigint(&value)?;
 
         Ok(ion_int)
     }

--- a/ion-c-sys/src/lib.rs
+++ b/ion-c-sys/src/lib.rs
@@ -386,6 +386,8 @@ impl ION_DECIMAL {
     ///
     /// This implementation borrows mutably, to avoid a copy of the underlying
     /// decimal implementation, but does not change the value.
+    ///
+    /// Specifically, this code scales from/to the exponent the value to extract the coefficient.
     pub fn try_to_bigdecimal(&mut self) -> IonCResult<BigDecimal> {
         // special values are not supported
         let special =
@@ -604,7 +606,13 @@ mod test_bigdecimal {
             cstring.as_ptr(),
             &mut ctx
         ))?;
+
         let bval = ival.try_to_bigdecimal()?;
+        assert_eq!(
+            bval,
+            ival.try_to_bigdecimal()?,
+            "Make sure conversion is effectively immutable"
+        );
 
         // we test against the coefficient and exponent because the string representation
         // is not stable between decNum and BigDecimal

--- a/ion-c-sys/src/reader.rs
+++ b/ion-c-sys/src/reader.rs
@@ -347,7 +347,32 @@ impl<'a> IonCReaderHandle<'a> {
         Ok(value)
     }
 
-    // TODO ion-rust/#42 - support decimal reads
+    /// Reads a `bigdecimal` value from the reader.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use bigdecimal::BigDecimal;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::decimal::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut reader = IonCReaderHandle::try_from("3.0")?;
+    /// assert_eq!(ION_TYPE_DECIMAL, reader.next()?);
+    /// let value = BigDecimal::parse_bytes(b"30E-1", 10).unwrap();
+    /// assert_eq!(value, reader.read_bigdecimal()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn read_bigdecimal(&mut self) -> IonCResult<BigDecimal> {
+        let mut value = ION_DECIMAL::default();
+        ionc!(ion_reader_read_ion_decimal(self.reader, &mut value))?;
+
+        Ok(value.try_to_bigdecimal()?)
+    }
+
     // TODO ion-rust/#43 - support timestamp reads
 
     /// Reads a `string`/`symbol` value from the reader.

--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -327,7 +327,7 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
         ionc!(ion_writer_write_double(self.writer, value))
     }
 
-    /// Writes an `decimal` value.
+    /// Writes a `decimal` value.
     ///
     /// ## Usage
     /// ```


### PR DESCRIPTION
Implements `bigdecimal::BigDecimal` conversions to/from
`ION_DECIMAL`.

* Adds `IonDecimalPtr` smart pointer to manage `ION_DECIMAL` instances.
* Adds `ION_DECIMAL` methods:
  - `try_assign_bigdecimal` to convert from `BigDecimal`.
  - `try_to_bigdecimal` to convert to `BigDecimal`.
* Adds `IonCReaderHandle.read_bigdecimal`.
* Adds `IonCWriterHandle.write_bigdecimal`.
* Renames `ION_INT` conversion methods to be consistent.
* Works around construction of `ION_DECIMAL` from `ION_INT` (#80).
  - Adds `bindings.h` header and updates `build.rs` to expose internal
    Ion decimal APIs.
* Adds error cases and test skips for:
  - `ION_INT` to `decNumber` conversion problems (#79).

There is no limit on *reading*, however default options are still 37
digits in Ion C.  Currently, *writing* decimals with over 34 digits
may error out (#79), but should *never* emit incorrect data.

Resolves #42, #78.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
