### PR TITLE
Fixes doc test to plain text.

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -122,7 +122,7 @@ pub trait ImportSource {
 ///
 /// Consider the following pseudo-code describing Ion data model semantics:
 ///
-/// ```ignore,
+/// ```plain
 ///     //   (<text>, <local id>, <source>)
 ///     
 ///     a := (nil, 200, ("my_table", 1))


### PR DESCRIPTION
Our symbol table explainer code block was annotated as `ignore` this is
not quite right as it is not even Rust code so annotating it with
`plain` is more appropriate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
