### PR TITLE
Include current reader position in errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 [workspace]
 members = [
   "ion-c-sys",
+  "ion-c-sys-macros",
   "ion-hash"
 ]
 

--- a/ion-c-sys-macros/Cargo.toml
+++ b/ion-c-sys-macros/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ion-c-sys-macros"
+authors = ["Amazon Ion Team <ion-team@amazon.com>"]
+description = "Macros used to implement ion-c-sys"
+homepage = "https://github.com/amzn/ion-rust"
+repository = "https://github.com/amzn/ion-rust"
+license = "Apache-2.0"
+readme = "README.md"
+keywords = ["ion", "parser", "json", "format", "serde"]
+categories = ["encoding", "parser-implementations"]
+exclude = [
+  "**/.git/**",
+  "**/.github/**",
+]
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0.72", features = ["full"] }
+quote = "1.0.9"
+proc-macro2 = "1.0.26"

--- a/ion-c-sys-macros/src/lib.rs
+++ b/ion-c-sys-macros/src/lib.rs
@@ -1,0 +1,89 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{parse_quote, FnArg, Ident, PatType, ReturnType};
+
+/// This macro is intended to support the `IonCReaderHandle` type. When any
+/// function returns an `IonCError`, the error should be populated with the
+/// current reader position.
+///
+/// Without this macro, errors could be decorated like so:
+///
+/// ```no_test
+/// fn foo() -> IonCResult<()> {
+///     fn1().map_err(|err| include_current_position(self.reader, err))?
+///     // ...
+///     Ok(())
+/// }
+/// ```
+///
+/// However, functions can fail in many places, so decorating each of these with
+/// `map_err` is tedious and error prone:
+///
+/// ```no_test
+/// fn foo() -> IonCResult<()> {
+///   fn1()?.map_err(..);
+///   fn2()?.map_err(..);
+/// }
+/// ```
+///
+/// This macro rewrites the function such that any error gets the position
+/// added. It does this by moving the existing implementation into a closure and
+/// then calling `map_err` on the result.
+///
+/// ***Note***: to make the variety of possible functions work (which include mutable
+/// borrows, lifetime elision), the closure uses the `move` keyword. There are
+/// some gymnastics (adapted from ***[dtolnay/no-panic][no-panic]***) to make that work out.
+///
+/// [no-panic]: https://github.com/dtolnay/no-panic
+#[proc_macro_attribute]
+pub fn position_error(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut function = syn::parse_macro_input!(item as syn::ItemFn);
+
+    // this is heavily adapted for dtolnay/panic - as this code evolves to deal
+    // with rustc/ion-c-sys changes refer to to the above for any changes
+    // here...
+    let mut move_self = None;
+    let mut arg_pat = Vec::new();
+    let mut arg_val = Vec::new();
+    for (i, input) in function.sig.inputs.iter_mut().enumerate() {
+        let numbered = Ident::new(&format!("__arg{}", i), Span::call_site());
+        match input {
+            FnArg::Typed(PatType { pat, .. }) => {
+                arg_pat.push(quote!(#pat));
+                arg_val.push(quote!(#numbered));
+                *pat = parse_quote!(mut #numbered);
+            }
+            FnArg::Receiver(_) => {
+                move_self = Some(quote! {
+                    if false {
+                        loop {}
+                        #[allow(unreachable_code)]
+                        {
+                            let __self = self;
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    let ret = match &function.sig.output {
+        ReturnType::Default => quote!(-> ()),
+        output @ ReturnType::Type(..) => quote!(#output),
+    };
+    let stmts = function.block.stmts;
+    function.block = Box::new(parse_quote!({
+        let reader = self.reader;
+        let __result = (move || #ret {
+            #move_self
+            #(
+                let #arg_pat = #arg_val;
+            )*
+            #(#stmts)*
+        })();
+        __result.map_err(|err| include_current_position(&reader, err))
+    }));
+
+    TokenStream::from(quote!(#function))
+}

--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -20,6 +20,7 @@ version = "0.4.10"
 edition = "2018"
 
 [dependencies]
+ion-c-sys-macros = { version = "0.1", path = "../ion-c-sys-macros" }
 paste = "1.0"
 num-bigint = "0.3"
 bigdecimal = "0.2"

--- a/src/value/reader.rs
+++ b/src/value/reader.rs
@@ -230,7 +230,7 @@ mod reader_tests {
     use crate::value::{AnyInt, Element};
     use crate::IonType;
     use bigdecimal::BigDecimal;
-    use ion_c_sys::result::IonCError;
+    use ion_c_sys::result::{IonCError, Position};
     use ion_c_sys::{
         ion_error_code_IERR_INVALID_BINARY, ion_error_code_IERR_INVALID_STATE,
         ion_error_code_IERR_NULL_VALUE,
@@ -442,7 +442,9 @@ mod reader_tests {
             $10
         "#,
         vec![
-            Err(IonCError::from(ion_error_code_IERR_NULL_VALUE).into())
+            Err(IonCError::from(ion_error_code_IERR_NULL_VALUE)
+                .with_position(Position::text(124, 4, 8))
+                .into())
         ]
     )]
     #[case::unknown_shared_symbol_field_name(
@@ -454,19 +456,25 @@ mod reader_tests {
             {$10:5}
         "#,
         vec![
-            Err(IonCError::from(ion_error_code_IERR_NULL_VALUE).into())
+            Err(IonCError::from(ion_error_code_IERR_NULL_VALUE)
+                .with_position(Position::text(157, 1, 5))
+                .into())
         ]
     )]
     #[case::illegal_negative_zero_int(
         &[0xE0, 0x01, 0x00, 0xEA, 0x30],
         vec![
-            Err(IonCError::from(ion_error_code_IERR_INVALID_BINARY).into())
+            Err(IonCError::from(ion_error_code_IERR_INVALID_BINARY)
+                .with_position(Position::binary(5))
+                .into())
         ]
     )]
     #[case::illegal_fcode(
         &[0xE0, 0x01, 0x00, 0xEA, 0xF0],
         vec![
-            Err(IonCError::from(ion_error_code_IERR_INVALID_STATE).into())
+            Err(IonCError::from(ion_error_code_IERR_INVALID_STATE)
+                .with_position(Position::binary(5))
+                .into())
         ]
     )]
     /// Like read_and_compare, but against results (which makes it easier to test for errors).


### PR DESCRIPTION
 Introduce Position, populate in IonCReader

This commit introduces a `Position` type that represents the bytes,
lines and offset into data. Essentially, this mirrors the ion-c
`ion_reader_get_position` API. The `Reader` trait can produce one of
these via a new method, `Reader::pos()`.

A new proc macro `#[position_error]` automatically calls this API if any
of the `Reader` methods fail. The resulting `Position` is stored in
`IonCError::position`.

The motivation behind this commit is quite simple: while working on
ion-hash, the ion_hash_tests.ion sample failed to load. All I got was a
test failure with a `Result` that said "null": not super helpful! No
backtraces, nada. Now, the error includes the exact place where the
Reader produced the Err variant from!


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
