### PR TITLE
[ion-c-sys] Refactors the traits for `IonCReader` and `IonCWriter`.

### DIFF
--- a/ion-c-sys/src/lib.rs
+++ b/ion-c-sys/src/lib.rs
@@ -16,12 +16,12 @@
 //! generally be used, especially with `Result` handling code.  These types provide some facade
 //! over Ion C, but only for the most generally used APIs. See:
 //!
-//! * [IonCReaderHandle][reader-handle]
-//! * [IonCWriterHandle][writer-handle]
+//! * [`IonCReader`][reader-trait]
+//! * [`IonCWriter`][writer-trait]
 //!
 //! [ionc-call]: macro.ionc.html
-//! [reader-handle]: reader/struct.IonCReaderHandle.html
-//! [writer-handle]: writer/struct.IonCWriterHandle.html
+//! [reader-trait]: reader/trait.IonCReader.html
+//! [writer-trait]: writer/trait.IonCWriter.html
 //!
 //! ### Ion Reader
 //! Here is an end-to-end example of reading some Ion data.

--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -421,7 +421,7 @@ pub trait IonCWriter<'a>: IonCValueWriter + IonCAnnotationsFieldWriter {
     fn finish(&mut self) -> IonCResult<usize>;
 }
 
-/// Wrapper over `hWRITER` to make it easier to writers in IonC correctly.
+/// Wrapper over `hWRITER` to make it easier to use writers in IonC correctly.
 ///
 /// Specifically supports the `Drop` trait to make sure `ion_writer_close` is run.
 /// Access to the underlying `hWRITER` pointer is done by de-referencing the handle.
@@ -431,7 +431,7 @@ pub trait IonCWriter<'a>: IonCValueWriter + IonCAnnotationsFieldWriter {
 /// * [IonCValueWriter](./trait.IonCValueWriter.html)
 pub struct IonCWriterHandle<'a> {
     writer: hWRITER,
-    /// Placeholder to tie our lifecycle back to the source of the data--which might not
+    /// Placeholder to tie our lifecycle back to the destination--which might not
     /// actually be a byte slice (if we constructed this from a file or Ion C stream callback)
     referent: PhantomData<&'a mut u8>,
 }

