### PR TITLE
Updates versions for crates for publishing `ion-hash`.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2021-04-21
+          toolchain: nightly-2021-04-24
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 
 [workspace]

--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.4.6"
+version = "0.4.7"
 edition = "2018"
 
 [dependencies]

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.0.1"
 edition = "2018"
 
 [dependencies]
-ion-rs = { path = "../", version = "0.4" }
+ion-rs = { path = "../", version = "0.5" }
 ion-c-sys = { path = "../ion-c-sys", version = "0.4" }
 sha2 = { version = "0.9.3" }
 


### PR DESCRIPTION
Updates code coverage for `nightly-2021-04-24`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
