### PR TITLE
Configures workflow to not run on PRs within repository. DUPLICATE of #166

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     name: Build and Test
     runs-on: ${{ matrix.os }}
+    # We want to run on external PRs, but not on internal ones as push automatically builds
+    # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amzn/ion-rust'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
***Do not merge--this is to test #166 to make sure external PRs (this one coming from my fork) still run the `pull_request` trigger.***

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