--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -20,51 +20,310 @@ pub enum WriterMode {
 /// The API for Ion C value writing.
 pub trait IonCValueWriter {
     /// Writes a `null` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
+    ///     writer.write_null(ION_TYPE_INT)?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"\xE0\x01\x00\xEA\x2F", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_null(&mut self, tid: ION_TYPE) -> IonCResult<()>;
 
     /// Writes a `bool` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
+    ///     writer.write_bool(true)?;
+    ///     writer.write_bool(false)?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"true false", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_bool(&mut self, value: bool) -> IonCResult<()>;
 
     /// Writes an `int` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
+    ///     writer.write_i64(-16)?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"\xE0\x01\x00\xEA\x31\x10", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_i64(&mut self, value: i64) -> IonCResult<()>;
 
     /// Writes an `int` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # use num_bigint::BigInt;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
+    ///     let value = BigInt::parse_bytes(b"987654321987654321987654321", 10).unwrap();
+    ///     writer.write_bigint(&value)?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(
+    ///     b"\xE0\x01\x00\xEA\x2C\x03\x30\xF7\xF0\x14\x03\xF9\x4E\xDB\x18\x12\xB1",
+    ///     &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_bigint(&mut self, value: &BigInt) -> IonCResult<()>;
 
     /// Writes a `float` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
+    ///     writer.write_f64(3.0)?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"\xE0\x01\x00\xEA\x48\x40\x08\x00\x00\x00\x00\x00\x00", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_f64(&mut self, value: f64) -> IonCResult<()>;
 
     /// Writes a `decimal` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # use bigdecimal::BigDecimal;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
+    ///     let value = BigDecimal::parse_bytes(b"1.1", 10).unwrap();
+    ///     writer.write_bigdecimal(&value)?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(
+    ///     b"\xE0\x01\x00\xEA\x52\xC1\x0B",
+    ///     &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_bigdecimal(&mut self, value: &BigDecimal) -> IonCResult<()>;
 
     /// Writes a `timestamp` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # use ion_c_sys::timestamp::*;
+    /// # use ion_c_sys::timestamp::Mantissa::*;
+    /// # use ion_c_sys::timestamp::TSPrecision::*;
+    /// # use ion_c_sys::timestamp::TSOffsetKind::*;
+    /// # use chrono::DateTime;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
+    ///     let dt = DateTime::parse_from_rfc3339("2020-01-02T12:34:00.123Z").unwrap();
+    ///
+    ///     // write the date time with microsecond precision and an unknown offset
+    ///     let ion_dt = IonDateTime::try_new(dt, Fractional(Digits(6)), UnknownOffset)?;
+    ///     writer.write_datetime(&ion_dt)?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(
+    ///     b"2020-01-02T12:34:00.123000-00:00",
+    ///     &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_datetime(&mut self, value: &IonDateTime) -> IonCResult<()>;
 
     /// Writes a `symbol` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
+    ///     writer.write_symbol("🍥")?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"'\xF0\x9F\x8D\xA5'", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_symbol(&mut self, value: &str) -> IonCResult<()>;
 
     /// Writes a `string` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
+    ///     writer.write_string("🐡")?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"\xE0\x01\x00\xEA\x84\xF0\x9F\x90\xA1", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_string(&mut self, value: &str) -> IonCResult<()>;
 
     /// Writes a `clob` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
+    ///     writer.write_clob("🐡".as_bytes())?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"\xE0\x01\x00\xEA\x94\xF0\x9F\x90\xA1", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_clob(&mut self, value: &[u8]) -> IonCResult<()>;
 
     /// Writes a `blob` value.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
+    ///     writer.write_blob("🍥".as_bytes())?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"{{8J+NpQ==}}", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn write_blob(&mut self, value: &[u8]) -> IonCResult<()>;
 
-    /// Starts  a container.
+    /// Starts a container.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
+    ///     writer.start_container(ION_TYPE_LIST)?;
+    ///     writer.finish_container()?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"\xE0\x01\x00\xEA\xB0", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn start_container(&mut self, tid: ION_TYPE) -> IonCResult<()>;
 
     /// Finishes a container.
     fn finish_container(&mut self) -> IonCResult<()>;
 }
 
-/// Wrapper over `hWRITER` to make it easier to writers in IonC correctly.
+/// The API for writing values with annotations and/or field names.
+pub trait IonCAnnotationsFieldWriter {
+    /// The associated type of value writer when writing within annotations/field context
+    type AFValueWriter: IonCValueWriter;
+
+    /// Writes a value within a context of annotations and/or a field name
+    ///
+    /// Note that it is undefined behavior if a value writing method is **not** called
+    /// or if a value writing method is called **more than once**.  For this reason,
+    /// most users should prefer the `field()` and/or `annotations()` method on the
+    /// [`IonCWriter`](./trait.IonCWriter.html) trait as it doesn't have this edge case.
+    fn write_annotations_and_field<'a, A, F, FN>(
+        &mut self,
+        annotations: A,
+        field: F,
+        applier: FN,
+    ) -> IonCResult<()>
+    where
+        A: Into<Option<&'a [&'a str]>>,
+        F: Into<Option<&'a str>>,
+        FN: Fn(&mut Self::AFValueWriter) -> IonCResult<()>;
+}
+
+/// The writing API for Ion C.
 ///
-/// Specifically supports the `Drop` trait to make sure `ion_writer_close` is run.
-/// Access to the underlying `hWRITER` pointer is done by de-referencing the handle.
-///
-/// See also [IonCValueWriter](./trait.IonCValueWriter.html) for details
+/// See also:
+/// * [`IonCValueWriter`](./trait.IonCValueWriter.html)
+/// * [`IonCWriterHandle`](./struct.IonCWriterHandle.html)
 ///
 /// ## Usage
 /// ```
