### PR TITLE
Pins Code Coverage to `nightly-2021-03-23`.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: nightly
+          # nightly can be very volatile--pin this to a version we know works well...
+          toolchain: nightly-2021-03-23
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Nightly builds can be really unstable--and has shown to break our
pipeline.  This pins the version to make it explicit to which
version of the compiler we use to generate code coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
