### PR TITLE
Update codecov to use rust nightly-2021-04-18.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: default
+          profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2021-03-23
+          toolchain: nightly-2021-04-18
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Also changes profile back to minimal.

Now that we're pinning the version, I've noticed that the most recent nightly works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
