### PR TITLE
Scaffold a subcrate for ion-hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 [workspace]
 members = [
   "ion-c-sys",
+  "ion-hash"
 ]
 
 [dependencies]

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ion-hash"
+authors = ["Amazon Ion Team <ion-team@amazon.com>"]
+description = "Ion Hash"
+homepage = "https://github.com/amzn/ion-rust"
+repository = "https://github.com/amzn/ion-rust"
+license = "Apache-2.0"
+readme = "README.md"
+keywords = ["ion", "parser", "json", "format", "serde", "hash"]
+categories = ["encoding", "parser-implementations", "hashing"]
+exclude = [
+    "**/.git/**",
+    "**/.github/**",
+    "**/.travis.yml",
+    "**/.appveyor.yml",
+    "**/ion-tests/iontestdata/**",
+    "*.pdf"
+]
+version = "0.0.1"
+edition = "2018"
+
+[dependencies]
+ion-rs = { path = "../", version = "0.4" }

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -21,3 +21,8 @@ edition = "2018"
 
 [dependencies]
 ion-rs = { path = "../", version = "0.4" }
+ion-c-sys = { path = "../ion-c-sys", version = "0.4" }
+sha2 = { version = "0.9.3" }
+
+[dev-dependencies]
+hex-literal = "0.3.1"

--- a/ion-hash/README.md
+++ b/ion-hash/README.md
@@ -1,0 +1,19 @@
+# `ion-hash-rust`
+
+[![Crate](https://img.shields.io/crates/v/ion-hash.svg)](https://crates.io/crates/ion-hash)
+[![Docs](https://docs.rs/ion-hash/badge.svg)](https://docs.rs/ion-hash)
+[![License](https://img.shields.io/crates/l/ion-hash)](https://crates.io/crates/ion-hash)
+[![CI Build](https://github.com/amzn/ion-rust/workflows/CI%20Build/badge.svg)](https://github.com/amzn/ion-rust/actions?query=workflow%3A%22CI+Build%22)
+
+A Rust implementation of [Ion Hash][spec].
+
+***This package is considered experimental, under active/early development, and the API is subject to change.***
+
+## Development
+
+See [Ion Rust][ion-rust] for details.  This crate is currently developed in concert with Ion Rust
+as a [Cargo workspace][cargo-workspace].
+
+[ion-rust]: https://github.com/amzn/ion-rust
+[spec]: https://amzn.github.io/ion-hash/docs/spec.html
+[cargo-workspace]: https://doc.rust-lang.org/cargo/reference/workspaces.html

--- a/ion-hash/src/lib.rs
+++ b/ion-hash/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+//! Implement Ion Hash as per the [spec](https://amzn.github.io/ion-hash/docs/spec.html)
+//!
+//! ## Examples
+//! Coming soon.

--- a/ion-hash/src/lib.rs
+++ b/ion-hash/src/lib.rs
@@ -3,4 +3,118 @@
 //! Implement Ion Hash as per the [spec](https://amzn.github.io/ion-hash/docs/spec.html)
 //!
 //! ## Examples
-//! Coming soon.
+//! ```rust
+//! use ion_rs::value::loader::{self, Loader};
+//! use ion_rs::result::IonResult;
+//!
+//! # fn main() -> IonResult<()> {
+//!   let loader = loader::loader();
+//!   let elem = loader.iterate_over(b"\"hello world\"")?.next().unwrap()?;
+//!   let digest = ion_hash::sha256(&elem);
+//!   println!("{:?}", digest);
+//! # Ok(())
+//! # }
+//! ```
+
+use ion_rs::{
+    value::{owned::OwnedElement, Element},
+    IonType,
+};
+
+use sha2::{digest::Output, Digest, Sha256};
+
+pub fn sha256(elem: &OwnedElement) -> Vec<u8> {
+    let mut hasher = IonHasher::new(Sha256::new());
+    let result = hasher.visit_element(elem);
+    Vec::from(result.as_slice())
+}
+
+/// Bytes markers as per the spec.
+mod markers {
+    /// single byte begin marker
+    pub(crate) const B: u8 = 0x0B;
+    /// single byte end marker
+    pub(crate) const E: u8 = 0x0E;
+    /// single byte escape
+    pub(crate) const ESC: u8 = 0x0C;
+    /// type qualifier octet consisting of a four-bit type code T followed by a four-bit qualifier Q
+    /// (this varies per type)
+    pub(crate) const TQ_STRING: u8 = 0x80;
+}
+
+// TODO: In the fullness of time, we will have a IonHashReader and a
+// IonHashWriter. This will allow reading/writing a value *while* computing a
+// hash. For now, we provide a standalone hasher using the OwnedElement API.
+pub struct IonHasher<D>
+where
+    D: Digest,
+{
+    hasher: D,
+}
+
+impl<D> IonHasher<D>
+where
+    D: Digest,
+{
+    fn new(hasher: D) -> IonHasher<D> {
+        IonHasher { hasher }
+    }
+
+    fn visit_element(&mut self, elem: &OwnedElement) -> Output<D> {
+        let serialized_bytes = match elem.ion_type() {
+            IonType::Null => todo!(),
+            IonType::Boolean => todo!(),
+            IonType::Integer => todo!(),
+            IonType::Float => todo!(),
+            IonType::Decimal => todo!(),
+            IonType::Timestamp => todo!(),
+            IonType::Symbol => todo!(),
+            IonType::String => self.visit_string(elem.as_str().unwrap()),
+            IonType::Clob => todo!(),
+            IonType::Blob => todo!(),
+            IonType::List => todo!(),
+            IonType::SExpression => todo!(),
+            IonType::Struct => todo!(),
+        };
+
+        self.hasher.update(serialized_bytes);
+        self.hasher.finalize_reset()
+    }
+
+    fn visit_string(&mut self, value: &str) -> Vec<u8> {
+        let representation = value.as_bytes();
+        let mut serialized_bytes = vec![markers::B, markers::TQ_STRING];
+        serialized_bytes.extend(ion_hash_escape(representation));
+        serialized_bytes.push(markers::E);
+        serialized_bytes
+    }
+}
+
+/// Replaces each marker byte M with ESC || M.
+fn ion_hash_escape(representation: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(representation.len());
+    for byte in representation {
+        if let markers::B | markers::E | markers::ESC = *byte {
+            out.push(0x0C);
+        }
+        out.push(*byte);
+    }
+
+    out
+}
+
+// TODO: Use the ion-hash test suite
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+    use ion_rs::value::owned::*;
+
+    #[test]
+    fn ion_hash_sha256_string() {
+        let expected = hex!("82c4010bfc9cace7f645c0a951243b9b122cb5ba21b60b3f71ea79c513c39342");
+        let hello_world = OwnedElement::new(vec![], OwnedValue::String("hello world".to_string()));
+        let computed = sha256(&hello_world);
+        assert_eq!(expected, &computed[..]);
+    }
+}


### PR DESCRIPTION
Not sure we want this to live here forever, but this should let us
iterate in lock step with the in-development ion-rs crate.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
