### PR TITLE
Adds value read tests for decimal/timestamp.

### DIFF
--- a/ion-c-sys/src/lib.rs
+++ b/ion-c-sys/src/lib.rs
@@ -335,6 +335,9 @@ fn make_context() -> decContext {
     ctx
 }
 
+// TODO amzn/ion-rust#79 - we need to fix decNumber support.
+const DEC_NUMBER_ERROR_MSG: &str = "DecNumber Not Supported";
+
 impl ION_DECIMAL {
     /// Assigns a `BigDecimal` into this `ION_DECIMAL`.
     pub fn try_assign_bigdecimal(&mut self, value: &BigDecimal) -> IonCResult<()> {
@@ -380,7 +383,7 @@ impl ION_DECIMAL {
             // FIXME amzn/ion-rust#79 - we need to fix decNumber support.
             DEC_Invalid_context => Err(IonCError::with_additional(
                 ion_error_code_IERR_INVALID_STATE,
-                "DecNumber Not Supported",
+                DEC_NUMBER_ERROR_MSG,
             )),
             _ => Err(IonCError::from(ion_error_code_IERR_INTERNAL_ERROR)),
         }
@@ -600,9 +603,7 @@ mod test_bigdecimal {
             }
             Err(e) => match e.code {
                 ion_error_code_IERR_INVALID_STATE => match e.additional {
-                    "DecNumber Not Supported" => {
-                        println!("Ignoring amzn/ion-rust#79 for {}", d_lit)
-                    }
+                    DEC_NUMBER_ERROR_MSG => println!("Ignoring amzn/ion-rust#79 for {}", d_lit),
                     _ => assert!(false, "Unexpected error {:?}", e),
                 },
                 _ => assert!(false, "Unexpected error: {:?}", e),

--- a/ion-c-sys/src/lib.rs
+++ b/ion-c-sys/src/lib.rs
@@ -378,7 +378,10 @@ impl ION_DECIMAL {
         match unsafe { decContextGetStatus(&mut ctx) } {
             0 => Ok(()),
             // FIXME amzn/ion-rust#79 - we need to fix decNumber support.
-            DEC_Invalid_context => Err(IonCError::from(ion_error_code_IERR_INVALID_STATE)),
+            DEC_Invalid_context => Err(IonCError::with_additional(
+                ion_error_code_IERR_INVALID_STATE,
+                "DecNumber Not Supported",
+            )),
             _ => Err(IonCError::from(ion_error_code_IERR_INTERNAL_ERROR)),
         }
     }
@@ -596,9 +599,12 @@ mod test_bigdecimal {
                 assert_eq!(exponent, actual_exponent, "Testing exponents");
             }
             Err(e) => match e.code {
-                ion_error_code_IERR_INVALID_STATE => {
-                    println!("Ignoring amzn/ion-rust#79 for {}", d_lit)
-                }
+                ion_error_code_IERR_INVALID_STATE => match e.additional {
+                    "DecNumber Not Supported" => {
+                        println!("Ignoring amzn/ion-rust#79 for {}", d_lit)
+                    }
+                    _ => assert!(false, "Unexpected error {:?}", e),
+                },
                 _ => assert!(false, "Unexpected error: {:?}", e),
             },
         }
@@ -743,7 +749,7 @@ impl ION_TIMESTAMP {
                     ));
                 }
                 unsafe {
-                    self.fraction = ion_frac.value.quad_value;
+                    self.fraction = (*ion_frac).value.quad_value;
                 }
             }
         }

--- a/ion-c-sys/tests/value.rs
+++ b/ion-c-sys/tests/value.rs
@@ -1,12 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
+use rstest::*;
+
 use ion_c_sys::reader::*;
+use ion_c_sys::timestamp::Mantissa::*;
+use ion_c_sys::timestamp::TSOffsetKind::*;
+use ion_c_sys::timestamp::TSPrecision::*;
+use ion_c_sys::timestamp::*;
 use ion_c_sys::*;
 
+use Val::*;
+
+use bigdecimal::BigDecimal;
+use chrono::DateTime;
 use std::convert::TryFrom;
 use std::error::Error;
-
-use rstest::*;
 
 type TestResult = Result<(), Box<dyn Error>>;
 
@@ -32,6 +40,19 @@ impl Elem {
     }
 }
 
