### PR TITLE
[ion-c-sys] Adds library path to lib/lib64 for Ion C.

### DIFF
--- a/ion-c-sys/build.rs
+++ b/ion-c-sys/build.rs
@@ -19,9 +19,13 @@ macro_rules! mkpath {
 
 fn main() {
     let ionc_path = cmake::Config::new("ion-c").build();
-    let ionc_lib_path = mkpath!(&ionc_path, "lib");
 
-    println!("cargo:rustc-link-search=native={}", ionc_lib_path.display());
+    let lib_suffixes = &["lib", "lib64"];
+    for lib_suffix in lib_suffixes {
+        let ionc_lib_path = mkpath!(&ionc_path, lib_suffix);
+        println!("cargo:rustc-link-search=native={}", ionc_lib_path.display());
+    }
+
     println!("cargo:rustc-link-lib=static=decNumber_static");
     println!("cargo:rustc-link-lib=static=ionc_static");
 


### PR DESCRIPTION
RHEL/CentOS/AL2 generates an output directory of `lib64` versus
`lib` on the other platform, this supports either modality.

Fixes #106.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
