### PR TITLE
Added unit tests with fixture for `Element` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = "1.0"
 nom = "6.1.0"
 num-bigint = "0.3.1"
 num-traits = "0.2.14"
+rstest = "0.7.0"
 
 # NB: We use the tree dependency here for development and CI.
 #     Note that when publishing you should update the version

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -282,7 +282,7 @@ impl<'val> Element for BorrowedElement<'val> {
         }
     }
 
-    fn as_float(&self) -> Option<f64> {
+    fn as_f64(&self) -> Option<f64> {
         match &self.value {
             BorrowedValue::Float(f) => Some(*f),
             _ => None,
@@ -325,16 +325,9 @@ impl<'val> Element for BorrowedElement<'val> {
         }
     }
 
-    fn as_blob(&self) -> Option<&[u8]> {
+    fn as_bytes(&self) -> Option<&[u8]> {
         match &self.value {
-            BorrowedValue::Blob(bytes) => Some(*bytes),
-            _ => None,
-        }
-    }
-
-    fn as_clob(&self) -> Option<&[u8]> {
-        match &self.value {
-            BorrowedValue::Clob(bytes) => Some(*bytes),
+            BorrowedValue::Blob(bytes) | BorrowedValue::Clob(bytes) => Some(*bytes),
             _ => None,
         }
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -207,6 +207,24 @@ impl IntAccess for AnyInt {
     }
 }
 
+impl PartialEq for AnyInt {
+    fn eq(&self, other: &Self) -> bool {
+        use AnyInt::*;
+        match self {
+            I64(my_i64) => match other {
+                I64(other_i64) => my_i64 == other_i64,
+                BigInt(other_bi) => Some(*my_i64) == other_bi.to_i64(),
+            },
+            BigInt(my_bi) => match other {
+                I64(other_i64) => my_bi.to_i64() == Some(*other_i64),
+                BigInt(other_bi) => my_bi == other_bi,
+            },
+        }
+    }
+}
+
+impl Eq for AnyInt {}
+
 /// Represents a either a borrowed or owned Ion datum.  There are/will be specific APIs for
 /// _borrowed_ and _owned_ implementations, but this trait unifies operations on either.
 pub trait Element {
@@ -263,7 +281,7 @@ pub trait Element {
     /// Returns a reference to the underlying float value for this element.
     ///
     /// This will return `None` if the type is not `float` or the value is any `null`.
-    fn as_float(&self) -> Option<f64>;
+    fn as_f64(&self) -> Option<f64>;
 
     /// Returns a reference to the underlying [`Decimal`] for this element.
     ///
@@ -295,15 +313,9 @@ pub trait Element {
 
     /// Returns a reference to the underlying bytes of this element.
     ///
-    /// This will return `None` in the case that the type is not `blob` or the value is
+    /// This will return `None` in the case that the type is not `blob`/`clob` or the value is
     /// any `null`.
-    fn as_blob(&self) -> Option<&[u8]>;
-
-    /// Returns a reference to the underlying bytes of this element.
-    ///
-    /// This will return `None` in the case that the type is not `clob` or the value is
-    /// any `null`.
-    fn as_clob(&self) -> Option<&[u8]>;
+    fn as_bytes(&self) -> Option<&[u8]>;
 
     /// Returns a reference to the [`Sequence`] of this element.
     ///

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -283,7 +283,7 @@ impl Element for OwnedElement {
         }
     }
 
-    fn as_float(&self) -> Option<f64> {
+    fn as_f64(&self) -> Option<f64> {
         match &self.value {
             OwnedValue::Float(f) => Some(*f),
             _ => None,
@@ -326,16 +326,9 @@ impl Element for OwnedElement {
         }
     }
 
-    fn as_blob(&self) -> Option<&[u8]> {
+    fn as_bytes(&self) -> Option<&[u8]> {
         match &self.value {
-            OwnedValue::Blob(bytes) => Some(bytes),
-            _ => None,
-        }
-    }
-
-    fn as_clob(&self) -> Option<&[u8]> {
-        match &self.value {
-            OwnedValue::Clob(bytes) => Some(bytes),
+            OwnedValue::Blob(bytes) | OwnedValue::Clob(bytes) => Some(bytes),
             _ => None,
         }
     }
@@ -357,110 +350,170 @@ impl Element for OwnedElement {
 
 #[cfg(test)]
 mod value_tests {
-    use crate::result::IonResult;
+    use super::*;
     use crate::types::decimal::Decimal;
     use crate::types::timestamp::Timestamp;
-    use crate::value::owned::{OwnedElement, OwnedSymbolToken, OwnedValue};
     use crate::value::{AnyInt, Element, IntAccess, SymbolToken};
     use crate::IonType;
+    use chrono::*;
     use rstest::*;
+    use std::iter::{once, Once};
 
-    fn extract_text<T: SymbolToken>(tok: &T) -> &str {
-        tok.text().unwrap().into()
+    /// Makes a timestamp from an RFC-3339 string and panics if it can't
+    fn mk_ts<T: AsRef<str>>(text: T) -> Timestamp {
+        DateTime::parse_from_rfc3339(text.as_ref()).unwrap().into()
     }
 
-    #[fixture(owned_value = OwnedValue::Null(IonType::Null))]
-    fn owned_element(owned_value: OwnedValue) -> OwnedElement {
-        let annotations = vec!["foo", "bar", "baz"];
-        let owned_elem = OwnedElement::new(
-            annotations.iter().map(|s| (*s).into()).collect(),
-            owned_value,
-        );
-        owned_elem
+    // TODO consider refactoring in a common generic form for the `borrowed` module.
+
+    /// Models the operations on `Element` that we want to test.
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    enum ElemOp {
+        IsNull,
+        AsBool,
+        AsAnyInt,
+        AsF64,
+        AsDecimal,
+        AsTimestamp,
+        AsStr,
+        AsSym,
+        AsBytes,
+        AsSequence,
+        AsStruct,
     }
 
-    #[rstest]
-    fn test_as_any_int(
-        #[with(OwnedValue::Integer(AnyInt::I64(100)))] owned_element: OwnedElement,
-    ) -> IonResult<()> {
-        assert_eq!(&AnyInt::I64(100).as_i64(), &owned_element.as_i64());
-        assert_eq!(&AnyInt::I64(100).as_big_int(), &owned_element.as_big_int());
-        Ok(())
+    impl IntoIterator for ElemOp {
+        type Item = ElemOp;
+        type IntoIter = <Once<ElemOp> as IntoIterator>::IntoIter;
+
+        fn into_iter(self) -> Self::IntoIter {
+            once(self)
+        }
     }
 
-    #[rstest]
-    fn test_as_float(
-        #[with(OwnedValue::Float(305e1))] owned_element: OwnedElement,
-    ) -> IonResult<()> {
-        assert_eq!(&Some(305e1), &owned_element.as_float());
-        Ok(())
-    }
+    use std::collections::HashSet;
+    use ElemOp::*;
 
-    #[rstest]
-    fn test_as_decimal(
-        #[with(OwnedValue::Decimal(Decimal::new(8, 3)))] owned_element: OwnedElement,
-    ) -> IonResult<()> {
-        let decimal_value2 = Decimal::new(80, 2);
-        let expected_elem = Some(&decimal_value2);
+    type ElemAssertFunc = dyn Fn(&OwnedElement) -> ();
 
-        assert_eq!(&expected_elem, &owned_element.as_decimal());
-        Ok(())
-    }
+    #[rstest(
+        val, ion_type, valid_ops_iter, op_assert,
+        case::null(
+            OwnedValue::Null(IonType::Null),
+            IonType::Null,
+            IsNull,
+            &|e: &OwnedElement| assert_eq!(true, e.is_null())
+        ),
+        // TODO more null testing (probably its own fixture)
+        case::bool(
+            OwnedValue::Boolean(true),
+            IonType::Boolean,
+            AsBool,
+            &|e: &OwnedElement| assert_eq!(Some(true), e.as_bool())
+        ),
+        case::i64(
+            OwnedValue::Integer(AnyInt::I64(100)),
+            IonType::Integer,
+            AsAnyInt,
+            &|e: &OwnedElement| {
+                assert_eq!(Some(&AnyInt::I64(100)), e.as_any_int());
+                assert_eq!(Some(100), e.as_i64());
+                assert_eq!(None, e.as_big_int());
+            }
+        ),
+        // TODO a BigInt test case
+        case::f64(
+            OwnedValue::Float(16.0),
+            IonType::Float,
+            AsF64,
+            &|e: &OwnedElement| assert_eq!(Some(16.0), e.as_f64())
+        ),
+        case::decimal(
+            OwnedValue::Decimal(Decimal::new(8, 3)),
+            IonType::Decimal,
+            AsDecimal,
+            &|e: &OwnedElement| assert_eq!(Some(&Decimal::new(80, 2)), e.as_decimal())
+        ),
+        case::timestamp(
+            OwnedValue::Timestamp(mk_ts("2014-10-16T12:01:00-00:00")),
+            IonType::Timestamp,
+            AsTimestamp,
+            &|e: &OwnedElement| assert_eq!(Some(&mk_ts("2014-10-16T12:01:00+00:00")), e.as_timestamp())
+        ),
+        case::str(
+            OwnedValue::String("hello".into()),
+            IonType::String,
+            AsStr,
+            &|e: &OwnedElement| assert_eq!(Some("hello"), e.as_str())
+        ),
+        case::sym_text(
+            OwnedValue::Symbol("hello".into()),
+            IonType::Symbol,
+            vec![AsStr, AsSym],
+            &|e: &OwnedElement| {
+                assert_eq!(Some("hello"), e.as_str());
+                assert_eq!(Some("hello"), e.as_sym().unwrap().text());
+            }
+        ),
+        // TODO more symbol token tests (without text)
+        case::blob(
+            OwnedValue::Blob("world".as_bytes().into()),
+            IonType::Blob,
+            AsBytes,
+            &|e: &OwnedElement| {
+                assert_eq!(Some("world".as_bytes()), e.as_bytes());
+            }
+        ),
+        case::clob(
+            OwnedValue::Clob("goodbye".as_bytes().into()),
+            IonType::Clob,
+            AsBytes,
+            &|e: &OwnedElement| {
+                assert_eq!(Some("goodbye".as_bytes()), e.as_bytes());
+            }
+        ),
+        // TODO add cases for list/sexp/struct
+    )]
+    fn owned_element_accessors<O: IntoIterator<Item = ElemOp>>(
+        val: OwnedValue,
+        ion_type: IonType,
+        valid_ops_iter: O,
+        op_assert: &ElemAssertFunc,
+    ) {
+        // table of negative assertions for each operation
+        let neg_table: Vec<(ElemOp, &ElemAssertFunc)> = vec![
+            (IsNull, &|e| assert_eq!(false, e.is_null())),
+            (AsBool, &|e| assert_eq!(None, e.as_bool())),
+            (AsAnyInt, &|e| {
+                assert_eq!(None, e.as_any_int());
+                assert_eq!(None, e.as_i64());
+                assert_eq!(None, e.as_big_int());
+            }),
+            (AsF64, &|e| assert_eq!(None, e.as_f64())),
+            (AsDecimal, &|e| assert_eq!(None, e.as_decimal())),
+            (AsTimestamp, &|e| assert_eq!(None, e.as_timestamp())),
+            (AsStr, &|e| assert_eq!(None, e.as_str())),
+            (AsSym, &|e| assert_eq!(true, e.as_sym().is_none())),
+            (AsBytes, &|e| assert_eq!(None, e.as_bytes())),
+            (AsSequence, &|e| assert_eq!(true, e.as_sequence().is_none())),
+            (AsStruct, &|e| assert_eq!(true, e.as_struct().is_none())),
+        ];
+        // produce the table of assertions to operate on, replacing the one specified by
+        // the test case
+        let valid_ops: HashSet<ElemOp> = valid_ops_iter.into_iter().collect();
+        let op_assertions: Vec<&ElemAssertFunc> = neg_table
+            .into_iter()
+            .filter(|(op, _)| !valid_ops.contains(op))
+            .map(|(_, neg_assert)| neg_assert)
+            .chain(once(op_assert))
+            .collect();
 
-    #[rstest]
-    fn test_as_timestamp(
-        #[with(OwnedValue::Timestamp(Timestamp::with_ymd_hms_millis(2021, 2, 5, 16, 43, 51, 192).clone().build_at_offset(5 * 60 * 60).unwrap().into()))]
-        owned_element: OwnedElement,
-    ) -> IonResult<()> {
-        let builder = Timestamp::with_ymd_hms_millis(2021, 2, 5, 16, 43, 51, 192);
-        let timestamp_value2 = builder.clone().build_at_offset(5 * 60 * 60)?;
+        // construct an element to test
+        let elem: OwnedElement = val.into();
+        assert_eq!(ion_type, elem.ion_type());
 
-        assert_eq!(&Some(&timestamp_value2), &owned_element.as_timestamp());
-        Ok(())
-    }
-
-    #[rstest]
-    fn test_as_str(
-        #[with(OwnedValue::String("hello".into()))] owned_element: OwnedElement,
-    ) -> IonResult<()> {
-        assert_eq!(&Some("hello"), &owned_element.as_str());
-        Ok(())
-    }
-
-    #[rstest]
-    fn test_as_sym(
-        #[with(OwnedValue::Symbol("hello".into()))] owned_element: OwnedElement,
-    ) -> IonResult<()> {
-        let expected_elem: &OwnedSymbolToken = &("hello".into());
-
-        assert_eq!(
-            extract_text(expected_elem),
-            extract_text(owned_element.as_sym().unwrap().into())
-        );
-        Ok(())
-    }
-
-    #[rstest]
-    fn test_as_bool(
-        #[with(OwnedValue::Boolean(false))] owned_element: OwnedElement,
-    ) -> IonResult<()> {
-        assert_eq!(&Some(false), &owned_element.as_bool());
-        Ok(())
-    }
-
-    #[rstest]
-    fn test_as_blob(
-        #[with(OwnedValue::Blob("{{aGVsbG8h}}".as_bytes().to_vec()))] owned_element: OwnedElement,
-    ) -> IonResult<()> {
-        assert_eq!(&Some("{{aGVsbG8h}}".as_bytes()), &owned_element.as_blob());
-        Ok(())
-    }
-
-    #[rstest]
-    fn test_as_clob(
-        #[with(OwnedValue::Clob("{{\"hello\"}}".as_bytes().to_vec()))] owned_element: OwnedElement,
-    ) -> IonResult<()> {
-        assert_eq!(&Some("{{\"hello\"}}".as_bytes()), &owned_element.as_clob());
-        Ok(())
+        for assert in op_assertions {
+            assert(&elem);
+        }
     }
 }


### PR DESCRIPTION
*Issue #146*

*Description of changes:*
This PR works on using fixtures for `Element` API unit tests.

*Changes:*
- created a fixture for creating `owned_element` to be used for unit tests.
- added `rstest` to `Cargo.toml`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
