### PR TITLE
Adds generic `get`/`get_all` for `Struct` in terms of `AsRef<str>`.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: CI Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -350,6 +350,17 @@ pub trait Struct {
     /// returns `None` if the field_name does not exist in the struct
     ///
     /// ## Usage
+    /// Using the [borrowed] API:
+    /// ```
+    /// # use ion_rs::value::*;
+    /// # use ion_rs::value::borrowed::*;
+    /// let fields: Vec<(&str, BorrowedValue)>= vec![("e", "f"), ("g", "h")]
+    ///     .into_iter().map(|(k, v)| (k, BorrowedValue::String(v))).collect();
+    /// let borrowed: BorrowedStruct = fields.into_iter().collect();
+    /// assert_eq!("h", borrowed.get("g".to_string()).map(|e| e.as_str()).flatten().unwrap());
+    /// ```
+    ///
+    /// Using the [owned] API:
     /// ```
     /// # use ion_rs::value::*;
     /// # use ion_rs::value::owned::*;
@@ -364,15 +375,29 @@ pub trait Struct {
     /// returns an empty iterator if the field_name does not exist in the struct
     ///
     /// ## Usage
+    /// Using the [borrowed] API:
     /// ```
     /// # use ion_rs::value::*;
     /// # use ion_rs::value::borrowed::*;
     /// let fields: Vec<(&str, BorrowedValue)>= vec![("a", "b"), ("c", "d"), ("c", "e")]
     ///     .into_iter().map(|(k, v)| (k, BorrowedValue::String(v))).collect();
-    /// let owned: BorrowedStruct = fields.into_iter().collect();
+    /// let borrowed: BorrowedStruct = fields.into_iter().collect();
     /// assert_eq!(
     ///     vec!["d", "e"],
-    ///     owned.get_all("c").flat_map(|e| e.as_str()).collect::<Vec<&str>>()
+    ///     borrowed.get_all("c").flat_map(|e| e.as_str()).collect::<Vec<&str>>()
+    /// );
+    /// ```
+    ///
+    /// Using the [owned] API:
+    /// ```
+    /// # use ion_rs::value::*;
+    /// # use ion_rs::value::owned::*;
+    /// let fields: Vec<(&str, OwnedValue)>= vec![("d", "e"), ("d", "f"), ("g", "h")]
+    ///     .into_iter().map(|(k, v)| (k, OwnedValue::String(v.into()))).collect();
+    /// let owned: OwnedStruct = fields.into_iter().collect();
+    /// assert_eq!(
+    ///     vec!["e", "f"],
+    ///     owned.get_all("d").flat_map(|e| e.as_str()).collect::<Vec<&str>>()
     /// );
     /// ```
     fn get_all<'a, T: AsRef<str>>(

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -348,13 +348,35 @@ pub trait Struct {
 
     /// Returns the last value corresponding to the field_name in the struct or
     /// returns `None` if the field_name does not exist in the struct
-    /// TODO add generic implementation to allow &String, String for lookup
-    fn get(&self, field_name: &str) -> Option<&Self::Element>;
+    ///
+    /// ## Usage
+    /// ```
+    /// # use ion_rs::value::*;
+    /// # use ion_rs::value::owned::*;
+    /// let fields: Vec<(&str, OwnedValue)>= vec![("a", "b"), ("c", "d")]
+    ///     .into_iter().map(|(k, v)| (k, OwnedValue::String(v.into()))).collect();
+    /// let owned: OwnedStruct = fields.into_iter().collect();
+    /// assert_eq!("d", owned.get("c".to_string()).map(|e| e.as_str()).flatten().unwrap());
+    /// ```
+    fn get<T: AsRef<str>>(&self, field_name: T) -> Option<&Self::Element>;
 
     /// Returns an iterator with all the values corresponding to the field_name in the struct or
     /// returns an empty iterator if the field_name does not exist in the struct
-    fn get_all<'a>(
+    ///
+    /// ## Usage
+    /// ```
+    /// # use ion_rs::value::*;
+    /// # use ion_rs::value::borrowed::*;
+    /// let fields: Vec<(&str, BorrowedValue)>= vec![("a", "b"), ("c", "d"), ("c", "e")]
+    ///     .into_iter().map(|(k, v)| (k, BorrowedValue::String(v))).collect();
+    /// let owned: BorrowedStruct = fields.into_iter().collect();
+    /// assert_eq!(
+    ///     vec!["d", "e"],
+    ///     owned.get_all("c").flat_map(|e| e.as_str()).collect::<Vec<&str>>()
+    /// );
+    /// ```
+    fn get_all<'a, T: AsRef<str>>(
         &'a self,
-        field_name: &'a str,
+        field_name: T,
     ) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a>;
 }


### PR DESCRIPTION
* Ergonomic improvement of constructing a borrowed/owned `Struct` easier from an interator.
  (see #136).
* Adds a doc test that demonstrates the above constructor and the generic API in use.
* Also did some minor clean-up around some of the `get`/`get_all` implementation to
  be a little less verbose.

Resolves #142.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
