### PR TITLE
Added methods for Sequence and Struct (#132)

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -319,7 +319,15 @@ pub trait Sequence {
     /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
 
-    // TODO add a get by index method
+    /// Returns a reference to the element in the sequence at the given index or
+    /// returns `None` if the index is out of the bounds.
+    fn get(&self, i: usize) -> Option<&Self::Element>;
+
+    /// Returns the length of the sequence
+    fn len(&self) -> usize;
+
+    /// Returns true if the sequence is empty otherwise returns false
+    fn is_empty(&self) -> bool;
 }
 
 /// Represents the _value_ of `struct` of Ion elements.
@@ -338,5 +346,15 @@ pub trait Struct {
         &'a self,
     ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, &'a Self::Element)> + 'a>;
 
-    // TODO add a get first/all element by name
+    /// Returns the last value corresponding to the field_name in the struct or
+    /// returns `None` if the field_name does not exist in the struct
+    /// TODO add generic implementation to allow &String, String for lookup
+    fn get(&self, field_name: &String) -> Option<&Self::Element>;
+
+    /// Returns an iterator with all the values corresponding to the field_name in the struct or
+    /// returns an empty iterator if the field_name does not exist in the struct
+    fn get_all<'a>(
+        &'a self,
+        field_name: &'a String,
+    ) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
 }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -8,6 +8,7 @@
 use super::{AnyInt, Element, ImportSource, Sequence, Struct, SymbolToken};
 use crate::types::SymbolId;
 use crate::IonType;
+use std::collections::HashMap;
 
 /// An owned implementation of  [`ImportSource`].
 #[derive(Debug, Clone)]
@@ -100,6 +101,22 @@ impl Sequence for OwnedSequence {
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a> {
         Box::new(self.children.iter())
     }
+
+    fn get(&self, index: usize) -> Option<&Self::Element> {
+        if index > self.children.len() {
+            None
+        } else {
+            Some(&self.children[index])
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.children.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// An owned implementation of [`Struct`]
@@ -107,12 +124,20 @@ impl Sequence for OwnedSequence {
 pub struct OwnedStruct {
     // TODO model actual map indexing for the struct (maybe as a variant type)
     //      otherwise struct field lookup will be O(N)
-    fields: Vec<(OwnedSymbolToken, OwnedElement)>,
+    text_fields: HashMap<String, Vec<(OwnedSymbolToken, OwnedElement)>>,
+    no_text_fields: Vec<(OwnedSymbolToken, OwnedElement)>,
 }
 
 impl OwnedStruct {
-    pub fn new(fields: Vec<(OwnedSymbolToken, OwnedElement)>) -> Self {
-        Self { fields }
+    // TODO remove constructor and instead add from_iter function to HashMap and Vec from iterator
+    fn new(
+        text_fields: HashMap<String, Vec<(OwnedSymbolToken, OwnedElement)>>,
+        no_text_fields: Vec<(OwnedSymbolToken, OwnedElement)>,
+    ) -> Self {
+        Self {
+            text_fields,
+            no_text_fields,
+        }
     }
 }
 
@@ -124,9 +149,38 @@ impl Struct for OwnedStruct {
         &'a self,
     ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, &'a Self::Element)> + 'a> {
         // convert &(k, v) -> (&k, &v)
-        Box::new(self.fields.iter().map(|kv| match &kv {
-            (k, v) => (k, v),
-        }))
+        // flattens the fields_with_text_key HashMap and chains with fields_with_no_text_key
+        // to return all fields with iterator
+        Box::new(
+            self.text_fields
+                .values()
+                .flat_map(|v| v)
+                .into_iter()
+                .chain(self.no_text_fields.iter())
+                .map(|(k, v)| (k, v)),
+        )
+    }
+
+    fn get(&self, field_name: &String) -> Option<&Self::Element> {
+        match self.text_fields.get(field_name)?.last() {
+            None => None,
+            Some(value) => Some(&value.1),
+        }
+    }
+
+    fn get_all<'a>(
+        &'a self,
+        field_name: &'a String,
+    ) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a> {
+        Box::new(
+            self.text_fields
+                .get(field_name)
+                .into_iter()
+                .flat_map(|v| v.iter())
+                .map(|kv| match &kv {
+                    (_k, v) => v,
+                }),
+        )
     }
 }
 


### PR DESCRIPTION
*Issue #114 *

*Description of changes:*
This issues fills in the API methods for `Sequence` and `Struct` on the Value API.

*Changes:*
- Added `Sequence` methods: `get`, `len`, `is_empty`
- Added `Struct` methods: `get`, `get_all`
- `Struct` uses a `HashMap` with `(key, values) -> (String, Vec<(SymbolToken, Element)>)` as well as  a `Vec<(Symboltoken, Element)>` to store fields with no text `SymbolToken`