### PR TITLE
Changes rustup profile to `default` for `nightly`.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
+          profile: default
           toolchain: nightly
           override: true
       - name: Cargo Test


### PR DESCRIPTION
Coverage relies on `nightly`, and the `default` profile seems to be a bit more stable.

I noticed that 2021-04-11 nightly started breaking for `clang_sys`.  It seems that the version one installs by default for nightly was a few weeks behind.  I am trying setting this profile in the hopes that we get a more "stable" nightly for our coverage CI.  If we run into more problems, we might have to start pinning the nightly version to keep things more reliable.

Hopefully someday soon we won't have to rely on unstable `-Zprofile` for code coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
