### PR TITLE
Ts fix ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Env Variable Setup 
         if: matrix.os == 'windows-latest'
         run: | 
-          echo 'LIBCLANG_PATH::C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin' >> $GITHUB_ENV
+          echo 'LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin' >> $GITHUB_ENV
       - name: Git Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Env Variable Setup 
         if: matrix.os == 'windows-latest'
         run: | 
-          echo 'LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin' >> $GITHUB_ENV
+          echo 'PATH=$PATH:C:\msys64\mingw64\bin' >> $GITHUB_ENV
+          echo 'PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin' >> $GITHUB_ENV
       - name: Git Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Remove msys64
         if: runner.os == 'Windows'
-        run: Remove-Item -LiteralPath "C:\msys64\ " -Force -Recurse
+        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
       - name: Install Dependencies
         if: runner.os == 'Windows'
         run: choco install llvm -y

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: | 
           echo 'PATH=$PATH:C:\msys64\mingw64\bin' >> $GITHUB_ENV
-          echo 'PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin' >> $GITHUB_ENV
+          echo 'LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin' >> $GITHUB_ENV
       - name: Git Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Env Variable Setup 
         if: matrix.os == 'windows-latest'
         run: | 
-          echo '::set-env name=LIBCLANG_PATH::C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin'
+          echo 'LIBCLANG_PATH::C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin' >> $GITHUB_ENV
       - name: Git Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,11 +11,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - name: Env Variable Setup 
-        if: matrix.os == 'windows-latest'
-        run: | 
-          echo 'PATH=$PATH:C:\msys64\mingw64\bin' >> $GITHUB_ENV
-          echo 'LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin' >> $GITHUB_ENV
+      - name: Remove msys64
+        if: runner.os == 'Windows'
+        run: Remove-Item -LiteralPath "C:\msys64\ " -Force -Recurse
+      - name: Install Dependencies
+        if: runner.os == 'Windows'
+        run: choco install llvm -y
       - name: Git Checkout
         uses: actions/checkout@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ base64 = "^0.12.3"
 bigdecimal = "^0.2"
 bytes = "^0.4"
 chrono = "^0.4"
-delegate = "^0.4.2"
+delegate = "^0.5"
 failure = "^0.1"
 failure_derive = "^0.1"
 


### PR DESCRIPTION
*Description of changes:*

* updates dependency on `delegate` crate -- `syn` upgrade was causing compiler errors
* changes CI flow to uninstall LLVM and install usinc `choco`
    * CI was broken due to GitHub's move to [Environment Files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files). After this fix Windows build would fail linking to `libclang.dll`. The only work around that I have found to work is to remove the LLVM installed with the windows image and install LLVM using `choco`. This adds ~8 minutes to the Windows build. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
