### PR TITLE
Ran rustfmt

### DIFF
--- a/ion-c-sys/src/timestamp.rs
+++ b/ion-c-sys/src/timestamp.rs
@@ -163,7 +163,7 @@ impl IonDateTime {
                     if scale <= TS_MAX_MANTISSA_DIGITS {
                         return Err(IonCError::with_additional(
                             ion_error_code_IERR_INVALID_TIMESTAMP,
-                            "Fractional mantissa not allowed for sub-nanosecond precision"
+                            "Fractional mantissa not allowed for sub-nanosecond precision",
                         ));
                     }
                     let ns = date_time.nanosecond();

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -37,7 +37,6 @@ struct EncodedValue {
     //
     // See the Rust Performance Book section on measuring type sizes[1] for more information.
     // [1] https://nnethercote.github.io/perf-book/type-sizes.html#measuring-type-sizes
-
     ion_type: IonType,
     header: Header,
     is_null: bool,
@@ -86,7 +85,6 @@ struct EncodedValue {
 }
 
 impl EncodedValue {
-
     /// Returns the offset of the current value's type descriptor byte.
     fn header_offset(&self) -> usize {
         self.header_offset as usize
@@ -146,9 +144,7 @@ impl EncodedValue {
         if self.field_id.is_none() {
             return None;
         }
-        Some(self.header_offset
-            - self.annotations_length as usize
-            - self.field_id_length as usize)
+        Some(self.header_offset - self.annotations_length as usize - self.field_id_length as usize)
     }
 
     /// Returns an offset Range that contains the bytes used to encode this value's field ID,
@@ -208,7 +204,7 @@ impl Default for EncodedValue {
             header_offset: 0,
             header_length: 0,
             value_length: 0,
-            number_of_annotations: 0
+            number_of_annotations: 0,
         }
     }
 }
@@ -252,7 +248,7 @@ pub struct CursorState {
     // All of the annotations on values in `parents` and the current value.
     // Having a single, reusable Vec reduces allocations and keeps the size of
     // the EncodedValue type (which is frequently moved) small.
-    annotations: Vec<SymbolId>
+    annotations: Vec<SymbolId>,
 }
 
 /// Verifies that the current value is of the expected type and that the bytes representing that
@@ -504,8 +500,8 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
     }
 
     fn blob_ref_map<F, T>(&mut self, f: F) -> IonResult<Option<T>>
-        where
-            F: FnOnce(&[u8]) -> T,
+    where
+        F: FnOnce(&[u8]) -> T,
     {
         read_safety_checks!(self, IonType::Blob);
 
@@ -514,8 +510,8 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
     }
 
     fn clob_ref_map<F, T>(&mut self, f: F) -> IonResult<Option<T>>
-        where
-            F: FnOnce(&[u8]) -> T,
+    where
+        F: FnOnce(&[u8]) -> T,
     {
         read_safety_checks!(self, IonType::Clob);
 
@@ -588,11 +584,12 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
         //      Offer an read_* API that surfaces information about the encoded timestamp's
         //      precision.
         const NANOSECONDS_PER_SECOND: f64 = 1_000_000_000f64;
-        let fractional_seconds = subsecond_coefficient as f64 * 10f64.powf(subsecond_exponent as f64);
+        let fractional_seconds =
+            subsecond_coefficient as f64 * 10f64.powf(subsecond_exponent as f64);
         let nanoseconds = (fractional_seconds * NANOSECONDS_PER_SECOND).round() as u32;
 
         let naive_datetime = NaiveDate::from_ymd(year as i32, month as u32, day as u32)
-            .and_hms(hour as u32,minute as u32,second as u32)
+            .and_hms(hour as u32, minute as u32, second as u32)
             .with_nanosecond(nanoseconds);
 
         if naive_datetime.is_none() {
@@ -622,7 +619,10 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
         self.cursor.parents.push(EncodedValue::default());
         // We've just push()ed a value onto the `parents` Vec, so it's safe to call
         // last_mut().unwrap() below.
-        mem::swap(&mut self.cursor.value, self.cursor.parents.last_mut().unwrap());
+        mem::swap(
+            &mut self.cursor.value,
+            self.cursor.parents.last_mut().unwrap(),
+        );
         self.cursor.depth += 1;
         self.cursor.index_at_depth = 0;
         Ok(())
@@ -644,7 +644,9 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
         // Vec position.
 
         // Get an in-place handle to parent
-        let mut parent = self.cursor.parents
+        let mut parent = self
+            .cursor
+            .parents
             .last_mut()
             .ok_or_else(|| illegal_operation_raw("You cannot step out of the root level."))?;
 
@@ -791,7 +793,7 @@ where
                 is_in_struct: false,
                 value: Default::default(),
                 parents: Vec::new(),
-                annotations: Vec::new()
+                annotations: Vec::new(),
             },
             header_cache: create_header_byte_jump_table(),
         }
@@ -802,7 +804,8 @@ where
     }
 
     fn finished_reading_value(&mut self) -> bool {
-        self.cursor.value.value_length > 0 && self.cursor.bytes_read >= self.cursor.value.value_end_exclusive()
+        self.cursor.value.value_length > 0
+            && self.cursor.bytes_read >= self.cursor.value.value_end_exclusive()
     }
 
     fn clear_annotations(&mut self) {
@@ -871,7 +874,8 @@ where
             Reserved => return decoding_error("Found an Ion Value with a Reserved type code."),
         };
 
