### PR TITLE
Adds doc test example for `Loader` API.

### DIFF
--- a/src/types/magnitude.rs
+++ b/src/types/magnitude.rs
@@ -3,7 +3,9 @@ use std::cmp::Ordering;
 use bigdecimal::ToPrimitive;
 use num_bigint::{BigUint, ToBigUint};
 
-/// An unsigned integer that can be combined with a [Sign] to act as the coefficient of a [Decimal].
+/// An unsigned integer that can be combined with a [Sign](crate::types::coefficient::Sign)
+/// to act as the coefficient of a [Decimal](crate::types::decimal::Decimal).
+///
 /// When possible, users should prefer to represent the integer as a [u64] for efficiency. If the
 /// integer is too large to fit in a u64, users may instead opt to represent it as a [BigUint] at
 /// the cost of allocations and runtime complexity.

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -358,7 +358,7 @@ impl TimestampBuilder {
     }
 }
 
-/// Allows the user to set the `month` field on a [TimestampBuilder] that has already had its `year`
+/// Allows the user to set the `month` field on a builder that has already had its `year`
 /// field set. Or, if `Year` is the desired precision, they may build the [Timestamp] with an
 /// unknown offset instead.
 #[derive(Debug, Clone)]
@@ -389,7 +389,7 @@ impl MonthSetter {
     }
 }
 
-/// Allows the user to set the `day` field on a [TimestampBuilder] that has already had its `year`
+/// Allows the user to set the `day` field on a builder that has already had its `year`
 /// and `month` fields set. Or, if `Month` is the desired precision, they may build the [Timestamp]
 /// with an unknown offset instead.
 #[derive(Debug, Clone)]
@@ -420,7 +420,7 @@ impl DaySetter {
     }
 }
 
-/// Allows the user to set the `hour` and `minute` fields on a [TimestampBuilder] that has already
+/// Allows the user to set the `hour` and `minute` fields on a builder that has already
 /// had its `year`, `month`, and `day` fields set. Or, if `Day` is the desired precision,
 /// they may build the [Timestamp] with an unknown offset instead.
 #[derive(Debug, Clone)]
@@ -451,7 +451,7 @@ impl HourAndMinuteSetter {
     }
 }
 
-/// Allows the user to set the `second` field on a [TimestampBuilder] that has already
+/// Allows the user to set the `second` field on a builder that has already
 /// had its `year`, `month`, `day`, `hour`, and `minute` fields set. Or, if `HourAndMinute` is the
 /// desired precision, they may build the [Timestamp] instead, optionally specifying an offset if
 /// known.
@@ -479,7 +479,7 @@ impl SecondSetter {
     }
 }
 
-/// Allows the user to set the `fractional_seconds` field on a [TimestampBuilder] that has already
+/// Allows the user to set the `fractional_seconds` field on a builder that has already
 /// had its `year`, `month`, `day`, `hour`, `minute`, and `second` fields set. Or, if
 /// `Second` is the desired precision, they may build the [Timestamp] instead, optionally
 /// specifying an offset if known.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -10,9 +10,30 @@
 //! * The [`borrowed`] module provides an implementation of values that are tied to some
 //!   associated lifetime and borrow a reference to their underlying data in some way
 //!   (e.g. storing a `&str` in the value versus a fully owned `String`).
+//! * The [`loader`] module provides API and implementation to load Ion data into [`Element`]
+//!   instances.
 //!
 //! ## Examples
-//! In general, users should use the traits in this module to make their code work
+//! In general, users will use the [`loader::Loader`] trait to load in data:
+//!
+//! ```
+//! use ion_rs::IonType;
+//! use ion_rs::result::IonResult;
+//! use ion_rs::value::{Element, Struct};
+//! use ion_rs::value::loader::loader;
+//! use ion_rs::value::loader::Loader;
+//!
+//! fn main() -> IonResult<()> {
+//!     let mut iter = loader().iterate_over(br#""hello!"#)?;
+//!     if let Some(Ok(elem)) = iter.next() {
+//!         assert_eq!(IonType::String, elem.ion_type());
+//!         assert_eq!("hello!", elem.as_str().unwrap());
+//!     }
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Users should use the traits in this module to make their code work
 //! in contexts that have either [`borrowed`] or [`owned`] values.  This can be done
 //! most easily by writing generic functions that can work with a reference of any type.
 //!


### PR DESCRIPTION
* Fixes lifetimes on `Loader`.
* Cleans up `loader` module documentation a bit.
* Fixes references in `magnitude` and `timestamp` modules.

Fixes #208.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
