### PR TITLE
added remaining scalar value types for Element API

### DIFF
--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -8,12 +8,12 @@
 //! backed by octets or string data, `&[u8]` and `&str` are used.
 
 use super::{Element, ImportSource, Sequence, Struct, SymbolToken};
+use crate::types::decimal::Decimal;
+use crate::types::timestamp::Timestamp;
 use crate::types::SymbolId;
 use crate::value::AnyInt;
 use crate::IonType;
 use std::collections::HashMap;
-use crate::types::decimal::Decimal;
-use crate::types::timestamp::Timestamp;
 
 /// A borrowed implementation of [`ImportSource`].
 #[derive(Debug, Copy, Clone)]

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -188,12 +188,12 @@ impl<'val> Struct for BorrowedStruct<'val> {
 pub enum BorrowedValue<'val> {
     Null(IonType),
     Integer(AnyInt),
-    Float(&'val f64),
+    Float(f64),
     Decimal(Decimal),
     Timestamp(Timestamp),
     String(&'val str),
     Symbol(BorrowedSymbolToken<'val>),
-    Boolean(&'val bool),
+    Boolean(bool),
     Blob(&'val [u8]),
     Clob(&'val [u8]),
     SExpression(BorrowedSequence<'val>),
@@ -266,7 +266,7 @@ impl<'val> Element for BorrowedElement<'val> {
 
     fn as_float(&self) -> Option<f64> {
         match &self.value {
-            BorrowedValue::Float(&f) => Some(f),
+            BorrowedValue::Float(f) => Some(*f),
             _ => None,
         }
     }
@@ -302,7 +302,7 @@ impl<'val> Element for BorrowedElement<'val> {
 
     fn as_bool(&self) -> Option<bool> {
         match &self.value {
-            BorrowedValue::Boolean(&b) => Some(b),
+            BorrowedValue::Boolean(b) => Some(*b),
             _ => None,
         }
     }

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -12,6 +12,8 @@ use crate::types::SymbolId;
 use crate::value::AnyInt;
 use crate::IonType;
 use std::collections::HashMap;
+use crate::types::decimal::Decimal;
+use crate::types::timestamp::Timestamp;
 
 /// A borrowed implementation of [`ImportSource`].
 #[derive(Debug, Copy, Clone)]
@@ -186,8 +188,14 @@ impl<'val> Struct for BorrowedStruct<'val> {
 pub enum BorrowedValue<'val> {
     Null(IonType),
     Integer(AnyInt),
+    Float(f64),
+    Decimal(Decimal),
+    Timestamp(Timestamp),
     String(&'val str),
     Symbol(BorrowedSymbolToken<'val>),
+    Boolean(&'val bool),
+    Blob(Vec<u8>),
+    Clob(Vec<u8>),
     SExpression(BorrowedSequence<'val>),
     List(BorrowedSequence<'val>),
     Struct(BorrowedStruct<'val>),
@@ -224,8 +232,14 @@ impl<'val> Element for BorrowedElement<'val> {
         match &self.value {
             Null(t) => *t,
             Integer(_) => IonType::Integer,
+            Float(_) => IonType::Float,
+            Decimal(_) => IonType::Decimal,
+            Timestamp(_) => IonType::Timestamp,
             String(_) => IonType::String,
             Symbol(_) => IonType::Symbol,
+            Boolean(_) => IonType::Boolean,
+            Blob(_) => IonType::Blob,
+            Clob(_) => IonType::Clob,
             SExpression(_) => IonType::SExpression,
             List(_) => IonType::List,
             Struct(_) => IonType::Struct,
@@ -250,6 +264,27 @@ impl<'val> Element for BorrowedElement<'val> {
         }
     }
 
+    fn as_float(&self) -> Option<&f64> {
+        match &self.value {
+            BorrowedValue::Float(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    fn as_decimal(&self) -> Option<&Decimal> {
+        match &self.value {
+            BorrowedValue::Decimal(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    fn as_timestamp(&self) -> Option<&Timestamp> {
+        match &self.value {
+            BorrowedValue::Timestamp(t) => Some(t),
+            _ => None,
+        }
+    }
+
     fn as_str(&self) -> Option<&str> {
         match &self.value {
             BorrowedValue::String(text) => Some(*text),
@@ -261,6 +296,27 @@ impl<'val> Element for BorrowedElement<'val> {
     fn as_sym(&self) -> Option<&Self::SymbolToken> {
         match &self.value {
             BorrowedValue::Symbol(sym) => Some(sym),
+            _ => None,
+        }
+    }
+
+    fn as_bool(&self) -> Option<&bool> {
+        match &self.value {
+            BorrowedValue::Boolean(b) => Some(b),
+            _ => None,
+        }
+    }
+
+    fn as_blob(&self) -> Option<&Vec<u8>> {
+        match &self.value {
+            BorrowedValue::Blob(bytes) => Some(bytes),
+            _ => None,
+        }
+    }
+
+    fn as_clob(&self) -> Option<&Vec<u8>> {
+        match &self.value {
+            BorrowedValue::Clob(bytes) => Some(bytes),
             _ => None,
         }
     }

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -188,14 +188,14 @@ impl<'val> Struct for BorrowedStruct<'val> {
 pub enum BorrowedValue<'val> {
     Null(IonType),
     Integer(AnyInt),
-    Float(f64),
+    Float(&'val f64),
     Decimal(Decimal),
     Timestamp(Timestamp),
     String(&'val str),
     Symbol(BorrowedSymbolToken<'val>),
     Boolean(&'val bool),
-    Blob(Vec<u8>),
-    Clob(Vec<u8>),
+    Blob(&'val [u8]),
+    Clob(&'val [u8]),
     SExpression(BorrowedSequence<'val>),
     List(BorrowedSequence<'val>),
     Struct(BorrowedStruct<'val>),
@@ -264,9 +264,9 @@ impl<'val> Element for BorrowedElement<'val> {
         }
     }
 
-    fn as_float(&self) -> Option<&f64> {
+    fn as_float(&self) -> Option<f64> {
         match &self.value {
-            BorrowedValue::Float(f) => Some(f),
+            BorrowedValue::Float(&f) => Some(f),
             _ => None,
         }
     }
@@ -300,23 +300,23 @@ impl<'val> Element for BorrowedElement<'val> {
         }
     }
 
-    fn as_bool(&self) -> Option<&bool> {
+    fn as_bool(&self) -> Option<bool> {
         match &self.value {
-            BorrowedValue::Boolean(b) => Some(b),
+            BorrowedValue::Boolean(&b) => Some(b),
             _ => None,
         }
     }
 
-    fn as_blob(&self) -> Option<&Vec<u8>> {
+    fn as_blob(&self) -> Option<&[u8]> {
         match &self.value {
-            BorrowedValue::Blob(bytes) => Some(bytes),
+            BorrowedValue::Blob(bytes) => Some(*bytes),
             _ => None,
         }
     }
 
-    fn as_clob(&self) -> Option<&Vec<u8>> {
+    fn as_clob(&self) -> Option<&[u8]> {
         match &self.value {
-            BorrowedValue::Clob(bytes) => Some(bytes),
+            BorrowedValue::Clob(bytes) => Some(*bytes),
             _ => None,
         }
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -98,6 +98,8 @@ use crate::types::SymbolId;
 use crate::IonType;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
+use crate::types::decimal::Decimal;
+use crate::types::timestamp::Timestamp;
 
 pub mod borrowed;
 pub mod owned;
@@ -258,6 +260,21 @@ pub trait Element {
     /// This will return `None` if the type is not `int` or the value is any `null`.
     fn as_any_int(&self) -> Option<&AnyInt>;
 
+    /// Returns a reference to the underlying float value for this element.
+    ///
+    /// This will return `None` if the type is not `float` or the value is any `null`.
+    fn as_float(&self) -> Option<&f64>;
+
+    /// Returns a reference to the underlying [`Decimal`] for this element.
+    ///
+    /// This will return `None` if the type is not `decimal` or the value is any `null`.
+    fn as_decimal(&self) -> Option<&Decimal>;
+
+    /// Returns a reference to the underlying [`Timestamp`] for this element.
+    ///
+    /// This will return `None` if the type is not `timestamp` or the value is any `null`.
+    fn as_timestamp(&self) -> Option<&Timestamp>;
+
     /// Returns a slice to the textual value of this element.
     ///
     /// This will return `None` in the case that the type is not `string`/`symbol`,
@@ -269,6 +286,24 @@ pub trait Element {
     /// This will return `None` in the case that the type is not `symbol` or the value is
     /// any `null`.
     fn as_sym(&self) -> Option<&Self::SymbolToken>;
+
+    /// Returns a reference to the boolean value of this element.
+    ///
+    ///  This will return `None` in the case that the type is not `bool` or the value is
+    ///   any `null`.
+    fn as_bool(&self) -> Option<&bool>;
+
+    /// Returns a reference to the underlying bytes of this element.
+   ///
+   /// This will return `None` in the case that the type is not `blob` or the value is
+   /// any `null`.
+    fn as_blob(&self) -> Option<&Vec<u8>>;
+
+    /// Returns a reference to the underlying bytes of this element.
+   ///
+   /// This will return `None` in the case that the type is not `clob` or the value is
+   /// any `null`.
+    fn as_clob(&self) -> Option<&Vec<u8>>;
 
     /// Returns a reference to the [`Sequence`] of this element.
     ///

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -94,12 +94,12 @@
 //! [simd-json-value]: https://docs.rs/simd-json/latest/simd_json/value/index.html
 //! [serde-json-value]: https://docs.serde.rs/serde_json/value/enum.Value.html
 
+use crate::types::decimal::Decimal;
+use crate::types::timestamp::Timestamp;
 use crate::types::SymbolId;
 use crate::IonType;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
-use crate::types::decimal::Decimal;
-use crate::types::timestamp::Timestamp;
 
 pub mod borrowed;
 pub mod owned;
@@ -294,15 +294,15 @@ pub trait Element {
     fn as_bool(&self) -> Option<&bool>;
 
     /// Returns a reference to the underlying bytes of this element.
-   ///
-   /// This will return `None` in the case that the type is not `blob` or the value is
-   /// any `null`.
+    ///
+    /// This will return `None` in the case that the type is not `blob` or the value is
+    /// any `null`.
     fn as_blob(&self) -> Option<&Vec<u8>>;
 
     /// Returns a reference to the underlying bytes of this element.
-   ///
-   /// This will return `None` in the case that the type is not `clob` or the value is
-   /// any `null`.
+    ///
+    /// This will return `None` in the case that the type is not `clob` or the value is
+    /// any `null`.
     fn as_clob(&self) -> Option<&Vec<u8>>;
 
     /// Returns a reference to the [`Sequence`] of this element.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -263,7 +263,7 @@ pub trait Element {
     /// Returns a reference to the underlying float value for this element.
     ///
     /// This will return `None` if the type is not `float` or the value is any `null`.
-    fn as_float(&self) -> Option<&f64>;
+    fn as_float(&self) -> Option<f64>;
 
     /// Returns a reference to the underlying [`Decimal`] for this element.
     ///
@@ -291,19 +291,19 @@ pub trait Element {
     ///
     ///  This will return `None` in the case that the type is not `bool` or the value is
     ///   any `null`.
-    fn as_bool(&self) -> Option<&bool>;
+    fn as_bool(&self) -> Option<bool>;
 
     /// Returns a reference to the underlying bytes of this element.
     ///
     /// This will return `None` in the case that the type is not `blob` or the value is
     /// any `null`.
-    fn as_blob(&self) -> Option<&Vec<u8>>;
+    fn as_blob(&self) -> Option<&[u8]>;
 
     /// Returns a reference to the underlying bytes of this element.
     ///
     /// This will return `None` in the case that the type is not `clob` or the value is
     /// any `null`.
-    fn as_clob(&self) -> Option<&Vec<u8>>;
+    fn as_clob(&self) -> Option<&[u8]>;
 
     /// Returns a reference to the [`Sequence`] of this element.
     ///

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -10,6 +10,9 @@ use crate::types::SymbolId;
 use crate::IonType;
 use std::collections::HashMap;
 use std::rc::Rc;
+use crate::types::decimal::Decimal;
+use crate::types::timestamp::Timestamp;
+use crate::result::IonError::IllegalOperation;
 
 /// An owned implementation of  [`ImportSource`].
 #[derive(Debug, Clone)]
@@ -186,8 +189,14 @@ impl Struct for OwnedStruct {
 pub enum OwnedValue {
     Null(IonType),
     Integer(AnyInt),
+    Float(f64),
+    Decimal(Decimal),
+    Timestamp(Timestamp),
     String(String),
     Symbol(OwnedSymbolToken),
+    Boolean(bool),
+    Blob(Vec<u8>),
+    Clob(Vec<u8>),
     SExpression(OwnedSequence),
     List(OwnedSequence),
     Struct(OwnedStruct),
@@ -224,8 +233,14 @@ impl Element for OwnedElement {
         match &self.value {
             Null(t) => *t,
             Integer(_) => IonType::Integer,
+            Float(_) => IonType::Float,
+            Decimal(_) => IonType::Decimal,
+            Timestamp(_) => IonType::Timestamp,
             String(_) => IonType::String,
             Symbol(_) => IonType::Symbol,
+            Boolean(_) => IonType::Boolean,
+            Blob(_) => IonType::Blob,
+            Clob(_) => IonType::Clob,
             SExpression(_) => IonType::SExpression,
             List(_) => IonType::List,
             Struct(_) => IonType::Struct,
@@ -250,6 +265,27 @@ impl Element for OwnedElement {
         }
     }
 
+    fn as_float(&self) -> Option<&f64> {
+        match &self.value {
+            OwnedValue::Float(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    fn as_decimal(&self) -> Option<&Decimal> {
+        match &self.value {
+            OwnedValue::Decimal(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    fn as_timestamp(&self) -> Option<&Timestamp> {
+        match &self.value {
+            OwnedValue::Timestamp(t) => Some(t),
+            _ => None,
+        }
+    }
+
     fn as_str(&self) -> Option<&str> {
         match &self.value {
             OwnedValue::String(text) => Some(text),
@@ -261,6 +297,27 @@ impl Element for OwnedElement {
     fn as_sym(&self) -> Option<&Self::SymbolToken> {
         match &self.value {
             OwnedValue::Symbol(sym) => Some(sym),
+            _ => None,
+        }
+    }
+
+    fn as_bool(&self) -> Option<&bool> {
+        match &self.value {
+            OwnedValue::Boolean(b) => Some(b),
+            _ => None,
+        }
+    }
+
+    fn as_blob(&self) -> Option<&Vec<u8>> {
+        match &self.value {
+            OwnedValue::Blob(bytes) => Some(bytes),
+            _ => None,
+        }
+    }
+
+    fn as_clob(&self) -> Option<&Vec<u8>> {
+        match &self.value {
+            OwnedValue::Clob(bytes) => Some(bytes),
             _ => None,
         }
     }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -335,3 +335,118 @@ impl Element for OwnedElement {
         }
     }
 }
+
+#[cfg(test)]
+mod value_tests {
+    use crate::result::IonResult;
+    use crate::types::decimal::Decimal;
+    use crate::types::timestamp::Timestamp;
+    use crate::value::owned::{OwnedElement, OwnedSequence, OwnedSymbolToken, OwnedValue};
+    use crate::value::{AnyInt, Element, IntAccess, SymbolToken};
+
+    fn extract_text<T: SymbolToken>(tok: &T) -> String {
+        tok.text().unwrap().into()
+    }
+
+    fn create_element_from_value(value: OwnedValue) -> OwnedElement {
+        let annotations = vec!["foo", "bar", "baz"];
+        let owned_elem =
+            OwnedElement::new(annotations.iter().map(|s| (*s).into()).collect(), value);
+        owned_elem
+    }
+
+    #[test]
+    fn test_as_any_int() -> IonResult<()> {
+        let owned_elem = create_element_from_value(OwnedValue::Integer(AnyInt::I64(100)));
+        let expected_elem = AnyInt::I64(100);
+
+        assert_eq!(&expected_elem.as_i64(), &owned_elem.as_i64());
+        assert_eq!(&expected_elem.as_big_int(), &owned_elem.as_big_int());
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_float() -> IonResult<()> {
+        let owned_elem = create_element_from_value(OwnedValue::Float(305e1));
+        let expected_elem = Some(305e1);
+
+        assert_eq!(&expected_elem, &owned_elem.as_float());
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_decimal() -> IonResult<()> {
+        let decimal_value1 = Decimal::new(8, 3);
+        let decimal_value2 = Decimal::new(80, 2);
+
+        let owned_elem = create_element_from_value(OwnedValue::Decimal(decimal_value1));
+        let expected_elem = Some(&decimal_value2);
+
+        assert_eq!(&expected_elem, &owned_elem.as_decimal());
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_timestamp() -> IonResult<()> {
+        let builder = Timestamp::with_ymd_hms_millis(2021, 2, 5, 16, 43, 51, 192);
+        let timestamp_value1 = builder.clone().build_at_offset(5 * 60 * 60)?;
+        let timestamp_value2 = builder.clone().build_at_offset(5 * 60 * 60)?;
+
+        let owned_elem = create_element_from_value(OwnedValue::Timestamp(timestamp_value1));
+        let expected_elem = Some(&timestamp_value2);
+
+        assert_eq!(&expected_elem, &owned_elem.as_timestamp());
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_str() -> IonResult<()> {
+        let owned_elem = create_element_from_value(OwnedValue::String("hello".into()));
+        let expected_elem = Some("hello");
+
+        assert_eq!(&expected_elem, &owned_elem.as_str());
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_sym() -> IonResult<()> {
+        let owned_token: OwnedSymbolToken = "hello".into();
+        let owned_elem = create_element_from_value(OwnedValue::Symbol(owned_token));
+        let expected_elem: &OwnedSymbolToken = &("hello".into());
+
+        assert_eq!(
+            extract_text(expected_elem),
+            extract_text(owned_elem.as_sym().unwrap().into())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_bool() -> IonResult<()> {
+        let owned_elem = create_element_from_value(OwnedValue::Boolean(false));
+        let expected_elem = Some(false);
+
+        assert_eq!(&expected_elem, &owned_elem.as_bool());
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_blob() -> IonResult<()> {
+        let owned_elem =
+            create_element_from_value(OwnedValue::Blob(String::from("{{aGVsbG8h}}").into_bytes()));
+        let expected_elem = Some("{{aGVsbG8h}}".as_bytes());
+
+        assert_eq!(&expected_elem, &owned_elem.as_blob());
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_clob() -> IonResult<()> {
+        let owned_elem =
+            create_element_from_value(OwnedValue::Clob(String::from("{{\"hello\"}}").into_bytes()));
+        let expected_elem = Some("{{\"hello\"}}".as_bytes());
+
+        assert_eq!(&expected_elem, &owned_elem.as_clob());
+        Ok(())
+    }
+}

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -6,7 +6,6 @@
 //! ownership of data to do so.
 
 use super::{AnyInt, Element, ImportSource, Sequence, Struct, SymbolToken};
-use crate::result::IonError::IllegalOperation;
 use crate::types::decimal::Decimal;
 use crate::types::timestamp::Timestamp;
 use crate::types::SymbolId;
@@ -265,9 +264,9 @@ impl Element for OwnedElement {
         }
     }
 
-    fn as_float(&self) -> Option<&f64> {
+    fn as_float(&self) -> Option<f64> {
         match &self.value {
-            OwnedValue::Float(f) => Some(f),
+            OwnedValue::Float(f) => Some(*f),
             _ => None,
         }
     }
@@ -301,21 +300,21 @@ impl Element for OwnedElement {
         }
     }
 
-    fn as_bool(&self) -> Option<&bool> {
+    fn as_bool(&self) -> Option<bool> {
         match &self.value {
-            OwnedValue::Boolean(b) => Some(b),
+            OwnedValue::Boolean(b) => Some(*b),
             _ => None,
         }
     }
 
-    fn as_blob(&self) -> Option<&Vec<u8>> {
+    fn as_blob(&self) -> Option<&[u8]> {
         match &self.value {
             OwnedValue::Blob(bytes) => Some(bytes),
             _ => None,
         }
     }
 
-    fn as_clob(&self) -> Option<&Vec<u8>> {
+    fn as_clob(&self) -> Option<&[u8]> {
         match &self.value {
             OwnedValue::Clob(bytes) => Some(bytes),
             _ => None,

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -341,10 +341,10 @@ mod value_tests {
     use crate::result::IonResult;
     use crate::types::decimal::Decimal;
     use crate::types::timestamp::Timestamp;
-    use crate::value::owned::{OwnedElement, OwnedSequence, OwnedSymbolToken, OwnedValue};
+    use crate::value::owned::{OwnedElement, OwnedSymbolToken, OwnedValue};
     use crate::value::{AnyInt, Element, IntAccess, SymbolToken};
 
-    fn extract_text<T: SymbolToken>(tok: &T) -> String {
+    fn extract_text<T: SymbolToken>(tok: &T) -> &str {
         tok.text().unwrap().into()
     }
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -6,13 +6,13 @@
 //! ownership of data to do so.
 
 use super::{AnyInt, Element, ImportSource, Sequence, Struct, SymbolToken};
+use crate::result::IonError::IllegalOperation;
+use crate::types::decimal::Decimal;
+use crate::types::timestamp::Timestamp;
 use crate::types::SymbolId;
 use crate::IonType;
 use std::collections::HashMap;
 use std::rc::Rc;
-use crate::types::decimal::Decimal;
-use crate::types::timestamp::Timestamp;
-use crate::result::IonError::IllegalOperation;
 
 /// An owned implementation of  [`ImportSource`].
 #[derive(Debug, Clone)]


### PR DESCRIPTION
*Issue #139*

*Description of changes:*
This PR works on filling in rest of the scalar value types for Element API.

*Changes:*
Added following scalar types with this PR:
- Float
- Decimal
- Timestamp
- Boolean
- Blob
- Clob