### PR TITLE
Filled `Builder` trait with `new_...` methods for all types

### DIFF
--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -68,21 +68,6 @@ impl<'val> BorrowedSymbolToken<'val> {
             source,
         }
     }
-
-    fn with_text_borrowed(mut self, text: &'static str) -> Self {
-        self.text = Some(text);
-        self
-    }
-
-    fn with_local_sid_borrrowed(mut self, local_sid: SymbolId) -> Self {
-        self.local_sid = Some(local_sid);
-        self
-    }
-
-    fn with_source_borrowed(mut self, table: &'static str, sid: SymbolId) -> Self {
-        self.source = Some(BorrowedImportSource::new(table, sid));
-        self
-    }
 }
 
 /// Constructs an [`BorrowedSymbolToken`] with unknown text and a local ID.
@@ -135,15 +120,19 @@ impl<'val> SymbolToken for BorrowedSymbolToken<'val> {
     }
 
     fn with_text(self, text: &'static str) -> Self {
-        self.with_text_borrowed(text)
+        BorrowedSymbolToken::new(Some(text), self.local_sid, self.source)
     }
 
     fn with_local_sid(self, local_sid: SymbolId) -> Self {
-        self.with_local_sid_borrrowed(local_sid)
+        BorrowedSymbolToken::new(self.text, Some(local_sid), self.source)
     }
 
     fn with_source(self, table: &'static str, sid: SymbolId) -> Self {
-        self.with_source_borrowed(table, sid)
+        BorrowedSymbolToken::new(
+            self.text,
+            self.local_sid,
+            Some(BorrowedImportSource::new(table, sid)),
+        )
     }
 }
 

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -16,7 +16,6 @@ use crate::IonType;
 use num_bigint::BigInt;
 use std::collections::HashMap;
 use std::iter::FromIterator;
-use std::rc::Rc;
 
 /// A borrowed implementation of [`ImportSource`].
 #[derive(Debug, Copy, Clone)]
@@ -70,20 +69,17 @@ impl<'val> BorrowedSymbolToken<'val> {
         }
     }
 