@@ -95,6 +354,81 @@ pub trait IonCValueWriter {
 /// # Ok(())
 /// # }
 /// ```
+pub trait IonCWriter<'a>: IonCValueWriter + IonCAnnotationsFieldWriter {
+    /// Returns a lifetime safe writing context for a field.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
+    ///     writer.start_container(ION_TYPE_STRUCT)?;
+    ///     {
+    ///         writer.field("name").write_string("kumo")?;
+    ///     }
+    ///     writer.finish_container()?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!(b"\xE0\x01\x00\xEA\xD6\x84\x84kumo", &buf[0..len]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn field<'b, 'c>(
+        &'b mut self,
+        field: &'c str,
+    ) -> IonCAnnotationsFieldWriterContext<'b, 'c, Self> {
+        IonCAnnotationsFieldWriterContext::new_field(self, field)
+    }
+
+    /// Returns a lifetime safe writing context for annotations.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use std::convert::*;
+    /// # use std::str;
+    /// # use ion_c_sys::*;
+    /// # use ion_c_sys::writer::*;
+    /// # use ion_c_sys::result::*;
+    /// # fn main() -> IonCResult<()> {
+    /// let mut buf = vec![0; 128];
+    /// let len = {
+    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
+    ///     writer.annotations(&["a", "b", "c"]).start_container(ION_TYPE_STRUCT)?;
+    ///     {
+    ///         writer.field("name").annotations(&["def"]).write_string("kumo")?;
+    ///         writer.annotations(&["ghi"]).field("type").write_symbol("dog")?;
+    ///     }
+    ///     writer.finish_container()?;
+    ///     writer.finish()?
+    /// };
+    /// assert_eq!("a::b::c::{name:def::\"kumo\",type:ghi::dog}", str::from_utf8(&buf[0..len])?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn annotations<'b, 'c>(
+        &'b mut self,
+        annotations: &'c [&'c str],
+    ) -> IonCAnnotationsFieldWriterContext<'b, 'c, Self> {
+        IonCAnnotationsFieldWriterContext::new_annotations(self, annotations)
+    }
+
+    /// Finalizes writing for the writer and returns the amount of bytes written.
+    fn finish(&mut self) -> IonCResult<usize>;
+}
+
+/// Wrapper over `hWRITER` to make it easier to writers in IonC correctly.
+///
+/// Specifically supports the `Drop` trait to make sure `ion_writer_close` is run.
+/// Access to the underlying `hWRITER` pointer is done by de-referencing the handle.
+///
+/// See also:
+/// * [IonCWriter](./trait.IonCWriter.html)
+/// * [IonCValueWriter](./trait.IonCValueWriter.html)
 pub struct IonCWriterHandle<'a> {
     writer: hWRITER,
     /// Placeholder to tie our lifecycle back to the source of the data--which might not
@@ -129,71 +463,11 @@ impl<'a> IonCWriterHandle<'a> {
         };
         Self::new_buf(buf, &mut options)
     }
+}
 
-    /// Returns a lifetime safe writing context for a field.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
-    ///     writer.start_container(ION_TYPE_STRUCT)?;
-    ///     {
-    ///         writer.field("name").write_string("kumo")?;
-    ///     }
-    ///     writer.finish_container()?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"\xE0\x01\x00\xEA\xD6\x84\x84kumo", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn field<'b, 'c>(
-        &'b mut self,
-        field: &'c str,
-    ) -> IonCAnnotationsFieldWriterContext<'a, 'b, 'c> {
-        IonCAnnotationsFieldWriterContext::new_field(self, field)
-    }
-
-    /// Returns a lifetime safe writing context for annotations.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use std::str;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
-    ///     writer.annotations(&["a", "b", "c"]).start_container(ION_TYPE_STRUCT)?;
-    ///     {
-    ///         writer.field("name").annotations(&["def"]).write_string("kumo")?;
-    ///         writer.annotations(&["ghi"]).field("type").write_symbol("dog")?;
-    ///     }
-    ///     writer.finish_container()?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!("a::b::c::{name:def::\"kumo\",type:ghi::dog}", str::from_utf8(&buf[0..len])?);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn annotations<'b, 'c>(
-        &'b mut self,
-        annotations: &'c [&'c str],
-    ) -> IonCAnnotationsFieldWriterContext<'a, 'b, 'c> {
-        IonCAnnotationsFieldWriterContext::new_annotations(self, annotations)
-    }
-
+impl<'a> IonCWriter<'a> for IonCWriterHandle<'a> {
     #[inline]
-    pub fn finish(&mut self) -> IonCResult<usize> {
+    fn finish(&mut self) -> IonCResult<usize> {
         let mut len = 0;
         ionc!(ion_writer_finish(self.writer, &mut len))?;
 
@@ -202,191 +476,38 @@ impl<'a> IonCWriterHandle<'a> {
 }
 
 impl IonCValueWriter for IonCWriterHandle<'_> {
-    /// Writes a `null` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
-    ///     writer.write_null(ION_TYPE_INT)?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"\xE0\x01\x00\xEA\x2F", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_null(&mut self, tid: ION_TYPE) -> IonCResult<()> {
         ionc!(ion_writer_write_typed_null(self.writer, tid))
     }
 
-    /// Writes a `bool` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
-    ///     writer.write_bool(true)?;
-    ///     writer.write_bool(false)?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"true false", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_bool(&mut self, value: bool) -> IonCResult<()> {
         ionc!(ion_writer_write_bool(self.writer, value as BOOL))
     }
 
