### PR TITLE
Configures workflow to not run on PRs within repository.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     name: Build and Test
     runs-on: ${{ matrix.os }}
+    # We want to run on external PRs, but not on internal ones as push automatically builds
+    # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amzn/ion-rust'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
Right now we build on `push` or `pull_request`.  This is fine for
PRs from forks, but not so great on internal PRs as we get two runs,
this makes us ignore the `pull_request` run for the latter case.

Resolves #162.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