-    /// Decorates the [`BorrowedSymbolToken`] with text.
-    pub fn with_text(mut self, text: &'val str) -> Self {
+    fn with_text_borrowed(mut self, text: &'static str) -> Self {
         self.text = Some(text);
         self
     }
 
-    /// Decorates the [`BorrowedSymbolToken`] with a local ID.
-    pub fn with_local_sid(mut self, local_sid: SymbolId) -> Self {
+    fn with_local_sid_borrrowed(mut self, local_sid: SymbolId) -> Self {
         self.local_sid = Some(local_sid);
         self
     }
 
-    /// Decorates the [`BorrowedSymbolToken`] with an [`BorrowedImportSource`].
-    pub fn with_source(mut self, table: &'val str, sid: SymbolId) -> Self {
+    fn with_source_borrowed(mut self, table: &'static str, sid: SymbolId) -> Self {
         self.source = Some(BorrowedImportSource::new(table, sid));
         self
     }
@@ -137,6 +133,18 @@ impl<'val> SymbolToken for BorrowedSymbolToken<'val> {
     fn source(&self) -> Option<&Self::ImportSource> {
         self.source.as_ref()
     }
+
+    fn with_text(self, text: &'static str) -> Self {
+        self.with_text_borrowed(text)
+    }
+
+    fn with_local_sid(self, local_sid: SymbolId) -> Self {
+        self.with_local_sid_borrrowed(local_sid)
+    }
+
+    fn with_source(self, table: &'static str, sid: SymbolId) -> Self {
+        self.with_source_borrowed(table, sid)
+    }
 }
 
 /// A borrowed implementation of [`Builder`].
@@ -159,12 +167,12 @@ impl<'val> Builder for BorrowedElement<'val> {
         BorrowedValue::String(str).into()
     }
 
-    fn symbol_token(
-        text: Option<&'static str>,
-        local_sid: Option<usize>,
-        source: Option<Self::ImportSource>,
-    ) -> Self::SymbolToken {
-        BorrowedSymbolToken::new(text, local_sid, source)
+    fn text_token(text: &'static str) -> Self::SymbolToken {
+        BorrowedSymbolToken::new(Some(text), None, None)
+    }
+
+    fn local_sid_token(local_sid: usize) -> Self::SymbolToken {
+        BorrowedSymbolToken::new(None, Some(local_sid), None)
     }
 
     fn new_symbol(sym: Self::SymbolToken) -> Self::Element {

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -197,8 +197,8 @@ impl<'val> Builder for BorrowedElement<'val> {
         BorrowedValue::SExpression(seq).into()
     }
 
-    fn new_struct(struct_: Self::Struct) -> Self::Element {
-        BorrowedValue::Struct(struct_).into()
+    fn new_struct(structure: Self::Struct) -> Self::Element {
+        BorrowedValue::Struct(structure).into()
     }
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -487,10 +487,36 @@ pub trait Struct {
 
 pub trait Builder {
     type Element: Element + ?Sized;
+    type SymbolToken: SymbolToken + ?Sized;
     type Sequence: Sequence<Element = Self::Element> + ?Sized;
+    type Struct: Struct<FieldName = Self::SymbolToken, Element = Self::Element> + ?Sized;
 
     /// Build a `null` from IonType using Builder
     fn new_null(e_type: IonType) -> Self::Element;
+
+    /// Build a `bool` using Builder
+    fn new_bool(bool: bool) -> Self::Element;
+
+    /// Build a `string` using Builder
+    fn new_string(str: &'static str) -> Self::Element;
+
+    /// Build a `symbol` from SymbolToken using Builder
+    fn new_symbol(sym: Self::SymbolToken) -> Self::Element;
+
+    /// Build a `i64` using Builder
+    fn new_i64(int: i64) -> Self::Element;
+
+    /// Build a `big int` using Builder
+    fn new_big_int(big_int: BigInt) -> Self::Element;
+
+    /// Build a `decimal` using Builder
+    fn new_decimal(decimal: Decimal) -> Self::Element;
+
+    /// Build a `timestamp` using Builder
+    fn new_timestamp(timestamp: Timestamp) -> Self::Element;
+
+    /// Build a `f64` using Builder
+    fn new_f64(float: f64) -> Self::Element;
 
     /// Build a `clob` using Builder
     fn new_clob(bytes: &'static [u8]) -> Self::Element;
@@ -503,4 +529,7 @@ pub trait Builder {
 
     /// Build a `sexp` from Sequence using Builder
     fn new_sexp(seq: Self::Sequence) -> Self::Element;
+
+    /// Build a `struct` from Struct using Builder
+    fn new_struct(struct_: Self::Struct) -> Self::Element;
 }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -200,8 +200,8 @@ impl Builder for OwnedElement {
         OwnedValue::SExpression(seq).into()
     }
 
-    fn new_struct(struct_: Self::Struct) -> Self::Element {
-        OwnedValue::Struct(struct_).into()
+    fn new_struct(structure: Self::Struct) -> Self::Element {
+        OwnedValue::Struct(structure).into()
     }
 }
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -71,20 +71,17 @@ impl OwnedSymbolToken {
         }
     }
 
-    /// Decorates the [`OwnedSymbolToken`] with text.
-    pub fn with_text<T: Into<Rc<str>>>(mut self, text: T) -> Self {
-        self.text = Some(text.into());
+    fn with_text_owned(mut self, text: &'static str) -> Self {
+        self.text = Some(Rc::from(text));
         self
     }
 
-    /// Decorates the [`OwnedSymbolToken`] with a local ID.
-    pub fn with_local_sid(mut self, local_sid: SymbolId) -> Self {
+    fn with_local_sid_owned(mut self, local_sid: SymbolId) -> Self {
         self.local_sid = Some(local_sid);
         self
     }
 
-    /// Decorates the [`OwnedSymbolToken`] with an [`OwnedImportSource`].
-    pub fn with_source<T: Into<Rc<str>>>(mut self, table: T, sid: SymbolId) -> Self {
+    fn with_source_owned(mut self, table: &'static str, sid: SymbolId) -> Self {
         self.source = Some(OwnedImportSource::new(table, sid));
         self
     }
@@ -139,6 +136,18 @@ impl SymbolToken for OwnedSymbolToken {
     fn source(&self) -> Option<&Self::ImportSource> {
         self.source.as_ref()
     }
+
+    fn with_text(self, text: &'static str) -> Self {
+        self.with_text_owned(text)
+    }
+
+    fn with_local_sid(self, local_sid: SymbolId) -> Self {
+        self.with_local_sid_owned(local_sid)
+    }
+
+    fn with_source(self, table: &'static str, sid: SymbolId) -> Self {
+        self.with_source_owned(table, sid)
+    }
 }
 
 /// An owned implementation of [`Builder`].
@@ -161,12 +170,12 @@ impl Builder for OwnedElement {
         OwnedValue::String(str.into()).into()
     }
 
-    fn symbol_token(
-        text: Option<&'static str>,
-        local_sid: Option<usize>,
-        source: Option<Self::ImportSource>,
-    ) -> Self::SymbolToken {
-        OwnedSymbolToken::new(Some(Rc::from(text.unwrap())), local_sid, source)
+    fn text_token(text: &'static str) -> Self::SymbolToken {
+        OwnedSymbolToken::new(Some(Rc::from(text)), None, None)
+    }
+
+    fn local_sid_token(local_sid: usize) -> Self::SymbolToken {
+        OwnedSymbolToken::new(None, Some(local_sid), None)
     }
 
     fn new_symbol(sym: Self::SymbolToken) -> Self::Element {

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -131,7 +131,11 @@ impl SymbolToken for OwnedSymbolToken {
     }
 
     fn with_source(self, table: &'static str, sid: SymbolId) -> Self {
-        OwnedSymbolToken::new(self.text, self.local_sid, Some(OwnedImportSource::new(table, sid)))
+        OwnedSymbolToken::new(
+            self.text,
+            self.local_sid,
+            Some(OwnedImportSource::new(table, sid)),
+        )
     }
 }
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -70,21 +70,6 @@ impl OwnedSymbolToken {
             source,
         }
     }
-
-    fn with_text_owned(mut self, text: &'static str) -> Self {
-        self.text = Some(Rc::from(text));
-        self
-    }
-
-    fn with_local_sid_owned(mut self, local_sid: SymbolId) -> Self {
-        self.local_sid = Some(local_sid);
-        self
-    }
-
-    fn with_source_owned(mut self, table: &'static str, sid: SymbolId) -> Self {
-        self.source = Some(OwnedImportSource::new(table, sid));
-        self
-    }
 }
 
 /// Constructs an [`OwnedSymbolToken`] with unknown text and a local ID.
@@ -138,15 +123,15 @@ impl SymbolToken for OwnedSymbolToken {
     }
 
     fn with_text(self, text: &'static str) -> Self {
-        self.with_text_owned(text)
+        OwnedSymbolToken::new(Some(Rc::from(text)), self.local_sid, self.source)
     }
 
     fn with_local_sid(self, local_sid: SymbolId) -> Self {
-        self.with_local_sid_owned(local_sid)
+        OwnedSymbolToken::new(self.text, Some(local_sid), self.source)
     }
 
     fn with_source(self, table: &'static str, sid: SymbolId) -> Self {
-        self.with_source_owned(table, sid)
+        OwnedSymbolToken::new(self.text, self.local_sid, Some(OwnedImportSource::new(table, sid)))
     }
 }
 


### PR DESCRIPTION
*Issue #204*

*Description of changes:*
This PR works on filling in all `new_...` methods for `Builder` trait created by #199.

*Changes:*
- Added `new_...` method for all types in Builder trait
- Modified tests to use `new_...` method construct element.

*TODO:*
- Add `From<X>` for all types in `Element` trait as defined below:
```rust
trait Element 
where
     Self:From<i64> + From<f64> + … {
```
- Add generic test to verify above mentioned element constructions `e1` and `e2`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
