### PR TITLE
Adds a preliminary `Element` DOM-like API.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cursor;
 pub mod data_source;
 pub mod text;
 pub mod types;
+pub mod value;
 
 pub mod constants;
 mod reader;

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -1,0 +1,229 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+//! Provides borrowed implementations of [`SymbolToken`], [`Element`] and its dependents.
+//!
+//! Specifically, all implementations are tied to some particular lifetime, generally linked
+//! to a parser implementation of some sort or some context from which the borrow can occur.
+//! For simple values, the values are inlined (see [`BorrowedValue`]), but for things that are
+//! backed by octets or string data, `&[u8]` and `&str` are used.
+
+use super::{Element, ImportSource, Sequence, Struct, SymbolToken};
+use crate::types::SymbolId;
+use crate::value::AnyInt;
+use crate::IonType;
+
+/// A borrowed implementation of [`ImportSource`].
+#[derive(Debug, Copy, Clone)]
+pub struct BorrowedImportSource<'val> {
+    table: &'val str,
+    sid: SymbolId,
+}
+
+impl<'val> BorrowedImportSource<'val> {
+    pub fn new(table: &'val str, sid: SymbolId) -> Self {
+        Self { table, sid }
+    }
+}
+
+impl<'val> ImportSource for BorrowedImportSource<'val> {
+    fn table(&self) -> &str {
+        self.table
+    }
+
+    fn sid(&self) -> usize {
+        self.sid
+    }
+}
+
+/// A borrowed implementation of [`SymbolToken`].
+#[derive(Debug, Copy, Clone)]
+pub struct BorrowedSymbolToken<'val> {
+    text: Option<&'val str>,
+    local_sid: Option<SymbolId>,
+    source: Option<BorrowedImportSource<'val>>,
+}
+
+impl<'val> BorrowedSymbolToken<'val> {
+    pub fn new(
+        text: Option<&'val str>,
+        local_sid: Option<SymbolId>,
+        source: Option<BorrowedImportSource<'val>>,
+    ) -> Self {
+        Self {
+            text,
+            local_sid,
+            source,
+        }
+    }
+}
+
+impl<'val> From<&'val str> for BorrowedSymbolToken<'val> {
+    fn from(text: &'val str) -> Self {
+        Self::new(Some(text), None, None)
+    }
+}
+
+impl<'val> SymbolToken for BorrowedSymbolToken<'val> {
+    type ImportSource = BorrowedImportSource<'val>;
+
+    fn text(&self) -> Option<&str> {
+        self.text
+    }
+
+    fn local_sid(&self) -> Option<usize> {
+        self.local_sid
+    }
+
+    fn source(&self) -> Option<&Self::ImportSource> {
+        self.source.as_ref()
+    }
+}
+
+/// A borrowed implementation of [`Sequence`].
+#[derive(Debug, Clone)]
+pub struct BorrowedSequence<'val> {
+    children: Vec<BorrowedElement<'val>>,
+}
+
+impl<'val> BorrowedSequence<'val> {
+    pub fn new(children: Vec<BorrowedElement<'val>>) -> Self {
+        Self { children }
+    }
+}
+
+impl<'val> Sequence for BorrowedSequence<'val> {
+    type Element = BorrowedElement<'val>;
+
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a> {
+        Box::new(self.children.iter())
+    }
+}
+
+/// A borrowed implementation of [`Struct`]
+#[derive(Debug, Clone)]
+pub struct BorrowedStruct<'val> {
+    // TODO model actual map indexing for the struct (maybe as a variant type)
+    //      otherwise struct field lookup will be O(N)
+    fields: Vec<(BorrowedSymbolToken<'val>, BorrowedElement<'val>)>,
+}
+
+impl<'val> BorrowedStruct<'val> {
+    pub fn new(fields: Vec<(BorrowedSymbolToken<'val>, BorrowedElement<'val>)>) -> Self {
+        Self { fields }
+    }
+}
+
+impl<'val> Struct for BorrowedStruct<'val> {
+    type FieldName = BorrowedSymbolToken<'val>;
+    type Element = BorrowedElement<'val>;
+
+    fn iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, &'a Self::Element)> + 'a> {
+        // convert &(k, v) -> (&k, &v)
+        Box::new(self.fields.iter().map(|kv| match &kv {
+            (k, v) => (k, v),
+        }))
+    }
+}
+
+// TODO replace the references with `Cow` and bridge to the owned APIs for mutability
+
+/// Variants for all borrowed version _values_ within an [`Element`].
+#[derive(Debug, Clone)]
+pub enum BorrowedValue<'val> {
+    Null(IonType),
+    Integer(AnyInt),
+    String(&'val str),
+    Symbol(BorrowedSymbolToken<'val>),
+    SExpression(BorrowedSequence<'val>),
+    List(BorrowedSequence<'val>),
+    Struct(BorrowedStruct<'val>),
+    // TODO fill this in with the rest...
+}
+
+/// A borrowed implementation of [`Element`]
+#[derive(Debug, Clone)]
+pub struct BorrowedElement<'val> {
+    annotations: Vec<BorrowedSymbolToken<'val>>,
+    value: BorrowedValue<'val>,
+}
+
+impl<'val> BorrowedElement<'val> {
+    pub fn new(annotations: Vec<BorrowedSymbolToken<'val>>, value: BorrowedValue<'val>) -> Self {
+        Self { annotations, value }
+    }
+}
+
+impl<'val> From<BorrowedValue<'val>> for BorrowedElement<'val> {
+    /// Constructs a [`BorrowedElement`] without annotations from this value.
+    fn from(val: BorrowedValue<'val>) -> Self {
+        Self::new(vec![], val)
+    }
+}
+
+impl<'val> Element for BorrowedElement<'val> {
+    type SymbolToken = BorrowedSymbolToken<'val>;
+    type Sequence = BorrowedSequence<'val>;
+    type Struct = BorrowedStruct<'val>;
+
+    fn ion_type(&self) -> IonType {
+        use BorrowedValue::*;
+        match &self.value {
+            Null(t) => *t,
+            Integer(_) => IonType::Integer,
+            String(_) => IonType::String,
+            Symbol(_) => IonType::Symbol,
+            SExpression(_) => IonType::SExpression,
+            List(_) => IonType::List,
+            Struct(_) => IonType::Struct,
+        }
+    }
+
+    fn annotations<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::SymbolToken> + 'a> {
+        Box::new(self.annotations.iter())
+    }
+
+    fn is_null(&self) -> bool {
+        match &self.value {
+            BorrowedValue::Null(_) => true,
+            _ => false,
+        }
+    }
+
+    fn as_any_int(&self) -> Option<&AnyInt> {
+        match &self.value {
+            BorrowedValue::Integer(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        match &self.value {
+            BorrowedValue::String(text) => Some(*text),
+            BorrowedValue::Symbol(sym) => sym.text(),
+            _ => None,
+        }
+    }
+
+    fn as_sym(&self) -> Option<&Self::SymbolToken> {
+        match &self.value {
+            BorrowedValue::Symbol(sym) => Some(sym),
+            _ => None,
+        }
+    }
+
+    fn as_sequence(&self) -> Option<&Self::Sequence> {
+        match &self.value {
+            BorrowedValue::SExpression(seq) | BorrowedValue::List(seq) => Some(seq),
+            _ => None,
+        }
+    }
+
+    fn as_struct(&self) -> Option<&Self::Struct> {
+        match &self.value {
+            BorrowedValue::Struct(structure) => Some(structure),
+            _ => None,
+        }
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -49,11 +49,8 @@
 //! use ion_rs::value::borrowed::*;
 //! use ion_rs::value::owned::*;
 //!
-//! /// Note that this API will filter out any annotations without text.
-//! /// Which may change the position of the annotation
-//! /// (if one cares about such things).
-//! fn extract_annotations<T: Element>(elem: &T) -> Vec<String> {
-//!     elem.annotations().flat_map(
+//! fn extract_annotations<T: Element>(elem: &T) -> Vec<Option<String>> {
+//!     elem.annotations().map(
 //!         |tok| tok.text().map(|text_ref| text_ref.to_string())
 //!     ).collect()
 //! }
@@ -75,12 +72,12 @@
 //!     vec!["hello", "world"].iter().map(|x| x.to_string()).collect();
 //! let borrowed_elem = BorrowedElement::new(
 //!     vec![
-//!         strings[0].as_str().into(),
 //!         BorrowedSymbolToken::new(
 //!             None,
 //!             Some(200),
 //!             Some(BorrowedImportSource::new("bar", 9))
-//!         )
+//!         ),
+//!         strings[0].as_str().into()
 //!     ],
 //!     BorrowedValue::String(&strings[1])
 //! );
@@ -225,7 +222,8 @@ pub trait Element {
     /// # use ion_rs::value::*;
     /// # use ion_rs::value::owned::*;
     /// # use ion_rs::value::borrowed::*;
-    /// // simple function to extract the annotations to owned strings
+    /// // simple function to extract the annotations to owned strings.
+    /// // will panic if the text is not there!
     /// fn annotation_strings<T: Element>(elem: &T) -> Vec<String> {
     ///     elem.annotations().map(|tok| tok.text().unwrap().into()).collect()
     /// }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,0 +1,341 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+//! Provides a in-memory tree representation of Ion values that can be operated on in
+//! a dynamically typed way.
+//!
+//! This module consists of two submodules that implement the value traits:
+//!
+//! * The [`owned`] module provides an implementation of values that have no associated
+//!   lifetime.  These types are convenient, but may imply extra copying/cloning.
+//! * The [`borrowed`] module provides an implementation of values that are tied to some
+//!   associated lifetime and borrow a reference to their underlying data in some way
+//!   (e.g. storing a `&str` in the value versus a fully owned `String`).
+//!
+//! ## Examples
+//! In general, users should use the traits in this module to make their code work
+//! in contexts that have either [`borrowed`] or [`owned`] values.  This can be done
+//! most easily by writing generic functions that can work with a reference of any type.
+//!
+//! For example, consider a fairly contrived, but generic `extract_text` function that unwraps
+//! and converts [`SymbolToken::text()`] into an owned `String`:
+//!
+//! ```
+//! use ion_rs::value::SymbolToken;
+//! use ion_rs::value::borrowed::BorrowedSymbolToken;
+//! use ion_rs::value::owned::OwnedSymbolToken;
+//!
+//! fn extract_text<T: SymbolToken>(tok: &T) -> String {
+//!     tok.text().unwrap().into()
+//! }
+//!
+//! let owned_token: OwnedSymbolToken = "hello".into();
+//!
+//! // owned value to emphasize lifetime
+//! let text = String::from("hello");
+//! let borrowed_token: BorrowedSymbolToken = text.as_str().into();
+//!
+//! let owned_text = extract_text(&owned_token);
+//! let borrowed_text = extract_text(&borrowed_token);
+//! assert_eq!(owned_text, borrowed_text);
+//! ```
+//!
+//! This extends to the [`Element`] trait as well which is the "top-level" API type for
+//! any Ion datum.  Consider a contrived function that extracts returns the annotations
+//! of an underlying element as a `Vec<String>`.  Note that filters out any annotation
+//! that may not have text (so data could be dropped):
+//!
+//! ```
+//! use ion_rs::value::{Element, SymbolToken};
+//! use ion_rs::value::borrowed::*;
+//! use ion_rs::value::owned::*;
+//!
+//! fn extract_annotations<T: Element>(elem: &T) -> Vec<String> {
+//!     elem.annotations().flat_map(
+//!         |tok| tok.text().map(|text_ref| text_ref.to_string())
+//!     ).collect()
+//! }
+//!
+//! let owned_elem = OwnedElement::new(
+//!     vec![
+//!         OwnedSymbolToken::new(
+//!             None,
+//!             Some(300),
+//!             Some(OwnedImportSource::new("foo", 12))
+//!         ),
+//!         "hello".into()
+//!     ],
+//!     OwnedValue::String("world".into())
+//! );
+//!
+//! // owned values to emphasize lifetime
+//! let strings: Vec<String> =
+//!     vec!["hello", "world"].iter().map(|x| x.to_string()).collect();
+//! let borrowed_elem = BorrowedElement::new(
+//!     vec![
+//!         strings[0].as_str().into(),
+//!         BorrowedSymbolToken::new(
+//!             None,
+//!             Some(200),
+//!             Some(BorrowedImportSource::new("bar", 9))
+//!         )
+//!     ],
+//!     BorrowedValue::String(&strings[1])
+//! );
+//!
+//! let owned_annotations = extract_annotations(&owned_elem);
+//! let borrowed_annotations = extract_annotations(&borrowed_elem);
+//! assert_eq!(owned_annotations, borrowed_annotations);
+//! ```
+//!
+//! For reference here are a couple other _value_ style APIs for JSON:
+//! * [`simd_json`'s `Value` API][simd-json-value]
+//! * [`serde_json`'s `Value` API][serde-json-value]
+//!
+//! [simd-json-value]: https://docs.rs/simd-json/latest/simd_json/value/index.html
+//! [serde-json-value]: https://docs.serde.rs/serde_json/value/enum.Value.html
+
+use crate::types::SymbolId;
+use crate::IonType;
+use num_bigint::BigInt;
+use num_traits::ToPrimitive;
+
+pub mod borrowed;
+pub mod owned;
+
+/// The shared symbol table source of a given [`SymbolToken`].
+pub trait ImportSource {
+    /// The name of the shared symbol table that the token is from.
+    fn table(&self) -> &str;
+
+    /// The ID within the shared symbol table that the token is positioned in.
+    fn sid(&self) -> SymbolId;
+}
+
+/// A view of a symbolic token.
+/// This can be either a symbol value itself, an annotation, or an field name.
+/// A token may have `text`, a symbol `id`, or both.
+pub trait SymbolToken {
+    type ImportSource: ImportSource + ?Sized;
+
+    /// The text of the token, which may be `None` if no text is associated with the token
+    /// (e.g. lack of a shared symbol table import for a given SID).
+    fn text(&self) -> Option<&str>;
+
+    /// The ID of the token, which may be `None` if no ID is associated with the token
+    /// (e.g. Ion text symbols).
+    fn local_sid(&self) -> Option<SymbolId>;
+
+    /// The source of this token, which may be `None` if the symbol is locally defined.
+    fn source(&self) -> Option<&Self::ImportSource>;
+}
+
+/// Provides convenient integer accessors for integer values that are like [`AnyInt`]
+pub trait IntAccess {
+    /// Returns the value as an `i64` if it can be represented as such.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use ion_rs::value::*;
+    /// # use ion_rs::value::owned::*;
+    /// # use ion_rs::value::borrowed::*;
+    /// # use num_bigint::*;
+    /// let big_any = AnyInt::BigInt(BigInt::from(100));
+    /// let i64_any = AnyInt::I64(100);
+    /// assert_eq!(big_any.as_i64(), i64_any.as_i64());
+    ///
+    /// // works on element too
+    /// let big_elem: OwnedElement = OwnedValue::Integer(big_any).into();
+    /// let i64_elem: BorrowedElement = BorrowedValue::Integer(i64_any).into();
+    ///
+    /// assert_eq!(big_elem.as_i64(), i64_elem.as_i64());
+    /// ```
+    fn as_i64(&self) -> Option<i64>;
+
+    /// Returns a reference as a [`BigInt`] if it is represented as such.  Note that this
+    /// method may return `None` if the underlying representation *is not* stored in a [`BigInt`]
+    /// such as if it is represented as an `i64` so it is somewhat asymmetric with respect
+    /// to [`IntAccess::as_i64`].
+    ///
+    /// ## Usage
+    /// ```
+    /// # use ion_rs::value::*;
+    /// # use ion_rs::value::owned::*;
+    /// # use ion_rs::value::borrowed::*;
+    /// # use num_bigint::*;
+    /// # use std::str::FromStr;
+    /// let big_any = AnyInt::BigInt(BigInt::from(100));
+    /// assert_eq!(BigInt::from_str("100").unwrap(), *big_any.as_big_int().unwrap());
+    /// let i64_any = AnyInt::I64(100);
+    /// assert_eq!(None, i64_any.as_big_int());
+    ///
+    /// // works on element too
+    /// let big_elem: BorrowedElement = BorrowedValue::Integer(big_any).into();
+    /// assert_eq!(BigInt::from_str("100").unwrap(), *big_elem.as_big_int().unwrap());
+    /// let i64_elem: OwnedElement = OwnedValue::Integer(i64_any).into();
+    /// assert_eq!(None, i64_elem.as_big_int());
+    /// ```
+    fn as_big_int(&self) -> Option<&BigInt>;
+}
+
+/// Container for either an integer that can fit in a 64-bit word or an arbitrarily sized
+/// [`BigInt`].
+///
+/// See [`IntAccess`] for common operations.
+#[derive(Debug, Clone)]
+pub enum AnyInt {
+    I64(i64),
+    BigInt(BigInt),
+}
+
+impl IntAccess for AnyInt {
+    #[inline]
+    fn as_i64(&self) -> Option<i64> {
+        match &self {
+            AnyInt::I64(i) => Some(*i),
+            AnyInt::BigInt(big) => big.to_i64(),
+        }
+    }
+
+    #[inline]
+    fn as_big_int(&self) -> Option<&BigInt> {
+        match &self {
+            AnyInt::I64(_) => None,
+            AnyInt::BigInt(big) => Some(big),
+        }
+    }
+}
+
+/// Represents a either a borrowed or owned Ion datum.  There are/will be specific APIs for
+/// _borrowed_ and _owned_ implementations, but this trait unifies operations on either.
+pub trait Element {
+    type SymbolToken: SymbolToken + ?Sized;
+    type Sequence: Sequence + ?Sized;
+    type Struct: Struct + ?Sized;
+
+    /// The type of data this element represents.
+    fn ion_type(&self) -> IonType;
+
+    /// The annotations for this element.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use ion_rs::value::*;
+    /// # use ion_rs::value::owned::*;
+    /// # use ion_rs::value::borrowed::*;
+    /// // simple function to extract the annotations to owned strings
+    /// fn annotation_strings<T: Element>(elem: &T) -> Vec<String> {
+    ///     elem.annotations().map(|tok| tok.text().unwrap().into()).collect()
+    /// }
+    ///
+    /// let strs = vec!["a", "b", "c"];
+    /// let owned_elem = OwnedElement::new(
+    ///     strs.iter().map(|s| (*s).into()).collect(),
+    ///     OwnedValue::String("moo".into())
+    /// );
+    /// let borrowed_elem = BorrowedElement::new(
+    ///     strs.iter().map(|s| (*s).into()).collect(),
+    ///     BorrowedValue::String("moo")
+    /// );
+    ///
+    /// let expected: Vec<String> = strs.iter().map(|s| (*s).into()).collect();
+    /// assert_eq!(expected, annotation_strings(&owned_elem));
+    /// assert_eq!(expected, annotation_strings(&borrowed_elem));
+    /// ```
+    ///
+    /// Note that this uses a `Box<dyn Iterator<...>>` to capture the borrow cleanly without
+    /// without [generic associated types (GAT)][gat].  In theory, when GAT lands, this could
+    /// be replaced with static polymorphism.
+    ///
+    /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
+    fn annotations<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::SymbolToken> + 'a>;
+
+    /// Returns whether this element is a `null` value
+    fn is_null(&self) -> bool;
+
+    /// Returns a reference to the underlying [`AnyInt`] for this element.
+    ///
+    /// This will return `None` if the type is not `int` or the value is any `null`.
+    fn as_any_int(&self) -> Option<&AnyInt>;
+
+    /// Returns a slice to the textual value of this element.
+    ///
+    /// This will return `None` in the case that the type is not `string`/`symbol`,
+    /// if the value is any `null`, or the text of the `symbol` is not defined.
+    fn as_str(&self) -> Option<&str>;
+
+    /// Returns a reference to the [`SymbolToken`] of this element.
+    ///
+    /// This will return `None` in the case that the type is not `symbol` or the value is
+    /// any `null`.
+    fn as_sym(&self) -> Option<&Self::SymbolToken>;
+
+    /// Returns a reference to the [`Sequence`] of this element.
+    ///
+    /// This will return `None` in the case that the type is not `sexp`/`list` or
+    /// if the value is any `null`.
+    fn as_sequence(&self) -> Option<&Self::Sequence>;
+
+    /// Returns a reference to the [`Struct`] of this element.
+    ///
+    /// This will return `None` in the case that the type is not `struct` or the value is
+    /// any `null`.
+    fn as_struct(&self) -> Option<&Self::Struct>;
+
+    // TODO add all the accessors to the trait
+
+    // TODO add mutation methods to the trait
+}
+
+impl<T> IntAccess for T
+where
+    T: Element,
+{
+    fn as_i64(&self) -> Option<i64> {
+        match self.as_any_int() {
+            Some(any) => any.as_i64(),
+            _ => None,
+        }
+    }
+
+    fn as_big_int(&self) -> Option<&BigInt> {
+        match self.as_any_int() {
+            Some(any) => any.as_big_int(),
+            _ => None,
+        }
+    }
+}
+
+/// Represents the _value_ of sequences of Ion elements (i.e. `list` and `sexp`).
+pub trait Sequence {
+    type Element: Element + ?Sized;
+
+    /// The children of the sequence.
+    ///
+    /// Note that this uses a `Box<dyn Iterator<...>>` to capture the borrow cleanly without
+    /// without [generic associated types (GAT)][gat].  In theory, when GAT lands, this could
+    /// be replaced with static polymorphism.
+    ///
+    /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
+
+    // TODO add a get by index method
+}
+
+/// Represents the _value_ of `struct` of Ion elements.
+pub trait Struct {
+    type FieldName: SymbolToken + ?Sized;
+    type Element: Element + ?Sized;
+
+    /// The fields of the structure.
+    ///
+    /// Note that this uses a `Box<dyn Iterator<...>>` to capture the borrow cleanly without
+    /// without [generic associated types (GAT)][gat].  In theory, when GAT lands, this could
+    /// be replaced with static polymorphism.
+    ///
+    /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
+    fn iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, &'a Self::Element)> + 'a>;
+
+    // TODO add a get first/all element by name
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -40,8 +40,8 @@
 //! ```
 //!
 //! This extends to the [`Element`] trait as well which is the "top-level" API type for
-//! any Ion datum.  Consider a contrived function that extracts returns the annotations
-//! of an underlying element as a `Vec<String>`.  Note that filters out any annotation
+//! any Ion datum.  Consider a contrived function that extracts and returns the annotations
+//! of an underlying element as a `Vec<String>`.  Note that it filters out any annotation
 //! that may not have text (so data could be dropped):
 //!
 //! ```

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -49,6 +49,9 @@
 //! use ion_rs::value::borrowed::*;
 //! use ion_rs::value::owned::*;
 //!
+//! /// Note that this API will filter out any annotations without text.
+//! /// Which may change the position of the annotation
+//! /// (if one cares about such things).
 //! fn extract_annotations<T: Element>(elem: &T) -> Vec<String> {
 //!     elem.annotations().flat_map(
 //!         |tok| tok.text().map(|text_ref| text_ref.to_string())

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -1,0 +1,228 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+//! Provides owned implementations of [`SymbolToken`], [`Element`] and its dependents.
+//!
+//! This API is simpler to manage with respect to borrowing lifetimes, but requires full
+//! ownership of data to do so.
+
+use super::{AnyInt, Element, ImportSource, Sequence, Struct, SymbolToken};
+use crate::types::SymbolId;
+use crate::IonType;
+
+/// An owned implementation of  [`ImportSource`].
+#[derive(Debug, Clone)]
+pub struct OwnedImportSource {
+    table: String,
+    sid: SymbolId,
+}
+
+impl OwnedImportSource {
+    pub fn new<T: Into<String>>(table: T, sid: SymbolId) -> Self {
+        Self {
+            table: table.into(),
+            sid,
+        }
+    }
+}
+
+impl ImportSource for OwnedImportSource {
+    fn table(&self) -> &str {
+        &self.table
+    }
+
+    fn sid(&self) -> usize {
+        self.sid
+    }
+}
+
+/// An owned implementation of [`SymbolToken`].
+#[derive(Debug, Clone)]
+pub struct OwnedSymbolToken {
+    text: Option<String>,
+    local_sid: Option<SymbolId>,
+    source: Option<OwnedImportSource>,
+}
+
+impl OwnedSymbolToken {
+    pub fn new(
+        text: Option<String>,
+        local_sid: Option<SymbolId>,
+        source: Option<OwnedImportSource>,
+    ) -> Self {
+        Self {
+            text,
+            local_sid,
+            source,
+        }
+    }
+}
+
+impl<T: Into<String>> From<T> for OwnedSymbolToken {
+    /// Constructs an owned token that has only text.
+    fn from(text: T) -> Self {
+        Self::new(Some(text.into()), None, None)
+    }
+}
+
+impl SymbolToken for OwnedSymbolToken {
+    type ImportSource = OwnedImportSource;
+
+    fn text(&self) -> Option<&str> {
+        self.text.as_ref().map(String::as_str)
+    }
+
+    fn local_sid(&self) -> Option<usize> {
+        self.local_sid
+    }
+
+    fn source(&self) -> Option<&Self::ImportSource> {
+        self.source.as_ref()
+    }
+}
+
+/// An owned implementation of [`Sequence`]
+#[derive(Debug, Clone)]
+pub struct OwnedSequence {
+    children: Vec<OwnedElement>,
+}
+
+impl OwnedSequence {
+    pub fn new(children: Vec<OwnedElement>) -> Self {
+        Self { children }
+    }
+}
+
+impl Sequence for OwnedSequence {
+    type Element = OwnedElement;
+
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a> {
+        Box::new(self.children.iter())
+    }
+}
+
+/// An owned implementation of [`Struct`]
+#[derive(Debug, Clone)]
+pub struct OwnedStruct {
+    // TODO model actual map indexing for the struct (maybe as a variant type)
+    //      otherwise struct field lookup will be O(N)
+    fields: Vec<(OwnedSymbolToken, OwnedElement)>,
+}
+
+impl OwnedStruct {
+    pub fn new(fields: Vec<(OwnedSymbolToken, OwnedElement)>) -> Self {
+        Self { fields }
+    }
+}
+
+impl Struct for OwnedStruct {
+    type FieldName = OwnedSymbolToken;
+    type Element = OwnedElement;
+
+    fn iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, &'a Self::Element)> + 'a> {
+        // convert &(k, v) -> (&k, &v)
+        Box::new(self.fields.iter().map(|kv| match &kv {
+            (k, v) => (k, v),
+        }))
+    }
+}
+
+/// Variants for all owned version _values_ within an [`Element`].
+#[derive(Debug, Clone)]
+pub enum OwnedValue {
+    Null(IonType),
+    Integer(AnyInt),
+    String(String),
+    Symbol(OwnedSymbolToken),
+    SExpression(OwnedSequence),
+    List(OwnedSequence),
+    Struct(OwnedStruct),
+    // TODO fill this in with the rest of the value types...
+}
+
+/// An owned implementation of [`Element`]
+#[derive(Debug, Clone)]
+pub struct OwnedElement {
+    annotations: Vec<OwnedSymbolToken>,
+    value: OwnedValue,
+}
+
+impl OwnedElement {
+    pub fn new(annotations: Vec<OwnedSymbolToken>, value: OwnedValue) -> Self {
+        Self { annotations, value }
+    }
+}
+
+impl From<OwnedValue> for OwnedElement {
+    fn from(val: OwnedValue) -> Self {
+        Self::new(vec![], val)
+    }
+}
+
+impl Element for OwnedElement {
+    type SymbolToken = OwnedSymbolToken;
+    type Sequence = OwnedSequence;
+    type Struct = OwnedStruct;
+
+    fn ion_type(&self) -> IonType {
+        use OwnedValue::*;
+
+        match &self.value {
+            Null(t) => *t,
+            Integer(_) => IonType::Integer,
+            String(_) => IonType::String,
+            Symbol(_) => IonType::Symbol,
+            SExpression(_) => IonType::SExpression,
+            List(_) => IonType::List,
+            Struct(_) => IonType::Struct,
+        }
+    }
+
+    fn annotations<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::SymbolToken> + 'a> {
+        Box::new(self.annotations.iter())
+    }
+
+    fn is_null(&self) -> bool {
+        match &self.value {
+            OwnedValue::Null(_) => true,
+            _ => false,
+        }
+    }
+
+    fn as_any_int(&self) -> Option<&AnyInt> {
+        match &self.value {
+            OwnedValue::Integer(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        match &self.value {
+            OwnedValue::String(text) => Some(text),
+            OwnedValue::Symbol(sym) => sym.text(),
+            _ => None,
+        }
+    }
+
+    fn as_sym(&self) -> Option<&Self::SymbolToken> {
+        match &self.value {
+            OwnedValue::Symbol(sym) => Some(sym),
+            _ => None,
+        }
+    }
+
+    fn as_sequence(&self) -> Option<&Self::Sequence> {
+        match &self.value {
+            OwnedValue::SExpression(seq) | OwnedValue::List(seq) => Some(seq),
+            _ => None,
+        }
+    }
+
+    fn as_struct(&self) -> Option<&Self::Struct> {
+        match &self.value {
+            OwnedValue::Struct(structure) => Some(structure),
+            _ => None,
+        }
+    }
+}

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -12,6 +12,7 @@ use crate::IonType;
 /// An owned implementation of  [`ImportSource`].
 #[derive(Debug, Clone)]
 pub struct OwnedImportSource {
+    // TODO consider Rc<String> here as we flesh out sharing/symbol tables.
     table: String,
     sid: SymbolId,
 }
@@ -38,6 +39,7 @@ impl ImportSource for OwnedImportSource {
 /// An owned implementation of [`SymbolToken`].
 #[derive(Debug, Clone)]
 pub struct OwnedSymbolToken {
+    // TODO consider Rc<String> for a common case of many symbols sharing the same text.
     text: Option<String>,
     local_sid: Option<SymbolId>,
     source: Option<OwnedImportSource>,


### PR DESCRIPTION
Provides an _borrowed_/_owned_ implementations of the traits in the `value` module.  The borrowed implementation is tied to a lifetime for string/binary data (but potentially more in the future).  The owned implementation is completely self contained.

* Defines `SymbolToken` and `ImportSource` traits that is the basis for full symbol/field name/annotation support in `ion-rs`, but also is required for the `Element` trait.
* APIs that return `Iterator` types currently use a `Box` to avoid the need for generic associated types (GAT).
* Captures the variance of integers in Ion with the `IntAccess` trait and the `AnyInt` enum.
* Currently implements the `Struct` trait via `Vec` of tuples, which will have to be refactored for O(N) access but is suitable for the iterator APIS.

Starts to address #114, but is not nearly complete.  This commit is to provide the initial structure of this API for collaborative development, and to get early review.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
