### PR TITLE
Fixes bindgen dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ failure_derive = "~0.1"
 # NB: We use the tree dependency here for development and CI.
 #     Note that when publishing you should update the version
 #     so that users can get the correct underlying ion-c-sys version.
-ion-c-sys = { path = "./ion-c-sys", version = "0.4.0" }
+ion-c-sys = { path = "./ion-c-sys", version = "0.4.1" }
 
 [dev-dependencies]
 # Used by ion-tests integration

--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 
 [dependencies]
@@ -27,7 +27,7 @@ chrono = "0.4.13"
 
 [build-dependencies]
 cmake = "0.1.44"
-bindgen = "0.54.1"
+bindgen = "0.55.0"
 
 [dev-dependencies]
 rstest = "0.6.4"


### PR DESCRIPTION
* `bindgen` 0.54.1 was yanked on crates.io.
* Bumps `ion-c-sys` version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
