### PR TITLE
Version bump for `ion-rs` and `ion-c-sys`.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2021-04-18
+          toolchain: nightly-2021-04-21
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2018"
 
 [workspace]

--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.4.5"
+version = "0.4.6"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Updates coverage workflow to nightly-2021-04-21.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