-    /// Writes an `int` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
-    ///     writer.write_i64(-16)?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"\xE0\x01\x00\xEA\x31\x10", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_i64(&mut self, value: i64) -> IonCResult<()> {
         ionc!(ion_writer_write_int64(self.writer, value))
     }
 
-    /// Writes an `int` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # use num_bigint::BigInt;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
-    ///     let value = BigInt::parse_bytes(b"987654321987654321987654321", 10).unwrap();
-    ///     writer.write_bigint(&value)?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(
-    ///     b"\xE0\x01\x00\xEA\x2C\x03\x30\xF7\xF0\x14\x03\xF9\x4E\xDB\x18\x12\xB1",
-    ///     &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_bigint(&mut self, value: &BigInt) -> IonCResult<()> {
         let mut ion_int = IonIntPtr::try_from_bigint(value)?;
         ionc!(ion_writer_write_ion_int(self.writer, &mut *ion_int))
     }
 
-    /// Writes a `float` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
-    ///     writer.write_f64(3.0)?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"\xE0\x01\x00\xEA\x48\x40\x08\x00\x00\x00\x00\x00\x00", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_f64(&mut self, value: f64) -> IonCResult<()> {
         ionc!(ion_writer_write_double(self.writer, value))
     }
 
-    /// Writes a `decimal` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # use bigdecimal::BigDecimal;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
-    ///     let value = BigDecimal::parse_bytes(b"1.1", 10).unwrap();
-    ///     writer.write_bigdecimal(&value)?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(
-    ///     b"\xE0\x01\x00\xEA\x52\xC1\x0B",
-    ///     &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_bigdecimal(&mut self, value: &BigDecimal) -> IonCResult<()> {
         let mut ion_decimal = IonDecimalPtr::try_from_bigdecimal(value)?;
         ionc!(ion_writer_write_ion_decimal(self.writer, &mut *ion_decimal))
     }
 
-    /// Writes a `timestamp` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # use ion_c_sys::timestamp::*;
-    /// # use ion_c_sys::timestamp::Mantissa::*;
-    /// # use ion_c_sys::timestamp::TSPrecision::*;
-    /// # use ion_c_sys::timestamp::TSOffsetKind::*;
-    /// # use chrono::DateTime;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
-    ///     let dt = DateTime::parse_from_rfc3339("2020-01-02T12:34:00.123Z").unwrap();
-    ///
-    ///     // write the date time with microsecond precision and an unknown offset
-    ///     let ion_dt = IonDateTime::try_new(dt, Fractional(Digits(6)), UnknownOffset)?;
-    ///     writer.write_datetime(&ion_dt)?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(
-    ///     b"2020-01-02T12:34:00.123000-00:00",
-    ///     &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_datetime(&mut self, value: &IonDateTime) -> IonCResult<()> {
         let mut ion_timestamp = ION_TIMESTAMP::default();
@@ -394,25 +515,6 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
         ionc!(ion_writer_write_timestamp(self.writer, &mut ion_timestamp))
     }
 
-    /// Writes a `symbol` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
-    ///     writer.write_symbol("🍥")?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"'\xF0\x9F\x8D\xA5'", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_symbol(&mut self, value: &str) -> IonCResult<()> {
         // Ion C promises that it won't do mutation for this call!
@@ -420,25 +522,6 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
         ionc!(ion_writer_write_symbol(self.writer, &mut ion_str))
     }
 
-    /// Writes a `string` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
-    ///     writer.write_string("🐡")?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"\xE0\x01\x00\xEA\x84\xF0\x9F\x90\xA1", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_string(&mut self, value: &str) -> IonCResult<()> {
         // Ion C promises that it won't do mutation for this call!
@@ -446,25 +529,6 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
         ionc!(ion_writer_write_string(self.writer, &mut ion_str))
     }
 