-        self.cursor.value.header_length = (self.cursor.bytes_read - self.cursor.value.header_offset - 1) as u8;
+        self.cursor.value.header_length =
+            (self.cursor.bytes_read - self.cursor.value.header_offset - 1) as u8;
         self.cursor.value.value_length = length;
         Ok(())
     }
@@ -1454,7 +1458,10 @@ mod tests {
         assert_eq!(cursor.raw_annotations_bytes(), Some(&ion_data[12..=14]));
         assert_eq!(cursor.annotation_ids(), &[12]);
         assert_eq!(cursor.raw_header_bytes(), Some(&ion_data[15..=15]));
-        assert_eq!(cursor.raw_value_bytes(), Some(&ion_data[15..15] /*That is, zero bytes*/));
+        assert_eq!(
+            cursor.raw_value_bytes(),
+            Some(&ion_data[15..15] /*That is, zero bytes*/)
+        );
         Ok(())
     }
 

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -1459,6 +1459,7 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_clear_annotations() -> IonResult<()> {
         // Verifies that byte offset bookkeeping is correct when the cursor reads a field with
         // annotations, then a field with no annotations, and finally a value with neither a

--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -93,9 +93,9 @@ impl Int {
 #[cfg(test)]
 mod tests {
     use super::Int;
-    use std::io::Cursor;
     use crate::result::IonResult;
     use std::io;
+    use std::io::Cursor;
 
     const READ_ERROR_MESSAGE: &str = "Failed to read an Int from the provided cursor.";
 

--- a/src/binary/var_int.rs
+++ b/src/binary/var_int.rs
@@ -1,7 +1,7 @@
 use crate::data_source::IonDataSource;
 use crate::result::{decoding_error, IonResult};
-use std::mem;
 use std::io::Write;
+use std::mem;
 
 // ion_rust does not currently support reading variable length integers of truly arbitrary size.
 // These type aliases will simplify the process of changing the data types used to represent each
@@ -149,8 +149,8 @@ impl VarInt {
 #[cfg(test)]
 mod tests {
     use super::VarInt;
-    use std::io::{BufReader, Cursor};
     use crate::result::IonResult;
+    use std::io::{BufReader, Cursor};
 
     const ERROR_MESSAGE: &'static str = "Failed to read a VarUInt from the provided data.";
 
@@ -226,7 +226,7 @@ mod tests {
         let mut buffer = vec![];
         VarInt::write_i64(&mut buffer, value)?;
         assert_eq!(buffer.as_slice(), expected_encoding);
-        return Ok(())
+        return Ok(());
     }
 
     #[test]
@@ -243,7 +243,7 @@ mod tests {
     }
 
     #[test]
-    fn test_write_var_int_two_byte_values() -> IonResult<()>  {
+    fn test_write_var_int_two_byte_values() -> IonResult<()> {
         var_int_encoding_test(555, &[0b0000_0100, 0b1010_1011])?;
         var_int_encoding_test(-555, &[0b0100_0100, 0b1010_1011])?;
         Ok(())

--- a/src/binary/var_int.rs
+++ b/src/binary/var_int.rs
@@ -74,6 +74,7 @@ impl VarInt {
         })
     }
 
+    #[rustfmt::skip]
     pub fn write_i64<W: Write>(sink: &mut W, value: i64) -> IonResult<()> {
         // An i64 is 8 bytes of data. The VarInt encoding will add one continuation bit per byte
         // as well as a sign bit, for a total of 9 extra bits. Therefore, the largest encoding

--- a/src/binary/var_uint.rs
+++ b/src/binary/var_uint.rs
@@ -65,6 +65,7 @@ impl VarUInt {
     }
 
     /// Encodes the given unsigned int value as a VarUInt and writes it to the sink.
+    #[rustfmt::skip]
     pub fn write_u64<W: Write>(sink: &mut W, mut magnitude: u64) -> IonResult<usize> {
         // A u64 is 8 bytes of data. The VarUInt encoding will add a continuation bit to every byte,
         // growing the data size by 8 more bits. Therefore, the largest encoded size of a u64 is

--- a/src/binary/var_uint.rs
+++ b/src/binary/var_uint.rs
@@ -1,7 +1,7 @@
 use crate::data_source::IonDataSource;
 use crate::result::{decoding_error, IonResult};
-use std::mem;
 use std::io::Write;
+use std::mem;
 
 // ion_rust does not currently support reading variable length integers of truly arbitrary size.
 // These type aliases will simplify the process of changing the data types used to represent each
@@ -118,8 +118,8 @@ impl VarUInt {
 #[cfg(test)]
 mod tests {
     use super::VarUInt;
-    use std::io::{BufReader, Cursor};
     use crate::result::IonResult;
+    use std::io::{BufReader, Cursor};
 
     const ERROR_MESSAGE: &'static str = "Failed to read a VarUInt from the provided data.";
 
@@ -179,7 +179,7 @@ mod tests {
         let mut buffer = vec![];
         VarUInt::write_u64(&mut buffer, value)?;
         assert_eq!(buffer.as_slice(), expected_encoding);
-        return Ok(())
+        return Ok(());
     }
 
     #[test]
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn test_write_var_uint_two_byte_values() -> IonResult<()>  {
+    fn test_write_var_uint_two_byte_values() -> IonResult<()> {
         var_uint_encoding_test(279, &[0b0000_0010, 0b1001_0111])?;
         var_uint_encoding_test(555, &[0b0000_0100, 0b1010_1011])?;
         var_uint_encoding_test(999, &[0b0000_0111, 0b1110_0111])?;

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -89,7 +89,9 @@ pub trait Cursor {
     /// Runs the provided closure, passing in a reference to the blob to be read and allowing a
     /// calculated value of any type to be returned. When possible, blob_ref_map will pass a
     /// reference directly to the bytes in the input buffer rather than allocating a new array.
-    fn blob_ref_map<F, U>(&mut self, f: F) -> IonResult<Option<U>> where F: FnOnce(&[u8]) -> U;
+    fn blob_ref_map<F, U>(&mut self, f: F) -> IonResult<Option<U>>
+    where
+        F: FnOnce(&[u8]) -> U;
 
     /// If the current value is a clob, returns its value as a Vec<u8>; otherwise, returns None.
     fn read_clob_bytes(&mut self) -> IonResult<Option<Vec<u8>>>;
@@ -97,7 +99,9 @@ pub trait Cursor {
     /// Runs the provided closure, passing in a reference to the clob to be read and allowing a
     /// calculated value of any type to be returned. When possible, clob_ref_map will pass a
     /// reference directly to the bytes in the input buffer rather than allocating a new array.
-    fn clob_ref_map<F, U>(&mut self, f: F) -> IonResult<Option<U>> where F: FnOnce(&[u8]) -> U;
+    fn clob_ref_map<F, U>(&mut self, f: F) -> IonResult<Option<U>>
+    where
+        F: FnOnce(&[u8]) -> U;
 
     /// If the current value is a timestamp, returns its value as a DateTime<FixedOffset>;
     /// otherwise, returns None.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -6,13 +6,13 @@ use bigdecimal::BigDecimal;
 use chrono::{DateTime, FixedOffset};
 use delegate::delegate;
 
-use crate::{BinaryIonCursor, Cursor, IonType};
 use crate::constants::v1_0::system_symbol_ids;
 use crate::cursor::StreamItem::*;
 use crate::result::IonResult;
 use crate::symbol_table::SymbolTable;
 use crate::system_event_handler::SystemEventHandler;
 use crate::types::SymbolId;
+use crate::{BinaryIonCursor, Cursor, IonType};
 
 /// A streaming Ion reader that resolves symbol IDs into the appropriate text.
 ///
@@ -245,13 +245,13 @@ impl<T: AsRef<[u8]>> Reader<BinaryIonCursor<io::Cursor<T>>> {
 mod tests {
     use std::io;
 
-    use crate::{Reader, SymbolTable};
     use crate::binary::constants::v1_0::IVM;
     use crate::binary::cursor::BinaryIonCursor;
     use crate::cursor::{Cursor, StreamItem::*};
     use crate::result::IonResult;
     use crate::system_event_handler::SystemEventHandler;
     use crate::types::IonType;
+    use crate::{Reader, SymbolTable};
 
     type TestDataSource = io::Cursor<Vec<u8>>;
 
@@ -310,7 +310,11 @@ mod tests {
 
     struct Handler;
     impl SystemEventHandler for Handler {
-        fn on_symbol_table_append<'a>(&'a mut self, symbol_table: &'a SymbolTable, starting_id: usize) {
+        fn on_symbol_table_append<'a>(
+            &'a mut self,
+            symbol_table: &'a SymbolTable,
+            starting_id: usize,
+        ) {
             let new_symbols = symbol_table.symbols_tail(starting_id);
             assert_eq!(3, new_symbols.len());
             assert_eq!("foo", new_symbols[0].as_str());

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 use std::convert::From;
-use std::{io, fmt};
+use std::{fmt, io};
 
 /// A unified Result type representing the outcome of method calls that may fail.
 pub type IonResult<T> = Result<T, IonError>;
@@ -28,7 +28,9 @@ pub enum IonError {
 
     /// Returned when the user has performed an illegal operation (for example: calling stepOut()
     /// on the cursor at the top level.)
-    #[error("The user has performed an operation that is not legal in the current state: {operation}")]
+    #[error(
+        "The user has performed an operation that is not legal in the current state: {operation}"
+    )]
     IllegalOperation { operation: String },
 }
 
@@ -40,19 +42,19 @@ impl Clone for IonError {
     fn clone(&self) -> Self {
         use IonError::*;
         match self {
-            IoError {source} => IoError {
+            IoError { source } => IoError {
                 // io::Error implements From<ErrorKind>, and ErrorKind is cloneable.
-                source: io::Error::from(source.kind().clone())
+                source: io::Error::from(source.kind().clone()),
             },
-            FmtError {source} => FmtError {
-                source: source.clone()
+            FmtError { source } => FmtError {
+                source: source.clone(),
             },
-            DecodingError {description} => DecodingError {
-                description: description.clone()
+            DecodingError { description } => DecodingError {
+                description: description.clone(),
             },
-            IllegalOperation {operation} => IllegalOperation {
-                operation: operation.clone()
-            }
+            IllegalOperation { operation } => IllegalOperation {
+                operation: operation.clone(),
+            },
         }
     }
 }
@@ -65,11 +67,11 @@ impl PartialEq for IonError {
         use IonError::*;
         match (self, other) {
             // We can compare the io::Errors' ErrorKinds, offering a weak definition of equality.
-            (IoError {source: s1}, IoError {source: s2}) => s1.kind() == s2.kind(),
-            (FmtError {source: s1}, FmtError {source: s2}) => s1 == s2,
-            (DecodingError {description: s1}, DecodingError {description: s2}) => s1 == s2,
-            (IllegalOperation {operation: s1}, IllegalOperation {operation: s2}) => s1 == s2,
-            _ => false
+            (IoError { source: s1 }, IoError { source: s2 }) => s1.kind() == s2.kind(),
+            (FmtError { source: s1 }, FmtError { source: s2 }) => s1 == s2,
+            (DecodingError { description: s1 }, DecodingError { description: s2 }) => s1 == s2,
+            (IllegalOperation { operation: s1 }, IllegalOperation { operation: s2 }) => s1 == s2,
+            _ => false,
         }
     }
 }

--- a/src/system_event_handler.rs
+++ b/src/system_event_handler.rs
@@ -9,7 +9,12 @@ pub trait SystemEventHandler {
     /// Invoked when the cursor encounters an Ion Version Marker.
     fn on_ivm(&mut self, _ion_version: (u8, u8)) {}
     /// Invoked when new symbols are added to the end of the existing table.
-    fn on_symbol_table_append<'a>(&'a mut self, _symbol_table: &'a SymbolTable, _starting_id: usize) {}
+    fn on_symbol_table_append<'a>(
+        &'a mut self,
+        _symbol_table: &'a SymbolTable,
+        _starting_id: usize,
+    ) {
+    }
     /// Invoked when the active symbol table is reset, potentially defining new symbols.
     fn on_symbol_table_reset<'a>(&'a mut self, _symbol_table: &'a SymbolTable) {}
 }

--- a/src/types/type.rs
+++ b/src/types/type.rs
@@ -23,7 +23,7 @@ impl IonType {
         use IonType::*;
         match self {
             List | SExpression | Struct => true,
-            _ => false
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*

Runs `rustfmt` on the entire codebase for consistency. This PR contains no logic changes, just reformatting. A few functions have been flagged with the `#[rustfmt::skip]` annotation because they have comments that are carefully spaced.

After this is merged, I'll add `rustfmt --check` to the CI build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
