### PR TITLE
Refactors `OwnedElement` tests to do some equivalence testing.

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -57,12 +57,8 @@
 //!
 //! let owned_elem = OwnedElement::new(
 //!     vec![
-//!         OwnedSymbolToken::new(
-//!             None,
-//!             Some(300),
-//!             Some(OwnedImportSource::new("foo", 12))
-//!         ),
-//!         "hello".into()
+//!         local_sid_token(300).with_source("foo", 12),
+//!         text_token("hello")
 //!     ],
 //!     OwnedValue::String("world".into())
 //! );


### PR DESCRIPTION
Adds new top-level constructor functions for `OwnedSymbolToken` that
makes it more ergonomic.  Makes the low-level `OwnedSymbolToken::new`
private in preference of the new functions.

Adds annotation tests on the elements in various equivalences.

TODO refactor this to `borrowed`, add non-equivalence, and refactor
to smaller units.

This is based on #152.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