-    /// Writes a `clob` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
-    ///     writer.write_clob("🐡".as_bytes())?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"\xE0\x01\x00\xEA\x94\xF0\x9F\x90\xA1", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_clob(&mut self, value: &[u8]) -> IonCResult<()> {
         // Ion C promises that it won't mutate the buffer for this call!
@@ -475,25 +539,6 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
         ))
     }
 
-    /// Writes a `blob` value.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Text)?;
-    ///     writer.write_blob("🍥".as_bytes())?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"{{8J+NpQ==}}", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn write_blob(&mut self, value: &[u8]) -> IonCResult<()> {
         // Ion C promises that it won't mutate the buffer for this call!
@@ -504,35 +549,46 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
         ))
     }
 
-    /// Starts a container.
-    ///
-    /// ## Usage
-    /// ```
-    /// # use std::convert::*;
-    /// # use ion_c_sys::*;
-    /// # use ion_c_sys::writer::*;
-    /// # use ion_c_sys::result::*;
-    /// # fn main() -> IonCResult<()> {
-    /// let mut buf = vec![0; 128];
-    /// let len = {
-    ///     let mut writer = IonCWriterHandle::new_buf_mode(buf.as_mut_slice(), WriterMode::Binary)?;
-    ///     writer.start_container(ION_TYPE_LIST)?;
-    ///     writer.finish_container()?;
-    ///     writer.finish()?
-    /// };
-    /// assert_eq!(b"\xE0\x01\x00\xEA\xB0", &buf[0..len]);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[inline]
     fn start_container(&mut self, tid: ION_TYPE) -> IonCResult<()> {
         ionc!(ion_writer_start_container(self.writer, tid))
     }
 
-    /// Finishes a container.
     #[inline]
     fn finish_container(&mut self) -> IonCResult<()> {
         ionc!(ion_writer_finish_container(self.writer))
+    }
+}
+
+impl IonCAnnotationsFieldWriter for IonCWriterHandle<'_> {
+    type AFValueWriter = Self;
+
+    #[inline]
+    fn write_annotations_and_field<'a, A, F, FN>(
+        &mut self,
+        possible_annotations: A,
+        possible_field: F,
+        applier: FN,
+    ) -> IonCResult<()>
+    where
+        A: Into<Option<&'a [&'a str]>>,
+        F: Into<Option<&'a str>>,
+        FN: Fn(&mut Self::AFValueWriter) -> IonCResult<()>,
+    {
+        // Ion C promises that it won't do mutation for these!
+        if let Some(annotations) = possible_annotations.into() {
+            for annotation in annotations {
+                let mut annotation_str = ION_STRING::try_from_str(annotation)?;
+                ionc!(ion_writer_add_annotation(self.writer, &mut annotation_str))?;
+            }
+        }
+        if let Some(field) = possible_field.into() {
+            let mut ion_field = ION_STRING::try_from_str(field)?;
+            ionc!(ion_writer_write_field_name(self.writer, &mut ion_field))?;
+        }
+        applier(self)?;
+
+        Ok(())
     }
 }
 
@@ -576,26 +632,26 @@ impl Drop for IonCWriterHandle<'_> {
 /// multiple [`IonCValueWriter`](./trait.IonCValueWriter.html) trait method invocations
 /// is the same as writing the field before invoking the value writing methods
 /// (so duplicate fields would be generated in that case).
-pub struct IonCAnnotationsFieldWriterContext<'a, 'b, 'c> {
-    handle: &'b mut IonCWriterHandle<'a>,
+pub struct IonCAnnotationsFieldWriterContext<'b, 'c, T: IonCAnnotationsFieldWriter + ?Sized> {
+    writer: &'b mut T,
     annotations: Option<&'c [&'c str]>,
     field: Option<&'c str>,
 }
 
