### PR TITLE
Adds `TryInto<IonDateTime>` for `Timestamp`.

### DIFF
--- a/src/types/coefficient.rs
+++ b/src/types/coefficient.rs
@@ -1,6 +1,7 @@
 use num_bigint::{BigInt, BigUint};
 use num_traits::Zero;
 
+use crate::result::{illegal_operation, IonError};
 use crate::types::magnitude::Magnitude;
 use std::convert::TryFrom;
 use std::ops::MulAssign;
@@ -80,15 +81,13 @@ impl_coefficient_from_signed_int_types!(i8, i16, i32, i64, i128, isize);
 
 // `BigInt` can't represent -0, so this is technically a lossy operation.
 impl TryFrom<Coefficient> for BigInt {
-    //TODO: There's only one possible cause of failure for this method, but it would still be nice
-    //      to return an error type that's more descriptive than `()`.
-    type Error = ();
+    type Error = IonError;
 
     /// Attempts to create a BigInt from a Coefficient. Returns an Error if the Coefficient being
     /// converted is a negative zero, which BigInt cannot represent. Returns Ok otherwise.
     fn try_from(value: Coefficient) -> Result<Self, Self::Error> {
         if value.is_negative_zero() {
-            return Err(());
+            illegal_operation("Cannot convert negative zero Decimal to BigDecimal")?;
         }
         let mut big_int: BigInt = match value.magnitude {
             Magnitude::U64(m) => m.into(),

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use bigdecimal::{BigDecimal, Signed};
 use num_bigint::{BigInt, BigUint, ToBigUint};
 
+use crate::result::IonError;
 use crate::types::coefficient::{Coefficient, Sign};
 use crate::types::magnitude::Magnitude;
 use std::convert::{TryFrom, TryInto};
@@ -169,9 +170,7 @@ impl From<BigDecimal> for Decimal {
 }
 
 impl TryFrom<Decimal> for BigDecimal {
-    //TODO: There's only one possible cause of failure for this method, but it would still be nice
-    //      to return an error type that's more descriptive than `()`.
-    type Error = ();
+    type Error = IonError;
     /// Attempts to create a BigDecimal from a Decimal. Returns an Error if the Decimal being
     /// converted is a negative zero, which BigDecimal cannot represent. Returns Ok otherwise.
     fn try_from(value: Decimal) -> Result<Self, Self::Error> {
@@ -183,6 +182,7 @@ impl TryFrom<Decimal> for BigDecimal {
 
 #[cfg(test)]
 mod decimal_tests {
+    use crate::result::IonError;
     use crate::types::coefficient::{Coefficient, Sign};
     use crate::types::decimal::Decimal;
     use bigdecimal::BigDecimal;
@@ -225,15 +225,15 @@ mod decimal_tests {
         // Any form of negative zero will fail to be converted.
 
         let decimal = Decimal::negative_zero();
-        let conversion_result: Result<BigDecimal, ()> = decimal.try_into();
+        let conversion_result: Result<BigDecimal, IonError> = decimal.try_into();
         assert!(conversion_result.is_err());
 
         let decimal = Decimal::negative_zero_with_exponent(6);
-        let conversion_result: Result<BigDecimal, ()> = decimal.try_into();
+        let conversion_result: Result<BigDecimal, IonError> = decimal.try_into();
         assert!(conversion_result.is_err());
 
         let decimal = Decimal::negative_zero_with_exponent(-6);
-        let conversion_result: Result<BigDecimal, ()> = decimal.try_into();
+        let conversion_result: Result<BigDecimal, IonError> = decimal.try_into();
         assert!(conversion_result.is_err());
     }
 


### PR DESCRIPTION
Also Makes `TryFrom<Coefficient>` and `TryFrom<BigDecimal>` have
an associated error type be `IonError`.

This provides marginal utility for #209.

Prerequisite for #197.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
