### PR TITLE
[ion-c-sys] Adds Timestamp Support.

### DIFF
--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -23,6 +23,7 @@ edition = "2018"
 paste = "1.0.0"
 num-bigint = "0.2.6"
 bigdecimal = "0.1.2"
+chrono = "0.4.13"
 
 [build-dependencies]
 cmake = "0.1.44"

--- a/ion-c-sys/src/decimal.rs
+++ b/ion-c-sys/src/decimal.rs
@@ -29,6 +29,16 @@ impl IonDecimalPtr {
         Ok(decimal)
     }
 
+    /// Creates and `ION_DECIMAL` from a `decQuad`.
+    pub fn try_from_decquad(value: decQuad) -> IonCResult<Self> {
+        let ion_decimal = ION_DECIMAL {
+            type_: ION_DECIMAL_TYPE_ION_DECIMAL_TYPE_QUAD,
+            value: _ion_decimal__bindgen_ty_1 { quad_value: value },
+        };
+
+        Self::try_from_existing(ion_decimal)
+    }
+
     /// Binds an existing `ION_DECIMAL` to a pointer.
     pub fn try_from_existing(value: ION_DECIMAL) -> IonCResult<Self> {
         Ok(Self { value })

--- a/ion-c-sys/src/reader.rs
+++ b/ion-c-sys/src/reader.rs
@@ -373,7 +373,47 @@ impl<'a> IonCReaderHandle<'a> {
         Ok(value.try_to_bigdecimal()?)
     }
 
-    // TODO ion-rust/#43 - support timestamp reads
+    /// Reads a `timestamp` value from the reader.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use chrono::DateTime;
+    /// # use ion_c_sys::timestamp::*;
+    /// # use ion_c_sys::timestamp::Mantissa::*;
+    /// # use ion_c_sys::timestamp::TSPrecision::*;
+    /// # use ion_c_sys::timestamp::TSOffsetKind::*;
+    /// # use ion_c_sys::reader::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut reader = IonCReaderHandle::try_from("2020-10-10T12:34:45.123-00:00")?;
+    /// assert_eq!(ION_TYPE_TIMESTAMP, reader.next()?);
+    /// let ion_dt = reader.read_datetime()?;
+    ///
+    /// // the point in time should be the same
+    /// let expected_dt = DateTime::parse_from_rfc3339("2020-10-10T12:34:45.123Z").unwrap();
+    /// assert_eq!(&expected_dt, ion_dt.as_datetime());
+    ///
+    /// // precision should be millisecond level
+    /// if let Fractional(Digits(digits)) = ion_dt.precision() {
+    ///     assert_eq!(3, *digits);
+    /// } else {
+    ///     assert!(false, "Expected digits precision!");
+    /// }
+    ///
+    /// // we should have an unknown offset
+    /// assert_eq!(UnknownOffset, ion_dt.offset_kind());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn read_datetime(&mut self) -> IonCResult<IonDateTime> {
+        let mut value = ION_TIMESTAMP::default();
+        ionc!(ion_reader_read_timestamp(self.reader, &mut value))?;
+
+        Ok(value.try_to_iondt()?)
+    }
 
     /// Reads a `string`/`symbol` value from the reader.
     ///

