### PR TITLE
Bumps `bigdecimal` and `num-bigint` dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [dependencies]
 base64 = "^0.12.3"
-bigdecimal = "^0.1"
+bigdecimal = "^0.2"
 bytes = "^0.4"
 chrono = "^0.4"
 delegate = "^0.4.2"

--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -21,8 +21,8 @@ edition = "2018"
 
 [dependencies]
 paste = "1.0.0"
-num-bigint = "0.2.6"
-bigdecimal = "0.1.2"
+num-bigint = "0.3.0"
+bigdecimal = "0.2.0"
 chrono = "0.4.13"
 
 [build-dependencies]

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -874,6 +874,7 @@ mod tests {
     use crate::cursor::{Cursor, StreamItem, StreamItem::*};
     use crate::result::IonResult;
     use crate::types::IonType;
+    use std::convert::TryInto;
 
     type TestDataSource = io::Cursor<Vec<u8>>;
 
@@ -989,7 +990,7 @@ mod tests {
     fn test_read_big_decimal_negative_exponent() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x52, 0xC1, 0x02]);
         assert_eq!(cursor.next()?, Some(Value(IonType::Decimal, false)));
-        assert_eq!(cursor.read_big_decimal()?, Some(0.2f64.into()));
+        assert_eq!(cursor.read_big_decimal()?, Some(0.2f64.try_into().unwrap()));
         Ok(())
     }
 


### PR DESCRIPTION
Note that due to commit [30b79b7][1] in akubera/bigdecimal-rs, `f64` conversion must use `TryFrom` and not `From`, so minor fix to the unit tests are included.

[1]: https://github.com/akubera/bigdecimal-rs/commit/30b79b7601095e348eed845b116352f3feeb5fd0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
