### PR TITLE
Adds `Loader::load_one` convenience method.

### DIFF
--- a/src/value/loader.rs
+++ b/src/value/loader.rs
@@ -49,7 +49,7 @@ pub trait Loader {
     }
 
     /// Parses Ion over a given slice into a single [`Element`](super::Element) instance.
-    /// Returning [`IonError`](crate::result::IonError) if any error occurs during the parse
+    /// Returns [`IonError`](crate::result::IonError) if any error occurs during the parse
     /// or there is more than one top-level [`Element`](super::Element) in the data.
     #[inline]
     fn load_one(&self, data: &[u8]) -> IonResult<OwnedElement> {

--- a/src/value/loader.rs
+++ b/src/value/loader.rs
@@ -48,7 +48,7 @@ pub trait Loader {
         self.iterate_over(data)?.collect()
     }
 
-    /// Parses given Ion over a given slice into a single [`Element`](super::Element) instance.
+    /// Parses Ion over a given slice into a single [`Element`](super::Element) instance.
     /// Returning [`IonError`](crate::result::IonError) if any error occurs during the parse
     /// or there is more than one top-level [`Element`](super::Element) in the data.
     #[inline]

--- a/src/value/loader.rs
+++ b/src/value/loader.rs
@@ -3,7 +3,7 @@
 //! Provides utility to load Ion data into [`Element`](super::Element) from different sources such
 //! as slices or files.
 
-use crate::result::IonResult;
+use crate::result::{decoding_error, IonResult};
 use crate::value::owned::{OwnedElement, OwnedSequence, OwnedStruct, OwnedSymbolToken, OwnedValue};
 use crate::value::AnyInt;
 use crate::IonType;
@@ -43,8 +43,31 @@ pub trait Loader {
 
     /// Parses given Ion over a given slice into an [`Vec`] returning an
     /// [`IonError`](crate::result::IonError) if any error occurs during the parse.
+    #[inline]
     fn load_all(&self, data: &[u8]) -> IonResult<Vec<OwnedElement>> {
         self.iterate_over(data)?.collect()
+    }
+
+    /// Parses given Ion over a given slice into a single [`Element`](super::Element) instance.
+    /// Returning [`IonError`](crate::result::IonError) if any error occurs during the parse
+    /// or there is more than one top-level [`Element`](super::Element) in the data.
+    #[inline]
+    fn load_one(&self, data: &[u8]) -> IonResult<OwnedElement> {
+        let mut iter = self.iterate_over(data)?;
+        match iter.next() {
+            Some(Ok(elem)) => {
+                // make sure there is nothing else
+                match iter.next() {
+                    None => Ok(elem),
+                    Some(Ok(_)) => {
+                        decoding_error("Expected a single element, but there was more than one")
+                    }
+                    Some(other) => other,
+                }
+            }
+            Some(other) => other,
+            None => decoding_error("Expected a single element, data was empty"),
+        }
     }
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -58,6 +58,39 @@
 //! # }
 //! ```
 //!
+//! [`Loader::load_one`](loader::Loader::load_one) is another convenient way to parse a single
+//! top-level element into a [`Element`].  This method will return an error if the data has
+//! a parsing error or if there is more than one [`Element`] in the stream:
+//!
+//! ```
+//! # use ion_rs::IonType;
+//! # use ion_rs::result::IonResult;
+//! # use ion_rs::value::{Element, IntAccess, Struct};
+//! # use ion_rs::value::loader::loader;
+//! # use ion_rs::value::loader::Loader;
+//! # fn main() -> IonResult<()> {
+//! #
+//! // load a single value from binary: 42
+//! let elem = loader().load_one(&[0xE0, 0x01, 0x00, 0xEA, 0x21, 0x2A])?;
+//! assert_eq!(IonType::Integer, elem.ion_type());
+//! assert_eq!(42, elem.as_i64().unwrap());
+//!
+//! // cannot load two values in a stream this way: 42 0
+//! assert!(loader().load_one(&[0xE0, 0x01, 0x00, 0xEA, 0x21, 0x2A, 0x20]).is_err());
+//!
+//! // cannot load an empty stream (binary IVM only)
+//! assert!(loader().load_one(&[0xE0, 0x01, 0x00, 0xEA]).is_err());
+//!
+//! // normal malformed binary is a failure!
+//! assert!(loader().load_one(&[0xE0, 0x01, 0x00, 0xEA, 0xF0]).is_err());
+//!
+//! // also an error if malformed data happens after valid single value
+//! assert!(loader().load_one(&[0xE0, 0x01, 0x00, 0xEA, 0x20, 0x30]).is_err());
+//! #
+//! #    Ok(())
+//! # }
+//! ```
+//!
 //! Users should use the traits in this module to make their code work
 //! in contexts that have either [`borrowed`] or [`owned`] values.  This can be done
 //! most easily by writing generic functions that can work with a reference of any type.

--- a/tests/loader_test_vectors.rs
+++ b/tests/loader_test_vectors.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-use ion_rs::result::{decoding_error, IonResult};
+use ion_rs::result::{decoding_error, IonError, IonResult};
 use ion_rs::value::loader::{loader, Loader};
 use ion_rs::value::owned::OwnedElement;
 use ion_rs::value::{Element, Sequence, SymbolToken};
@@ -33,6 +33,12 @@ const ALL_SKIP_LIST: &[&str] = &[
     "ion-tests/iontestdata/good/typecodes/T7-small.10n",
 ];
 
+/// Files that should not be tested for equivalence with load_one against load_all
+const LOAD_ONE_EQUIVS_SKIP_LIST: &[&str] = &[
+    // we need a structural equality (IonEq) for these (amzn/ion-rust#220)
+    "ion-tests/iontestdata/good/floatSpecials.ion",
+];
+
 /// Files that should only be skipped in equivalence file testing
 const EQUIVS_SKIP_LIST: &[&str] = &[
     // ion-c seems to have a problem with negative binary literals (amzn/ion-c#235)
@@ -61,20 +67,64 @@ fn concat<'a>(left: &[&'a str], right: &[&'a str]) -> Vec<&'a str> {
         .collect()
 }
 
-fn load_file<L: Loader>(loader: &L, file_name: &str) -> IonResult<Vec<OwnedElement>> {
-    // TODO have a better API that doesn't require buffering into memory everything...
-    let data = read(file_name)?;
-    loader.load_all(&data)
-}
-
-fn assert_file<T, F: FnOnce() -> IonResult<T>>(skip_list: &[&str], file_name: &str, asserter: F) {
-    if skip_list
+/// Determines if the given file name is in the paths list.  This deals with platform
+/// path separator differences from '/' separators in the path list.
+#[inline]
+fn contains_path(paths: &[&str], file_name: &str) -> bool {
+    paths
         .into_iter()
         // TODO construct the paths in a not so hacky way
         .map(|p| p.replace("/", &PATH_SEPARATOR.to_string()))
         .find(|p| p == file_name)
         .is_some()
-    {
+}
+
+fn load_file<L: Loader>(loader: &L, file_name: &str) -> IonResult<Vec<OwnedElement>> {
+    // TODO have a better API that doesn't require buffering into memory everything...
+    let data = read(file_name)?;
+    let result = loader.load_all(&data);
+
+    // do some simple single value loading tests
+    let single_result = loader.load_one(&data);
+    match &result {
+        Ok(elems) => {
+            if elems.len() == 1 {
+                match single_result {
+                    Ok(elem) => {
+                        // only compare if we know equality to work
+                        if !contains_path(LOAD_ONE_EQUIVS_SKIP_LIST, file_name) {
+                            assert_eq!(elems[0], elem)
+                        }
+                    }
+                    Err(e) => panic!("Expected element {:?}, got {:?}", elems, e),
+                }
+            } else {
+                match single_result {
+                    Ok(elem) => panic!(
+                        "Did not expect element for duplicates: {:?}, {:?}",
+                        elems, elem
+                    ),
+                    Err(e) => match e {
+                        IonError::DecodingError { description: _ } => (),
+                        other => {
+                            panic!("Got an error we did not expect for duplicates: {:?}", other)
+                        }
+                    },
+                }
+            }
+        }
+        Err(_) => assert!(
+            single_result.is_err(),
+            "Expected error from load_one: {:?}",
+            single_result
+        ),
+    };
+
+    result
+}
+
+fn assert_file<T, F: FnOnce() -> IonResult<T>>(skip_list: &[&str], file_name: &str, asserter: F) {
+    if contains_path(skip_list, file_name) {
         println!("IGNORING: {}", file_name);
     } else {
         println!("TESTING: {}", file_name);


### PR DESCRIPTION
* Adds doc test examples for this API.
* Adds support in the loader integration tests for `load_one`.

Resolves #211.

Based on #217.

Here is an example of the rendered docs:
![image](https://user-images.githubusercontent.com/503506/116004581-3d8abc80-a5b8-11eb-8d82-57f22a731cc3.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