--- a/ion-c-sys/src/timestamp.rs
+++ b/ion-c-sys/src/timestamp.rs
@@ -1,0 +1,296 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+//! Provides integration between `ION_TIMESTAMP` and `chrono::DateTime`.
+//!
+//! Specifically, models the Ion notion of a Timestamp, with [`IonDateTime`](./struct.IonDateTime.html)
+//! Which combines a `DateTime` with the concept of [*precision*](./enum.TSPrecision.html) and
+//! [**known** versus **unknown** *offsets*](./enum.TSOffsetKind.html).
+
+use crate::result::*;
+use crate::*;
+
+use self::Mantissa::*;
+use self::TSOffsetKind::*;
+use self::TSPrecision::*;
+
+use bigdecimal::{BigDecimal, ToPrimitive};
+use chrono::{DateTime, FixedOffset, Timelike};
+
+pub(crate) const TS_MAX_MANTISSA_DIGITS: i64 = 9;
+
+/// The fractional part of a `Fractional` [`TSPrecision`](./enum.TSPrecision.html).
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
+pub enum Mantissa {
+    /// A kind of precision that uses digits from the nanoseconds field of the associated
+    /// `DateTime` to represent the amount of mantissa.
+    Digits(u32),
+    /// Specifies the mantissa precisely as a `BigDecimal` in the range `>= 0` and `< 1`.
+    /// This should correspond to the nanoseconds field insofar as it is not truncated.
+    Fraction(BigDecimal),
+}
+
+/// Precision of an [`IonDateTime`](./struct.IonDateTime.html).
+///
+/// All Ion timestamps are complete points in time, but they have explicit precision
+/// that is either at the date components, the minute, or second (including sub-second)
+/// granularity.
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
+pub enum TSPrecision {
+    /// Year-level precision (e.g. `2020T`)
+    Year,
+    /// Month-level precision (e.g. `2020-08T`)
+    Month,
+    /// Day-level precision (e.g. `2020-08-01T`)
+    Day,
+    /// Minute-level precision (e.g. `2020-08-01T12:34Z`)
+    Minute,
+    /// Second-level precision. (e.g. `2020-08-01T12:34:56Z`)
+    Second,
+    /// Sub-second precision (e.g. `2020-08-01T12:34:56.123456789Z`)
+    Fractional(Mantissa),
+}
+
+/// The kind of offset associated with a [`IonDateTime`](./struct.IonDateTime.html).
+///
+/// This is generally some specific `FixedOffset` associated with the `DateTime`,
+/// but in the case of a timestamp with an *unknown UTC offset*, this will be `Unknown`,
+/// and the effective `FixedOffset` will be UTC+00:00--this allows an application to
+/// preserve the difference between UTC+00:00 (zulu time) and UTC-00:00 which is the unknown offset.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum TSOffsetKind {
+    KnownOffset,
+    UnknownOffset,
+}
+
+/// Higher-level wrapper over `DateTime` preserving `ION_TIMESTAMP` properties
+/// that `DateTime` does not preserve on its own.
+///
+/// Specifically, this adds the [*precision*](./enum.TSPrecision.html) of the timestamp and
+/// its associated [*kind of offset*](./enum.TSOffsetKind.html).
+///
+/// ## Usage
+/// Generally, users will create their own `DateTime<FixedOffset>`
+/// and construct an `IonDateTime` indicating the precision as follows:
+/// ```
+/// # use ion_c_sys::timestamp::*;
+/// # use ion_c_sys::timestamp::TSPrecision::*;
+/// # use ion_c_sys::timestamp::TSOffsetKind::*;
+/// # use ion_c_sys::timestamp::Mantissa::*;
+/// # use ion_c_sys::result::*;
+/// # use chrono::*;
+/// # fn main() -> IonCResult<()> {
+/// // construct a DateTime with milliseconds of fractional seconds
+/// use ion_c_sys::timestamp::Mantissa::Digits;
+/// let dt = DateTime::parse_from_rfc3339("2020-02-27T04:15:00.123Z").unwrap();
+/// // move that into an IonDateTime with the explicit milliseconds of precision
+/// let ion_dt = IonDateTime::try_new(dt, Fractional(Digits(3)), KnownOffset)?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct IonDateTime {
+    date_time: DateTime<FixedOffset>,
+    precision: TSPrecision,
+    offset_kind: TSOffsetKind,
+}
+
+impl IonDateTime {
+    /// Constructs a new `IonDateTime` directly without validating the `Fractional` precision.
+    #[inline]
+    pub(crate) fn new(
+        date_time: DateTime<FixedOffset>,
+        precision: TSPrecision,
+        offset_kind: TSOffsetKind,
+    ) -> Self {
+        Self {
+            date_time,
+            precision,
+            offset_kind,
+        }
+    }
+
+    /// Constructs a new `IonDateTime` from its constituent components.
+    ///
+    /// Note that the `Fractional` precision must match the nanoseconds field of this
+    /// will fail.  Also note that the `TSOffsetKind` must be `Unknown` for precision less than
+    /// a `Minute` and must correspond to UTC+00:00 in the `DateTime`.
+    #[inline]
+    pub fn try_new(
+        date_time: DateTime<FixedOffset>,
+        precision: TSPrecision,
+        offset_kind: TSOffsetKind,
+    ) -> IonCResult<Self> {
+        match offset_kind {
+            KnownOffset => {
+                if precision <= Day {
+                    return Err(IonCError::with_additional(
+                        ion_error_code_IERR_INVALID_TIMESTAMP,
+                        "Day precision or less must not have KnownOffset",
+                    ));
+                }
+            }
+            UnknownOffset => {
+                if date_time.offset().utc_minus_local() != 0 {
+                    return Err(IonCError::with_additional(
+                        ion_error_code_IERR_INVALID_TIMESTAMP,
+                        "Mismatched offset with UnknownOffset",
+                    ));
+                }
+            }
+        };
+        match &precision {
+            Fractional(mantissa) => match mantissa {
+                Digits(digits) => {
+                    if (*digits as i64) > TS_MAX_MANTISSA_DIGITS {
+                        return Err(IonCError::with_additional(
+                            ion_error_code_IERR_INVALID_TIMESTAMP,
+                            "Invalid digits in precision",
+                        ));
+                    }
+                }
+                Fraction(frac) => {
+                    let ns = date_time.nanosecond();
+                    let frac_ns = (frac * BigDecimal::from(NS_IN_SEC)).abs().to_u32().ok_or(
+                        IonCError::with_additional(
+                            ion_error_code_IERR_INVALID_TIMESTAMP,
+                            "Invalid mantissa in precision",
+                        ),
+                    )?;
+                    if ns != frac_ns {
+                        return Err(IonCError::with_additional(
+                            ion_error_code_IERR_INVALID_TIMESTAMP,
+                            "Fractional mantissa inconsistent in precision",
+                        ));
+                    }
+                }
+            },
+            _ => {}
+        };
+
+        Ok(Self::new(date_time, precision, offset_kind))
+    }
+
+    /// Returns a reference to the underlying `DateTime`.
+    #[inline]
+    pub fn as_datetime(&self) -> &DateTime<FixedOffset> {
+        &(self.date_time)
+    }
+
+    /// Returns the precision of this `IonDateTime`.
+    #[inline]
+    pub fn precision(&self) -> &TSPrecision {
+        &(self.precision)
+    }
+
+    /// Returns the offset of this `IonDateTime`.
+    #[inline]
+    pub fn offset_kind(&self) -> TSOffsetKind {
+        self.offset_kind
+    }
+
+    /// Consumes the underlying components of this `IonDateTime` into a `DateTime`.
+    #[inline]
+    pub fn into_datetime(self) -> DateTime<FixedOffset> {
+        self.date_time
+    }
+}
+
+#[cfg(test)]
+mod test_iondt {
+    use super::*;
+
+    use rstest::rstest;
+
+    fn frac(lit: &str) -> Mantissa {
+        Fraction(BigDecimal::parse_bytes(lit.as_bytes(), 10).unwrap())
+    }
+
+    #[rstest(
+        dt_lit,
+        precision,
+        offset_kind,
+        error,
+        case::year("2020-01-01T00:01:00.1234567Z", Year, UnknownOffset, None),
+        case::month("2020-01-01T00:01:00.1234567Z", Month, UnknownOffset, None),
+        case::day("2020-01-01T00:01:00.1234567Z", Day, UnknownOffset, None),
+        case::year_bad_known_offset(
+            "2020-01-01T00:01:00.1234567Z",
+            Year,
+            KnownOffset,
+            Some(ion_error_code_IERR_INVALID_TIMESTAMP),
+        ),
+        case::month_bad_known_offset(
+            "2020-01-01T00:01:00.1234567Z",
+            Month,
+            KnownOffset,
+            Some(ion_error_code_IERR_INVALID_TIMESTAMP),
+        ),
+        case::day_bad_known_offset(
+            "2020-01-01T00:01:00.1234567Z",
+            Day,
+            KnownOffset,
+            Some(ion_error_code_IERR_INVALID_TIMESTAMP),
+        ),
+        case::minute("2020-01-01T00:01:00.1234567Z", Minute, KnownOffset, None),
+        case::second("2020-01-01T00:01:00.1234567Z", Second, KnownOffset, None),
+        case::second_unknown_offset("2020-01-01T00:01:00.1234567Z", Second, UnknownOffset, None),
+        case::second_bad_unknown_offset(
+            "2020-01-01T00:01:00.1234567-00:15",
+            Second,
+            UnknownOffset,
+            Some(ion_error_code_IERR_INVALID_TIMESTAMP),
+        ),
+        case::fractional_digits(
+            "2020-01-01T00:01:00.1234567Z",
+            Fractional(Digits(3)),
+            KnownOffset,
+            None,
+        ),
+        case::fractional_digits_too_big(
+            "2020-01-01T00:01:00.1234567Z",
+            Fractional(Digits(10)),
+            KnownOffset,
+            Some(ion_error_code_IERR_INVALID_TIMESTAMP),
+        ),
+        case::fractional_mantissa(
+            "2020-01-01T00:01:00.1234567Z",
+            Fractional(frac("0.1234567")),
+            KnownOffset,
+            None,
+        ),
+        case::fractional_mantissa_more_precision(
+            "2020-01-01T00:01:00.1234567Z",
+            Fractional(frac("0.1234567001234567")),
+            KnownOffset,
+            None,
+        ),
+        case::fractional_mantissa_mismatch_digits(
+            "2020-01-01T00:01:00.1234567Z",
+            Fractional(frac("0.123456789")),
+            KnownOffset,
+            Some(ion_error_code_IERR_INVALID_TIMESTAMP),
+        )
+    )]
+    fn try_new_precision(
+        dt_lit: &str,
+        precision: TSPrecision,
+        offset_kind: TSOffsetKind,
+        error: Option<i32>,
+    ) -> IonCResult<()> {
+        let dt = DateTime::parse_from_rfc3339(dt_lit).unwrap();
+        let res = IonDateTime::try_new(dt, precision, offset_kind);
+        match res {
+            Ok(_) => {
+                assert_eq!(None, error);
+            }
+            Err(actual) => {
+                if let Some(expected_code) = error {
+                    assert_eq!(expected_code, actual.code, "Testing expected error codes");
+                } else {
+                    assert!(false, "Expected no error, but got: {:?}", actual);
+                }
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds `IonDateTime` which wraps `chrono::DateTime` with the concept of
*precision* and *offset kind* to completely support the timestamp data
model.

* Adds conversion methods in `ION_TIMESTAMP`:
  - `try_to_iondt()` to convert to `IonDateTime`
  - `try_assign_from_iondt()` to convert from `IonDateTime`.
* Adds `IonCReaderHandle.read_datetime()`.
* Adds `IonCWriterHandle.write_datetime()`.
* Adds `timestamp` module:
  - Adds `TSOffsetKind` to cover the concept of *unknown offset*
  (i.e. `-00:00`).
  - Adds `TSPrecision` to cover Ion timestamp precision, including
    fractional precision via `Mantissa` which models digits or
    higher-precision fraction.
* Adds `additional` message field on `IonCError` to be more descriptive.
* Adds `IonDecimalPtr.try_from_decquad()`.

Resolves #43.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
