### PR TITLE
Changes the "Remove MSys64" CI Step for Windows.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,9 +14,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - name: Remove msys64
+      - name: Remove MSys64 MingW64 Binaries
         if: runner.os == 'Windows'
-        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
+        # remove this because there is a bad libclang.dll that confuses bindgen
+        run: Remove-Item -LiteralPath "C:\msys64\mingw64\bin" -Force -Recurse
       - name: Install Dependencies
         if: runner.os == 'Windows'
         run: choco install llvm -y


### PR DESCRIPTION
Doing the recursive delete is really slow sometimes taking up to 10
minutes.  This change just targets the directory with the `libclang.dll`
that is problematic for `bindgen`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
