### PR TITLE
Dependencies use ^ instead of ~

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ ion-c-sys = { path = "./ion-c-sys", version = "0.4.1" }
 
 [dev-dependencies]
 # Used by ion-tests integration
-walkdir = "~2.3"
+walkdir = "^2.3"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ members = [
 ]
 
 [dependencies]
-base64 = "~0.12.3"
-bigdecimal = "~0.1"
-bytes = "~0.4"
-chrono = "~0.4"
-delegate = "0.4.2"
-failure = "~0.1"
-failure_derive = "~0.1"
+base64 = "^0.12.3"
+bigdecimal = "^0.1"
+bytes = "^0.4"
+chrono = "^0.4"
+delegate = "^0.4.2"
+failure = "^0.1"
+failure_derive = "^0.1"
 
 # NB: We use the tree dependency here for development and CI.
 #     Note that when publishing you should update the version


### PR DESCRIPTION
*Issue #, if available:* Fixes #93.

Dependencies declared in `Cargo.toml` now use `^` syntax rather than `~`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
