### PR TITLE
Changed OwnedSymbolToken, OwnedImportSource, OwnedStruct from using String to Rc<String>

### DIFF
--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -156,7 +156,7 @@ impl<'val> Struct for BorrowedStruct<'val> {
         )
     }
 
-    fn get(&self, field_name: &String) -> Option<&Self::Element> {
+    fn get(&self, field_name: &str) -> Option<&Self::Element> {
         match self.text_fields.get(field_name)?.last() {
             None => None,
             Some(value) => Some(&value.1),
@@ -165,7 +165,7 @@ impl<'val> Struct for BorrowedStruct<'val> {
 
     fn get_all<'a>(
         &'a self,
-        field_name: &'a String,
+        field_name: &'a str,
     ) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a> {
         Box::new(
             self.text_fields

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -349,12 +349,12 @@ pub trait Struct {
     /// Returns the last value corresponding to the field_name in the struct or
     /// returns `None` if the field_name does not exist in the struct
     /// TODO add generic implementation to allow &String, String for lookup
-    fn get(&self, field_name: &String) -> Option<&Self::Element>;
+    fn get(&self, field_name: &str) -> Option<&Self::Element>;
 
     /// Returns an iterator with all the values corresponding to the field_name in the struct or
     /// returns an empty iterator if the field_name does not exist in the struct
     fn get_all<'a>(
         &'a self,
-        field_name: &'a String,
+        field_name: &'a str,
     ) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
 }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -121,8 +121,6 @@ impl Sequence for OwnedSequence {
 /// An owned implementation of [`Struct`]
 #[derive(Debug, Clone)]
 pub struct OwnedStruct {
-    // TODO model actual map indexing for the struct (maybe as a variant type)
-    //      otherwise struct field lookup will be O(N)
     text_fields: HashMap<Rc<str>, Vec<(OwnedSymbolToken, OwnedElement)>>,
     no_text_fields: Vec<(OwnedSymbolToken, OwnedElement)>,
 }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -14,15 +14,14 @@ use std::rc::Rc;
 /// An owned implementation of  [`ImportSource`].
 #[derive(Debug, Clone)]
 pub struct OwnedImportSource {
-    // TODO consider Rc<String> here as we flesh out sharing/symbol tables.
-    table: Rc<String>,
+    table: Rc<str>,
     sid: SymbolId,
 }
 
 impl OwnedImportSource {
-    pub fn new<T: Into<String>>(table: T, sid: SymbolId) -> Self {
+    pub fn new<T: Into<Rc<str>>>(table: T, sid: SymbolId) -> Self {
         Self {
-            table: Rc::new(table.into()),
+            table: table.into(),
             sid,
         }
     }
@@ -41,15 +40,14 @@ impl ImportSource for OwnedImportSource {
 /// An owned implementation of [`SymbolToken`].
 #[derive(Debug, Clone)]
 pub struct OwnedSymbolToken {
-    // TODO consider Rc<String> for a common case of many symbols sharing the same text.
-    text: Option<Rc<String>>,
+    text: Option<Rc<str>>,
     local_sid: Option<SymbolId>,
     source: Option<OwnedImportSource>,
 }
 
 impl OwnedSymbolToken {
     pub fn new(
-        text: Option<Rc<String>>,
+        text: Option<Rc<str>>,
         local_sid: Option<SymbolId>,
         source: Option<OwnedImportSource>,
     ) -> Self {
@@ -61,10 +59,10 @@ impl OwnedSymbolToken {
     }
 }
 
-impl<T: Into<String>> From<T> for OwnedSymbolToken {
+impl<T: Into<Rc<str>>> From<T> for OwnedSymbolToken {
     /// Constructs an owned token that has only text.
     fn from(text: T) -> Self {
-        Self::new(Some(Rc::new(text.into())), None, None)
+        Self::new(Some(text.into()), None, None)
     }
 }
 
@@ -72,10 +70,7 @@ impl SymbolToken for OwnedSymbolToken {
     type ImportSource = OwnedImportSource;
 
     fn text(&self) -> Option<&str> {
-        match self.text.as_ref() {
-            None => None,
-            Some(value) => Some(value.as_str()),
-        }
+        self.text.as_ref().map(|s| s.as_ref())
     }
 
     fn local_sid(&self) -> Option<usize> {
@@ -128,14 +123,14 @@ impl Sequence for OwnedSequence {
 pub struct OwnedStruct {
     // TODO model actual map indexing for the struct (maybe as a variant type)
     //      otherwise struct field lookup will be O(N)
-    text_fields: HashMap<Rc<String>, Vec<(OwnedSymbolToken, OwnedElement)>>,
+    text_fields: HashMap<Rc<str>, Vec<(OwnedSymbolToken, OwnedElement)>>,
     no_text_fields: Vec<(OwnedSymbolToken, OwnedElement)>,
 }
 
 impl OwnedStruct {
     // TODO remove constructor and instead add from_iter function to HashMap and Vec from iterator
     fn new(
-        text_fields: HashMap<Rc<String>, Vec<(OwnedSymbolToken, OwnedElement)>>,
+        text_fields: HashMap<Rc<str>, Vec<(OwnedSymbolToken, OwnedElement)>>,
         no_text_fields: Vec<(OwnedSymbolToken, OwnedElement)>,
     ) -> Self {
         Self {
@@ -165,7 +160,7 @@ impl Struct for OwnedStruct {
         )
     }
 
-    fn get(&self, field_name: &String) -> Option<&Self::Element> {
+    fn get(&self, field_name: &str) -> Option<&Self::Element> {
         match self.text_fields.get(field_name)?.last() {
             None => None,
             Some(value) => Some(&value.1),
@@ -174,7 +169,7 @@ impl Struct for OwnedStruct {
 
     fn get_all<'a>(
         &'a self,
-        field_name: &'a String,
+        field_name: &'a str,
     ) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a> {
         Box::new(
             self.text_fields


### PR DESCRIPTION

*Issue #134*

*Description of changes:*
This PR works on using `Rc<String>` instead of `String` for `OwnedSymbolToken`, `OwnedImportSource`, `OwnedStruct`.