### PR TITLE
Updates to the IonError type.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ bigdecimal = "^0.2"
 bytes = "^0.4"
 chrono = "^0.4"
 delegate = "^0.5"
-failure = "^0.1"
-failure_derive = "^0.1"
+thiserror = "1.0"
 
 # NB: We use the tree dependency here for development and CI.
 #     Note that when publishing you should update the version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![allow(dead_code)]
 
-#[macro_use]
-extern crate failure_derive;
-
 pub mod result;
 
 pub mod binary;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,35 +1,77 @@
+use thiserror::Error;
+
 use std::convert::From;
-use std::io;
+use std::{io, fmt};
 
 /// A unified Result type representing the outcome of method calls that may fail.
 pub type IonResult<T> = Result<T, IonError>;
 
 /// Represents the different types of high-level failures that might occur when reading Ion data.
-#[derive(Debug, Fail, Clone, PartialEq)]
+#[derive(Debug, Error)]
 pub enum IonError {
     /// Indicates that an IO error was encountered while reading or writing.
-    #[fail(display = "An IO error occurred: {}", description)]
-    IoError { description: String },
+    #[error("{source:?}")]
+    IoError {
+        #[from]
+        source: io::Error,
+    },
+
+    #[error("{source:?}")]
+    FmtError {
+        #[from]
+        source: fmt::Error,
+    },
 
     /// Indicates that the data stream being read contained illegal or otherwise unreadable data.
-    #[fail(display = "A decoding error occurred: {}", description)]
+    #[error("{description}")]
     DecodingError { description: String },
 
     /// Returned when the user has performed an illegal operation (for example: calling stepOut()
     /// on the cursor at the top level.)
-    #[fail(
-        display = "The user has performed an action that is not legal in the current state: {}",
-        description
-    )]
-    IllegalOperation { description: String },
+    #[error("The user has performed an operation that is not legal in the current state: {operation}")]
+    IllegalOperation { operation: String },
 }
 
-/// A convenience method for creating an IonResult containing an IonError::IoError with the
-/// provided description text.
-pub fn io_error<T>(description: &str) -> IonResult<T> {
-    Err(IonError::IoError {
-        description: description.to_string(),
-    })
+// io::Error does not implement Clone, which precludes us from simply deriving an implementation.
+// IonError needs a Clone implementation because we use a jump table of cached IonResult values when
+// parsing type descriptor bytes. The only error type that will be cloned by virtue of using the jump
+// table is DecodingError.
+impl Clone for IonError {
+    fn clone(&self) -> Self {
+        use IonError::*;
+        match self {
+            IoError {source} => IoError {
+                // io::Error implements From<ErrorKind>, and ErrorKind is cloneable.
+                source: io::Error::from(source.kind().clone())
+            },
+            FmtError {source} => FmtError {
+                source: source.clone()
+            },
+            DecodingError {description} => DecodingError {
+                description: description.clone()
+            },
+            IllegalOperation {operation} => IllegalOperation {
+                operation: operation.clone()
+            }
+        }
+    }
+}
+
+// io::Error does not implement PartialEq, which precludes us from simply deriving an implementation.
+// Providing an implementation of PartialEq allows IonResult values to be the left or right side in
+// an assert_eq!() statement.
+impl PartialEq for IonError {
+    fn eq(&self, other: &Self) -> bool {
+        use IonError::*;
+        match (self, other) {
+            // We can compare the io::Errors' ErrorKinds, offering a weak definition of equality.
+            (IoError {source: s1}, IoError {source: s2}) => s1.kind() == s2.kind(),
+            (FmtError {source: s1}, FmtError {source: s2}) => s1 == s2,
+            (DecodingError {description: s1}, DecodingError {description: s2}) => s1 == s2,
+            (IllegalOperation {operation: s1}, IllegalOperation {operation: s2}) => s1 == s2,
+            _ => false
+        }
+    }
 }
 
 /// A convenience method for creating an IonResult containing an IonError::DecodingError with the
@@ -41,33 +83,15 @@ pub fn decoding_error<T, S: AsRef<str>>(description: S) -> IonResult<T> {
 }
 
 /// A convenience method for creating an IonResult containing an IonError::IllegalOperation with the
-/// provided description text.
-pub fn illegal_operation<T, S: AsRef<str>>(description: S) -> IonResult<T> {
-    Err(illegal_operation_raw(description))
+/// provided operation text.
+pub fn illegal_operation<T, S: AsRef<str>>(operation: S) -> IonResult<T> {
+    Err(illegal_operation_raw(operation))
 }
 
-/// A convenience method for creating an IonError::IllegalOperation with the provided description
+/// A convenience method for creating an IonError::IllegalOperation with the provided operation
 /// text. Useful for calling Option#ok_or_else.
-pub fn illegal_operation_raw<S: AsRef<str>>(description: S) -> IonError {
+pub fn illegal_operation_raw<S: AsRef<str>>(operation: S) -> IonError {
     IonError::IllegalOperation {
-        description: description.as_ref().to_string(),
-    }
-}
-
-/// Allows [`io::Error`]s to be converted to an IonError and propagated using the `?` operator.
-impl From<io::Error> for IonError {
-    fn from(error: io::Error) -> Self {
-        IonError::IoError {
-            description: format!("Encountered an IO error: {:?}", error),
-        }
-    }
-}
-
-/// Allows [`std::fmt::Error`]s to be converted to an IonError and propagated using the `?` operator.
-impl From<std::fmt::Error> for IonError {
-    fn from(error: std::fmt::Error) -> Self {
-        IonError::IoError {
-            description: format!("Encountered an IO error: {:?}", error),
-        }
+        operation: operation.as_ref().to_string(),
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixes #110.

*Description of changes:*

* Switched from `failure` to the more  modern `thiserror` crate for generating  boilerplate trait implementations.
* IonError now implements the trait `std::error::Error`, a prerequisite for using it with the `anyhow` crate.
* An IonError can now retain the original `io::Error` or `fmt::Error` that caused it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
