### PR TITLE
Updates version for `ion-hash`.

### DIFF
--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -6,8 +6,8 @@ homepage = "https://github.com/amzn/ion-rust"
 repository = "https://github.com/amzn/ion-rust"
 license = "Apache-2.0"
 readme = "README.md"
-keywords = ["ion", "parser", "json", "format", "serde", "hash"]
-categories = ["encoding", "parser-implementations", "hashing"]
+keywords = ["ion", "parser", "json", "format", "hash"]
+categories = ["encoding", "parser-implementations", "cryptography"]
 exclude = [
     "**/.git/**",
     "**/.github/**",
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Fixes some meta-data for crates.io:
* Removes a keyword because of the 5 keyword limit on crates.io.
* Updates the keyword slug from `hash` to `cryptography`.
  - As per https://crates.io/category_slugs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