+fn dec(lit: &str) -> Val {
+    Decimal(BigDecimal::parse_bytes(lit.as_bytes(), 10).unwrap())
+}
+
+fn frac(lit: &str) -> Mantissa {
+    Fraction(BigDecimal::parse_bytes(lit.as_bytes(), 10).unwrap())
+}
+
+fn ts(dt_lit: &str, precision: TSPrecision, offset_kind: TSOffsetKind) -> Val {
+    let dt = DateTime::parse_from_rfc3339(dt_lit).unwrap();
+    Timestamp(IonDateTime::try_new(dt, precision, offset_kind).unwrap())
+}
+
 /// Simplified value enum for our tests.
 #[derive(Debug, Clone, PartialEq)]
 enum Val {
@@ -40,8 +61,8 @@ enum Val {
     Bool(bool),
     Int(i64),
     Float(f64),
-    // TODO ion-rust/#42 - decimal support
-    // TODO ion-rust/#43 - timestamp support
+    Decimal(BigDecimal),
+    Timestamp(IonDateTime),
     Sym(&'static str),
     Str(&'static str),
     Clob(&'static [u8]),
@@ -52,7 +73,6 @@ enum Val {
     Sexp(Vec<Elem>),
     Struct(Vec<(&'static str, Elem)>),
 }
-use Val::*;
 
 #[derive(Debug)]
 struct TestCase {
@@ -182,6 +202,98 @@ enum TestMode {
         bin: &[0xE0, 0x01, 0x00, 0xEA, 0x48, 0x7F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
         elem: Elem::new(Float(f64::INFINITY)),
     }),
+    case::decimal_p19_en13(TestCase {
+        lit: "123123.7546745674467",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x59, 0xCD, 0x11, 0x16, 0x3C, 0x06, 0x7F, 0xE6, 0x3A, 0xE3],
+        elem: Elem::new(dec("123123.7546745674467")),
+    }),
+    case::decimal_p28_en3000(TestCase {
+        lit: "9174312341723649127364192734d-3000",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x5E, 0x8E, 0x57, 0xB8, 0x1D, 0xA4, 0xD0,
+               0x34, 0x99, 0x0D, 0xDD, 0x28, 0xFB, 0xC4, 0x69, 0xDE],
+        elem: Elem::new(dec("9174312341723649127364192734E-3000")),
+    }),
+    case::decimal_p34_e4000(TestCase {
+        lit: "1743123417236491273641927340182374d4000",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x5E, 0x90, 0x1F, 0xA0, 0x55, 0xF1, 0x4F,
+               0x88, 0x06, 0x74, 0x02, 0xE0, 0x13, 0x1D, 0xD4, 0x0F, 0xCB, 0x66],
+        elem: Elem::new(dec("1743123417236491273641927340182374E4000")),
+    }),
+    case::timestamp_year(TestCase {
+        lit: "2010T",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x63, 0xC0, 0x0F, 0xDA],
+        elem: Elem::new(ts("2010-01-01T00:00:00Z", Year, UnknownOffset)),
+    }),
+    case::timestamp_month(TestCase {
+        lit: "2010-10T",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x64, 0xC0, 0x0F, 0xDA, 0x8A],
+        elem: Elem::new(ts("2010-10-01T00:00:00Z", Month, UnknownOffset)),
+    }),
+    case::timestamp_day(TestCase {
+        lit: "2010-10-10T",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x65, 0xC0, 0x0F, 0xDA, 0x8A, 0x8A],
+        elem: Elem::new(ts("2010-10-10T00:00:00Z", Day, UnknownOffset)),
+    }),
+    case::timestamp_minute_unknown(TestCase {
+        lit: "2010-10-10T12:34-00:00",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x67, 0xC0, 0x0F, 0xDA, 0x8A, 0x8A, 0x8C, 0xA2],
+        elem: Elem::new(ts("2010-10-10T12:34:00Z", Minute, UnknownOffset)),
+    }),
+    case::timestamp_minute_known(TestCase {
+        lit: "2010-10-10T12:34+07:30",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x68, 0x03, 0xC2, 0x0F, 0xDA, 0x8A, 0x8A, 0x85, 0x84],
+        elem: Elem::new(ts("2010-10-10T12:34:00+07:30", Minute, KnownOffset)),
+    }),
+    case::timestamp_second_unknown(TestCase {
+        lit: "2010-10-10T12:34:56-00:00",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x68, 0xC0, 0x0F, 0xDA, 0x8A, 0x8A, 0x8C, 0xA2, 0xB8],
+        elem: Elem::new(ts("2010-10-10T12:34:56.000000000-00:00", Second, UnknownOffset)),
+    }),
+    case::timestamp_second_known(TestCase {
+        lit: "2010-10-10T12:34:56-08:15",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x69, 0x43, 0xEF, 0x0F, 0xDA, 0x8A, 0x8A, 0x94, 0xB1, 0xB8],
+        elem: Elem::new(ts("2010-10-10T12:34:56.000000000-08:15", Second, KnownOffset)),
+    }),
+    case::timestamp_ms_unknown(TestCase {
+        lit: "2010-10-10T12:34:56.123-00:00",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x6A, 0xC0, 0x0F, 0xDA, 0x8A, 0x8A, 0x8C, 0xA2, 0xB8, 0xC3, 0x7B],
+        elem: Elem::new(ts("2010-10-10T12:34:56.123000000-00:00", Fractional(Digits(3)), UnknownOffset)),
+    }),
+    case::timestamp_ms_known(TestCase {
+        lit: "2010-10-10T12:34:56.001-08:15",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x6B, 0x43, 0xEF, 0x0F, 0xDA, 0x8A, 0x8A, 0x94, 0xB1, 0xB8, 0xC3, 0x01],
+        elem: Elem::new(ts("2010-10-10T12:34:56.001000000-08:15", Fractional(Digits(3)), KnownOffset)),
+    }),
+    case::timestamp_us_unknown(TestCase {
+        lit: "2010-10-10T12:34:56.123456-00:00",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x6C, 0xC0, 0x0F, 0xDA, 0x8A, 0x8A, 0x8C, 0xA2, 0xB8, 0xC6, 0x01, 0xE2, 0x40],
+        elem: Elem::new(ts("2010-10-10T12:34:56.123456000-00:00", Fractional(Digits(6)), UnknownOffset)),
+    }),
+    case::timestamp_us_known(TestCase {
+        lit: "2010-10-10T12:34:56.000001-08:15",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x6B, 0x43, 0xEF, 0x0F, 0xDA, 0x8A, 0x8A, 0x94, 0xB1, 0xB8, 0xC6, 0x01],
+        elem: Elem::new(ts("2010-10-10T12:34:56.000001000-08:15", Fractional(Digits(6)), KnownOffset)),
+    }),
+    case::timestamp_ns_unknown(TestCase {
+        lit: "2010-10-10T12:34:56.123456789-00:00",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x6D, 0xC0, 0x0F, 0xDA, 0x8A, 0x8A, 0x8C, 0xA2, 0xB8, 0xC9, 0x07, 0x5B, 0xCD, 0x15],
+        elem: Elem::new(ts("2010-10-10T12:34:56.123456789-00:00", Fractional(Digits(9)), UnknownOffset)),
+    }),
+    case::timestamp_ns_known(TestCase {
+        lit: "2010-10-10T12:34:56.000000001-08:15",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x6B, 0x43, 0xEF, 0x0F, 0xDA, 0x8A, 0x8A, 0x94, 0xB1, 0xB8, 0xC9, 0x01],
+        elem: Elem::new(ts("2010-10-10T12:34:56.000000001-08:15", Fractional(Digits(9)), KnownOffset)),
+    }),
+    case::timestamp_ps_unknown(TestCase {
+        lit: "2010-10-10T12:34:56.123456789123-00:00",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x6E, 0x8E, 0xC0, 0x0F, 0xDA, 0x8A, 0x8A, 0x8C, 0xA2, 0xB8, 0xCC, 0x1C, 0xBE, 0x99, 0x1A, 0x83],
+        elem: Elem::new(ts("2010-10-10T12:34:56.123456789-00:00", Fractional(frac("0.123456789123")), UnknownOffset)),
+    }),
+    case::timestamp_ps_known(TestCase {
+        lit: "2010-10-10T12:34:56.000000000001-08:15",
+        bin: &[0xE0, 0x01, 0x00, 0xEA, 0x6B, 0x43, 0xEF, 0x0F, 0xDA, 0x8A, 0x8A, 0x94, 0xB1, 0xB8, 0xCC, 0x01],
+        elem: Elem::new(ts("2010-10-10T12:34:56.000000000-08:15", Fractional(frac("0.000000000001")), KnownOffset)),
+    }),
     case::symbol(TestCase {
         lit: "'hello 👾!'",
         bin: &[0xE0, 0x01, 0x00, 0xEA, 0xEE, 0x92, 0x81, 0x83, 0xDE, 0x8E, 0x87,
@@ -302,6 +414,16 @@ fn assert_single_value(reader: &mut IonCReaderHandle, expected: &Elem, depth: i3
                 assert_eq!(true, val.is_nan());
                 assert_eq!(true, actual.is_nan());
             }
+        }
+        Decimal(val) => {
+            assert_eq!(ION_TYPE_DECIMAL, tid);
+            let actual = reader.read_bigdecimal()?;
+            assert_eq!(val, &actual);
+        }
+        Timestamp(val) => {
+            assert_eq!(ION_TYPE_TIMESTAMP, tid);
+            let actual = reader.read_datetime()?;
+            assert_eq!(val, &actual);
         }
         Sym(val) => {
             assert_eq!(ION_TYPE_SYMBOL, tid);


### PR DESCRIPTION
* Minor cleanup on BigDecimal conversion error message.
* Makes the dereference for the `ION_DECIMAL` explicit to get at fraction
  because it makes CLion confused (and is technically clearer as to what is going on).

Related to #42 and #43.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
