### PR TITLE
Added methods for Sequence and Struct

### DIFF
--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -152,9 +152,7 @@ impl<'val> Struct for BorrowedStruct<'val> {
                 .flat_map(|v| v)
                 .into_iter()
                 .chain(self.no_text_fields.iter())
-                .map(|kv| match &kv {
-                    (k, v) => (k, v),
-                }),
+                .map(|(k, v)| (k, v)),
         )
     }
 

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -187,7 +187,7 @@ impl<'val> Struct for BorrowedStruct<'val> {
                 .into_iter()
                 .flat_map(|v| v.iter())
                 .map(|kv| match &kv {
-                    (k, v) => v,
+                    (_k, v) => v,
                 }),
         )
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -318,20 +318,21 @@ pub trait Sequence {
     /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
 
-    // get value for the given index in the sequence
+    /// get value for the given index in the sequence
     fn get(&self, i: usize) -> Option<&Self::Element>;
 
-    // get length of the sequence
+    /// get length of the sequence
     fn len(&self) -> usize;
 
-    // check if the sequence is empty or not
+    /// check if the sequence is empty or not
     fn is_empty(&self) -> bool;
 
+    // TODO Add these mutable methods on Sequence
     // returns the last element from the sequence
-    fn pop(&mut self) -> Self::Element;
+    // fn pop(&mut self) -> Self::Element;
 
     // Appends the given value e to the end of the Array
-    fn push(&mut self, e: Self::Element);
+    // fn push(&mut self, e: Self::Element);
 }
 
 /// Represents the _value_ of `struct` of Ion elements.
@@ -348,14 +349,15 @@ pub trait Struct {
     /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
     fn iter<'a>(
         &'a self,
-    ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, Option<&'a Self::Element>)> + 'a>;
+    ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, &'a Self::Element)> + 'a>;
 
-    // gets the first value for the given field name in struct
-    fn get(&self, field_name: &Self::FieldName) -> Option<&Self::Element>;
+    /// gets the first value for the given field name in struct
+    /// TODO add generic implementation to allow &String, String for lookup
+    fn get(&self, field_name: &String) -> Option<&Self::Element>;
 
-    // gets all values corresponding to the given field name in struct
+    /// gets all values corresponding to the given field name in struct
     fn get_all<'a>(
         &'a self,
-        field_name: &'a Self::FieldName,
+        field_name: &'a String,
     ) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -318,21 +318,15 @@ pub trait Sequence {
     /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
 
-    /// get value for the given index in the sequence
+    /// Returns a reference to the element in the sequence at the given index or
+    /// returns `None` if the index is out of the bounds.
     fn get(&self, i: usize) -> Option<&Self::Element>;
 
-    /// get length of the sequence
+    /// Returns the length of the sequence
     fn len(&self) -> usize;
 
-    /// check if the sequence is empty or not
+    /// Returns true if the sequence is empty otherwise returns false
     fn is_empty(&self) -> bool;
-
-    // TODO Add these mutable methods on Sequence
-    // returns the last element from the sequence
-    // fn pop(&mut self) -> Self::Element;
-
-    // Appends the given value e to the end of the Array
-    // fn push(&mut self, e: Self::Element);
 }
 
 /// Represents the _value_ of `struct` of Ion elements.
@@ -351,11 +345,13 @@ pub trait Struct {
         &'a self,
     ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, &'a Self::Element)> + 'a>;
 
-    /// gets the first value for the given field name in struct
+    /// Returns the last value corresponding to the field_name in the struct or
+    /// returns `None` if the field_name does not exist in the struct
     /// TODO add generic implementation to allow &String, String for lookup
     fn get(&self, field_name: &String) -> Option<&Self::Element>;
 
-    /// gets all values corresponding to the given field name in struct
+    /// Returns an iterator with all the values corresponding to the field_name in the struct or
+    /// returns an empty iterator if the field_name does not exist in the struct
     fn get_all<'a>(
         &'a self,
         field_name: &'a String,

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -318,7 +318,20 @@ pub trait Sequence {
     /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
 
-    // TODO add a get by index method
+    // get value for the given index in the sequence
+    fn get(&self, i: usize) -> Option<&Self::Element>;
+
+    // get length of the sequence
+    fn len(&self) -> usize;
+
+    // check if the sequence is empty or not
+    fn is_empty(&self) -> bool;
+
+    // returns the last element from the sequence
+    fn pop(&mut self) -> Self::Element;
+
+    // Appends the given value e to the end of the Array
+    fn push(&mut self, e: Self::Element);
 }
 
 /// Represents the _value_ of `struct` of Ion elements.
@@ -335,7 +348,14 @@ pub trait Struct {
     /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
     fn iter<'a>(
         &'a self,
-    ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, &'a Self::Element)> + 'a>;
+    ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, Option<&'a Self::Element>)> + 'a>;
 
-    // TODO add a get first/all element by name
+    // gets the first value for the given field name in struct
+    fn get(&self, field_name: &Self::FieldName) -> Option<&Self::Element>;
+
+    // gets all values corresponding to the given field name in struct
+    fn get_all<'a>(
+        &'a self,
+        field_name: &'a Self::FieldName,
+    ) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
 }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -187,7 +187,7 @@ impl Struct for OwnedStruct {
                 .into_iter()
                 .flat_map(|v| v.iter())
                 .map(|kv| match &kv {
-                    (k, v) => v,
+                    (_k, v) => v,
                 }),
         )
     }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -155,9 +155,7 @@ impl Struct for OwnedStruct {
                 .flat_map(|v| v)
                 .into_iter()
                 .chain(self.no_text_fields.iter())
-                .map(|kv| match &kv {
-                    (k, v) => (k, v),
-                }),
+                .map(|(k, v)| (k, v)),
         )
     }
 


### PR DESCRIPTION
*Description of changes:*
This PR works on creating methods for `Sequence` and `Struct` in Value API.

*Completed Tasks:*
- Added `Eq`, `PartialEq` and `Hash` implementations for` Borrowed/OwnedSymbolTokens`.
- Added Sequence methods: `get`, `len`, `is_empty`, `pop`, `push`
- Added Struct methods: `get`, `get_all`
- Struct uses a `HashMap` with `(key, values) -> (SymbolToken, Vec<Element>)`

*TODO:*
- Remove usage of `unwrap()` as it will panic on `None`.
- Add tests for this implementation

*Base PR:* https://github.com/amzn/ion-rust/pull/131