-impl<'a, 'b, 'c> IonCAnnotationsFieldWriterContext<'a, 'b, 'c> {
+impl<'b, 'c, T: IonCAnnotationsFieldWriter + ?Sized> IonCAnnotationsFieldWriterContext<'b, 'c, T> {
     #[inline]
-    fn new_field(handle: &'b mut IonCWriterHandle<'a>, field: &'c str) -> Self {
+    fn new_field(writer: &'b mut T, field: &'c str) -> Self {
         Self {
-            handle,
+            writer,
             annotations: None,
             field: Some(field),
         }
     }
 
     #[inline]
-    fn new_annotations(handle: &'b mut IonCWriterHandle<'a>, annotations: &'c [&'c str]) -> Self {
+    fn new_annotations(writer: &'b mut T, annotations: &'c [&'c str]) -> Self {
         Self {
-            handle,
+            writer,
             annotations: Some(annotations),
             field: None,
         }
@@ -616,99 +672,77 @@ impl<'a, 'b, 'c> IonCAnnotationsFieldWriterContext<'a, 'b, 'c> {
     }
 
     #[inline]
-    fn write_annotations_and_field(&mut self) -> IonCResult<()> {
-        // Ion C promises that it won't do mutation for these!
-        if let Some(annotations) = self.annotations {
-            for annotation in annotations {
-                let mut annotation_str = ION_STRING::try_from_str(annotation)?;
-                ionc!(ion_writer_add_annotation(
-                    self.handle.writer,
-                    &mut annotation_str
-                ))?;
-            }
-        }
-        if let Some(field) = self.field {
-            let mut field_str = ION_STRING::try_from_str(field)?;
-            ionc!(ion_writer_write_field_name(
-                self.handle.writer,
-                &mut field_str
-            ))?;
-        }
+    fn write_annotations_and_field<F>(&mut self, applier: F) -> IonCResult<()>
+    where
+        F: Fn(&mut T::AFValueWriter) -> IonCResult<()>,
+    {
+        self.writer
+            .write_annotations_and_field(self.annotations, self.field, applier)?;
 
         Ok(())
     }
 }
 
-impl IonCValueWriter for IonCAnnotationsFieldWriterContext<'_, '_, '_> {
+impl<T: IonCAnnotationsFieldWriter + ?Sized> IonCValueWriter
+    for IonCAnnotationsFieldWriterContext<'_, '_, T>
+{
     #[inline]
     fn write_null(&mut self, tid: ION_TYPE) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_null(tid)
+        self.write_annotations_and_field(|v| v.write_null(tid))
     }
 
     #[inline]
     fn write_bool(&mut self, value: bool) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_bool(value)
+        self.write_annotations_and_field(|v| v.write_bool(value))
     }
 
     #[inline]
     fn write_i64(&mut self, value: i64) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_i64(value)
+        self.write_annotations_and_field(|v| v.write_i64(value))
     }
 
     #[inline]
     fn write_bigint(&mut self, value: &BigInt) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_bigint(value)
+        self.write_annotations_and_field(|v| v.write_bigint(value))
     }
 
     #[inline]
     fn write_f64(&mut self, value: f64) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_f64(value)
+        self.write_annotations_and_field(|v| v.write_f64(value))
     }
 
     #[inline]
     fn write_bigdecimal(&mut self, value: &BigDecimal) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_bigdecimal(value)
+        self.write_annotations_and_field(|v| v.write_bigdecimal(value))
     }
 
     fn write_datetime(&mut self, value: &IonDateTime) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_datetime(value)
+        self.write_annotations_and_field(|v| v.write_datetime(value))
     }
 
     #[inline]
     fn write_symbol(&mut self, value: &str) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_symbol(value)
+        self.write_annotations_and_field(|v| v.write_symbol(value))
     }
 
     #[inline]
     fn write_string(&mut self, value: &str) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_string(value)
+        self.write_annotations_and_field(|v| v.write_string(value))
     }
 
     #[inline]
     fn write_clob(&mut self, value: &[u8]) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_clob(value)
+        self.write_annotations_and_field(|v| v.write_clob(value))
     }
 
     #[inline]
     fn write_blob(&mut self, value: &[u8]) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.write_blob(value)
+        self.write_annotations_and_field(|v| v.write_blob(value))
     }
 
     #[inline]
     fn start_container(&mut self, tid: ION_TYPE) -> IonCResult<()> {
-        self.write_annotations_and_field()?;
-        self.handle.start_container(tid)
+        self.write_annotations_and_field(|v| v.start_container(tid))
     }
 
     /// This API is not relevant for this context and will always return an error.


### PR DESCRIPTION
* Adds `IonCAnnotationsFieldWriter` which is a functional way to capture
  the application of annotations and field name.
* Makes `IonCAnnotationsFieldWriterContext` generic and implemented in
  terms of the above.
* Changes `from_buf` to `try_from_buf` to be more consistent in `IonCReaderHandle`.

Resolves #85.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
