### PR TITLE
changed PartialEq for struct for symmetry bug

### DIFF
--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -375,7 +375,11 @@ impl<'val> PartialEq for BorrowedStruct<'val> {
     fn eq(&self, other: &Self) -> bool {
         // check if both text_fields and no_text_fields have same length
         self.text_fields.len() == other.text_fields.len() && self.no_text_fields.len() == other.no_text_fields.len()
-        // check if text_fields and no_text_fields are equal
+        // check if text_fields and no_text_fields are equal 
+        // we need to test equality in both directions for both text_fields and no_text_fields
+        // A good example for this is annotated vs not annotated values in struct
+        //  { a:4, a:4 } vs. { a:4, a:a::4 } // returns true
+        //  { a:4, a:a::4 } vs. { a:4, a:4 } // returns false 
         && self.eq_text_fields(other) && other.eq_text_fields(self)
             && self.eq_no_text_fields(other) && other.eq_no_text_fields(self)
     }

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -373,7 +373,7 @@ impl<'val> Struct for BorrowedStruct<'val> {
 
 impl<'val> PartialEq for BorrowedStruct<'val> {
     fn eq(&self, other: &Self) -> bool {
-        // check if both test_fields and no_text_fields have same length
+        // check if both text_fields and no_text_fields have same length
         self.text_fields.len() == other.text_fields.len() && self.no_text_fields.len() == other.no_text_fields.len()
         // check if text_fields and no_text_fields are equal
         && self.eq_text_fields(other) && other.eq_text_fields(self)

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -363,7 +363,8 @@ impl<'val> PartialEq for BorrowedStruct<'val> {
                 .iter()
                 .find(|(other_k, other_v)| my_k == other_k && my_v == other_v)
                 .is_some()
-        })
+        }) && self.text_fields.len() == other.text_fields.len()
+            && self.no_text_fields.len() == other.no_text_fields.len()
     }
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1340,6 +1340,46 @@ mod generic_value_tests {
         }
     }
 
+    fn struct_with_different_length_multiple_fields_case<E: Element>() -> Case<E>
+    where
+        E::Builder: Builder<SymbolToken = E::SymbolToken>,
+    {
+        Case {
+            elem: E::Builder::new_struct(
+                vec![
+                    (
+                        E::SymbolToken::text_token("greetings"),
+                        E::Builder::new_string("hello"),
+                    ),
+                    (
+                        E::SymbolToken::text_token("name"),
+                        E::Builder::new_string("Ion"),
+                    ),
+                ]
+                .into_iter(),
+            ),
+            ion_type: IonType::Struct,
+            ops: vec![AsStruct],
+            op_assert: Box::new(|e: &E| {
+                let actual = e.as_struct().unwrap();
+                // expected struct has different length
+                let unordered_struct = E::Builder::new_struct(
+                    vec![(
+                        E::SymbolToken::text_token("name"),
+                        E::Builder::new_string("Ion"),
+                    )]
+                    .into_iter(),
+                );
+                let expected = unordered_struct.as_struct().unwrap();
+                assert_eq!(actual.get("name"), expected.get("name"));
+                // expected struct doesn't contain field with field name "greetings"
+                assert_ne!(actual.get("greetings"), expected.get("greetings"));
+                assert_ne!(actual, expected);
+                assert_ne!(expected, actual);
+            }),
+        }
+    }
+
     fn struct_with_multiple_fields_not_equal_case<E: Element>() -> Case<E>
     where
         E::Builder: Builder<SymbolToken = E::SymbolToken>,
@@ -1555,6 +1595,8 @@ mod generic_value_tests {
     #[case::borrowed_struct_with_multiple_fields(struct_with_multiple_fields_case::<BorrowedElement>())]
     #[case::owned_struct_with_unordered_multiple_fields(struct_with_unordered_multiple_fields_case::<OwnedElement>())]
     #[case::borrowed_struct_with_unordered_multiple_fields(struct_with_unordered_multiple_fields_case::<BorrowedElement>())]
+    #[case::owned_struct_with_different_length_multiple_fields(struct_with_different_length_multiple_fields_case::<OwnedElement>())]
+    #[case::borrowed_struct_with_different_length_multiple_fields(struct_with_different_length_multiple_fields_case::<BorrowedElement>())]
     #[case::owned_struct_with_multiple_fields_not_equal(struct_with_multiple_fields_not_equal_case::<OwnedElement>())]
     #[case::borrowed_struct_with_multiple_fields_not_equal(struct_with_multiple_fields_not_equal_case::<BorrowedElement>())]
     #[case::owned_struct_with_text_and_duplicates(struct_with_text_and_duplicates_case::<OwnedElement>())]

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -838,6 +838,395 @@ mod generic_value_tests {
         }
     }
 
+    struct CaseStruct<E: Element> {
+        eq_annotations: Vec<E>,
+        ne_annotations: Vec<E>,
+    }
+
+    fn struct_with_local_sid_case<E: Element>() -> CaseStruct<E>
+    where
+        E::Builder: Builder<SymbolToken = E::SymbolToken>,
+    {
+        CaseStruct {
+            eq_annotations: vec![
+                E::Builder::new_struct(
+                    vec![(
+                        E::SymbolToken::local_sid_token(21),
+                        E::Builder::new_string("hello"),
+                    )]
+                    .into_iter(),
+                ),
+                // SymbolToken with local SID and no text are equivalent to each other and to SID $0
+                E::Builder::new_struct(
+                    vec![(
+                        E::SymbolToken::local_sid_token(22),
+                        E::Builder::new_string("hello"),
+                    )]
+                    .into_iter(),
+                ),
+            ],
+            ne_annotations: vec![
+                // structs with different symbol token values
+                E::Builder::new_struct(
+                    vec![(
+                        E::SymbolToken::local_sid_token(21).with_text("foo"),
+                        E::Builder::new_string("hello"),
+                    )]
+                    .into_iter(),
+                ),
+                // struct with annotated value
+                E::Builder::new_struct(
+                    vec![(
+                        E::SymbolToken::local_sid_token(21),
+                        E::Builder::new_string("hello")
+                            .with_annotations(vec![E::SymbolToken::text_token("foo")]),
+                    )]
+                    .into_iter(),
+                ),
+                // struct with different value for (field,value) pair
+                E::Builder::new_struct(
+                    vec![(E::SymbolToken::local_sid_token(21), E::Builder::new_i64(10))]
+                        .into_iter(),
+                ),
+                // structs with different fields length
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::local_sid_token(21),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::local_sid_token(21),
+                            E::Builder::new_string("hi"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+            ],
+        }
+    }
+
+    fn struct_with_import_source_case<E: Element>() -> CaseStruct<E>
+    where
+        E::Builder: Builder<SymbolToken = E::SymbolToken>,
+    {
+        CaseStruct {
+            eq_annotations: vec![
+                E::Builder::new_struct(
+                    vec![(
+                        E::SymbolToken::local_sid_token(21).with_source("hello_table", 2),
+                        E::Builder::new_string("hello"),
+                    )]
+                    .into_iter(),
+                ),
+                // SymbolToken with local SID and no text are equivalent to each other and to SID $0
+                E::Builder::new_struct(
+                    vec![(
+                        E::SymbolToken::local_sid_token(22).with_source("hello_table", 2),
+                        E::Builder::new_string("hello"),
+                    )]
+                    .into_iter(),
+                ),
+            ],
+            ne_annotations: vec![
+                // structs with different symbol token sources
+                E::Builder::new_struct(
+                    vec![(
+                        E::SymbolToken::local_sid_token(21).with_source("hey_table", 2),
+                        E::Builder::new_string("hello"),
+                    )]
+                    .into_iter(),
+                ),
+                // structs with different fields length
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::local_sid_token(21).with_source("hello_table", 2),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::local_sid_token(21),
+                            E::Builder::new_string("hi"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+            ],
+        }
+    }
+
+    fn struct_with_multiple_fields_case<E: Element>() -> CaseStruct<E>
+    where
+        E::Builder: Builder<SymbolToken = E::SymbolToken>,
+    {
+        CaseStruct {
+            eq_annotations: vec![
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("name"),
+                            E::Builder::new_string("Ion"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with different order of fields
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("name"),
+                            E::Builder::new_string("Ion"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+            ],
+            ne_annotations: vec![
+                // structs with different length and duplicates
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("name"),
+                            E::Builder::new_string("Ion"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with different fields length and duplicates
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("name"),
+                            E::Builder::new_string("Ion"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("bye"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with different fields length
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("name"),
+                            E::Builder::new_string("Ion"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("message"),
+                            E::Builder::new_string("bye"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+            ],
+        }
+    }
+
+    fn struct_with_duplicates_in_multiple_fields_case<E: Element>() -> CaseStruct<E>
+    where
+        E::Builder: Builder<SymbolToken = E::SymbolToken>,
+    {
+        CaseStruct {
+            eq_annotations: vec![
+                E::Builder::new_struct(
+                    vec![
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with different symbol token sids
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("a").with_local_sid(21),
+                            E::Builder::new_i64(1),
+                        ),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                    ]
+                    .into_iter(),
+                ),
+            ],
+            ne_annotations: vec![
+                // structs with different length
+                E::Builder::new_struct(
+                    vec![
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with annotated values
+                E::Builder::new_struct(
+                    vec![
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                        (
+                            E::SymbolToken::text_token("a"),
+                            E::Builder::new_i64(1)
+                                .with_annotations(vec![E::SymbolToken::text_token("a")]),
+                        ),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with different value for duplicates
+                E::Builder::new_struct(
+                    vec![
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(2)),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                    ]
+                    .into_iter(),
+                ),
+            ],
+        }
+    }
+
+    fn struct_with_duplicate_fieldnames_case<E: Element>() -> CaseStruct<E>
+    where
+        E::Builder: Builder<SymbolToken = E::SymbolToken>,
+    {
+        CaseStruct {
+            eq_annotations: vec![
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("world"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with unordered fields
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("world"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+            ],
+            ne_annotations: vec![
+                // structs with different length and duplicates
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("world"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hey"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with annotated values
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("world")
+                                .with_annotations(vec![E::SymbolToken::text_token("foo")]),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with different length
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("hello"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("greetings"),
+                            E::Builder::new_string("world"),
+                        ),
+                        (
+                            E::SymbolToken::text_token("name"),
+                            E::Builder::new_string("hello"),
+                        ),
+                    ]
+                    .into_iter(),
+                ),
+            ],
+        }
+    }
+
+    #[rstest]
+    #[case::owned_struct_with_local_sid(struct_with_local_sid_case::<OwnedElement>())]
+    #[case::borrowed_struct_with_local_sid(struct_with_local_sid_case::<BorrowedElement>())]
+    #[case::owned_struct_with_import_source(struct_with_import_source_case::<OwnedElement>())]
+    #[case::borrowed_struct_with_import_source(struct_with_import_source_case::<BorrowedElement>())]
+    #[case::owned_struct_with_multiple_fields(struct_with_multiple_fields_case::<OwnedElement>())]
+    #[case::borrowed_struct_with_multiple_fields(struct_with_multiple_fields_case::<BorrowedElement>())]
+    #[case::owned_struct_with_duplicates_in_multiple_fields(struct_with_duplicates_in_multiple_fields_case::<OwnedElement>())]
+    #[case::borrowed_struct_with_duplicates_in_multiple_fields(struct_with_duplicates_in_multiple_fields_case::<BorrowedElement>())]
+    #[case::owned_struct_with_duplicate_fieldnames(struct_with_duplicate_fieldnames_case::<OwnedElement>())]
+    #[case::borrowed_struct_with_duplicate_fieldnames(struct_with_duplicate_fieldnames_case::<BorrowedElement>())]
+    fn struct_accessors<E: Element>(#[case] input: CaseStruct<E>) {
+        // check if equivalent vector contains set of structs that are all equal
+        for eq_this_struct in &input.eq_annotations {
+            for eq_other_struct in &input.eq_annotations {
+                assert_eq!(eq_this_struct, eq_other_struct);
+            }
+        }
+
+        // check if non_equivalent vector contains a set of structs that are not ever equal
+        // to the equivalent set structs.
+        for eq_struct in &input.eq_annotations {
+            for non_eq_struct in &input.ne_annotations {
+                assert_ne!(eq_struct, non_eq_struct);
+            }
+        }
+    }
+
     /// Models the operations on `Element` that we want to test.
     #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
     enum ElemOp {
@@ -864,7 +1253,6 @@ mod generic_value_tests {
     }
 
     use std::collections::HashSet;
-    use std::fmt::Debug;
     use std::str::FromStr;
     use ElemOp::*;
 
@@ -1138,414 +1526,6 @@ mod generic_value_tests {
             }),
         }
     }
-
-    fn struct_with_local_sid_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![(
-                    E::SymbolToken::local_sid_token(21),
-                    E::Builder::new_string("hello"),
-                )]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct();
-                let expected = E::Builder::new_struct(
-                    vec![(
-                        E::SymbolToken::local_sid_token(21),
-                        E::Builder::new_string("hello"),
-                    )]
-                    .into_iter(),
-                );
-                assert_eq!(actual, expected.as_struct());
-            }),
-        }
-    }
-
-    // SymbolToken with local SID and no text are equivalent to each other and to SID $0
-    fn struct_with_different_local_sid_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![(
-                    E::SymbolToken::local_sid_token(21),
-                    E::Builder::new_string("hello"),
-                )]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct();
-                let expected = E::Builder::new_struct(
-                    vec![(
-                        E::SymbolToken::local_sid_token(22),
-                        E::Builder::new_string("hello"),
-                    )]
-                    .into_iter(),
-                );
-                assert_eq!(actual, expected.as_struct());
-            }),
-        }
-    }
-
-    fn struct_with_import_source_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![(
-                    E::SymbolToken::local_sid_token(21).with_source("hello_table", 2),
-                    E::Builder::new_string("hello"),
-                )]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct();
-                let expected = E::Builder::new_struct(
-                    vec![(
-                        E::SymbolToken::local_sid_token(21).with_source("hello_table", 2),
-                        E::Builder::new_string("hello"),
-                    )]
-                    .into_iter(),
-                );
-                assert_eq!(actual, expected.as_struct());
-            }),
-        }
-    }
-
-    fn struct_with_import_source_not_equal_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![(
-                    E::SymbolToken::local_sid_token(21).with_source("hello_table", 2),
-                    E::Builder::new_string("hello"),
-                )]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct();
-                let expected = E::Builder::new_struct(
-                    vec![(
-                        E::SymbolToken::local_sid_token(21).with_source("hey_table", 2),
-                        E::Builder::new_string("hello"),
-                    )]
-                    .into_iter(),
-                );
-                assert_ne!(actual, expected.as_struct());
-            }),
-        }
-    }
-
-    fn struct_with_multiple_fields_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![
-                    (
-                        E::SymbolToken::text_token("greetings"),
-                        E::Builder::new_string("hello"),
-                    ),
-                    (
-                        E::SymbolToken::text_token("name"),
-                        E::Builder::new_string("Ion"),
-                    ),
-                ]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct().unwrap();
-                // expected struct has unordered struct
-                let unordered_struct = E::Builder::new_struct(
-                    vec![
-                        (
-                            E::SymbolToken::text_token("greetings"),
-                            E::Builder::new_string("hello"),
-                        ),
-                        (
-                            E::SymbolToken::text_token("name"),
-                            E::Builder::new_string("Ion"),
-                        ),
-                    ]
-                    .into_iter(),
-                );
-                let expected = unordered_struct.as_struct().unwrap();
-                assert_eq!(actual.get("name"), expected.get("name"));
-                assert_eq!(actual.get("greetings"), expected.get("greetings"));
-                assert_eq!(actual, expected);
-            }),
-        }
-    }
-
-    fn struct_with_unordered_multiple_fields_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![
-                    (
-                        E::SymbolToken::text_token("greetings"),
-                        E::Builder::new_string("hello"),
-                    ),
-                    (
-                        E::SymbolToken::text_token("name"),
-                        E::Builder::new_string("Ion"),
-                    ),
-                ]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct().unwrap();
-                // expected struct has unordered struct
-                let unordered_struct = E::Builder::new_struct(
-                    vec![
-                        (
-                            E::SymbolToken::text_token("name"),
-                            E::Builder::new_string("Ion"),
-                        ),
-                        (
-                            E::SymbolToken::text_token("greetings"),
-                            E::Builder::new_string("hello"),
-                        ),
-                    ]
-                    .into_iter(),
-                );
-                let expected = unordered_struct.as_struct().unwrap();
-                assert_eq!(actual.get("name"), expected.get("name"));
-                assert_eq!(actual.get("greetings"), expected.get("greetings"));
-                assert_eq!(actual, expected);
-            }),
-        }
-    }
-
-    fn struct_with_different_length_multiple_fields_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![
-                    (
-                        E::SymbolToken::text_token("greetings"),
-                        E::Builder::new_string("hello"),
-                    ),
-                    (
-                        E::SymbolToken::text_token("name"),
-                        E::Builder::new_string("Ion"),
-                    ),
-                ]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct().unwrap();
-                // expected struct has different length
-                let unordered_struct = E::Builder::new_struct(
-                    vec![(
-                        E::SymbolToken::text_token("name"),
-                        E::Builder::new_string("Ion"),
-                    )]
-                    .into_iter(),
-                );
-                let expected = unordered_struct.as_struct().unwrap();
-                assert_eq!(actual.get("name"), expected.get("name"));
-                // expected struct doesn't contain field with field name "greetings"
-                assert_ne!(actual.get("greetings"), expected.get("greetings"));
-                assert_ne!(actual, expected);
-                assert_ne!(expected, actual);
-            }),
-        }
-    }
-
-    fn struct_with_multiple_fields_not_equal_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![
-                    (
-                        E::SymbolToken::text_token("greetings"),
-                        E::Builder::new_string("hello"),
-                    ),
-                    (
-                        E::SymbolToken::text_token("name"),
-                        E::Builder::new_string("Ion"),
-                    ),
-                ]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct().unwrap();
-                // expected struct with different value for field name: "greetings"
-                let not_equal_struct = E::Builder::new_struct(
-                    vec![
-                        (
-                            E::SymbolToken::text_token("greetings"),
-                            E::Builder::new_string("hey"),
-                        ),
-                        (
-                            E::SymbolToken::text_token("name"),
-                            E::Builder::new_string("Ion"),
-                        ),
-                    ]
-                    .into_iter(),
-                );
-                let expected = not_equal_struct.as_struct().unwrap();
-                assert_eq!(actual.get("name"), expected.get("name"));
-                assert_ne!(actual.get("greetings"), expected.get("greetings"));
-                assert_ne!(actual, expected);
-            }),
-        }
-    }
-
-    fn struct_with_text_and_duplicates_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![
-                    (
-                        E::SymbolToken::text_token("greetings"),
-                        E::Builder::new_string("hello"),
-                    ),
-                    (
-                        E::SymbolToken::text_token("greetings"),
-                        E::Builder::new_string("world"),
-                    ),
-                ]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct();
-                let struct_with_duplicates = E::Builder::new_struct(
-                    vec![
-                        (
-                            E::SymbolToken::text_token("greetings"),
-                            E::Builder::new_string("hello"),
-                        ),
-                        (
-                            E::SymbolToken::text_token("greetings"),
-                            E::Builder::new_string("world"),
-                        ),
-                    ]
-                    .into_iter(),
-                );
-                let expected = struct_with_duplicates.as_struct();
-                assert_eq!(actual, expected);
-            }),
-        }
-    }
-
-    fn struct_with_unordered_text_and_duplicates_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![
-                    (
-                        E::SymbolToken::text_token("greetings"),
-                        E::Builder::new_string("hello"),
-                    ),
-                    (
-                        E::SymbolToken::text_token("greetings"),
-                        E::Builder::new_string("world"),
-                    ),
-                ]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct();
-                let unordered_struct = E::Builder::new_struct(
-                    vec![
-                        (
-                            E::SymbolToken::text_token("greetings"),
-                            E::Builder::new_string("world"),
-                        ),
-                        (
-                            E::SymbolToken::text_token("greetings"),
-                            E::Builder::new_string("hello"),
-                        ),
-                    ]
-                    .into_iter(),
-                );
-                let expected = unordered_struct.as_struct();
-                assert_eq!(actual, expected);
-            }),
-        }
-    }
-
-    fn struct_with_unordered_no_text_and_duplicates_case<E: Element>() -> Case<E>
-    where
-        E::Builder: Builder<SymbolToken = E::SymbolToken>,
-    {
-        Case {
-            elem: E::Builder::new_struct(
-                vec![
-                    (
-                        E::SymbolToken::local_sid_token(21),
-                        E::Builder::new_string("hello"),
-                    ),
-                    (
-                        E::SymbolToken::local_sid_token(21),
-                        E::Builder::new_string("world"),
-                    ),
-                ]
-                .into_iter(),
-            ),
-            ion_type: IonType::Struct,
-            ops: vec![AsStruct],
-            op_assert: Box::new(|e: &E| {
-                let actual = e.as_struct();
-                let unordered_struct = E::Builder::new_struct(
-                    vec![
-                        (
-                            E::SymbolToken::local_sid_token(21),
-                            E::Builder::new_string("world"),
-                        ),
-                        (
-                            E::SymbolToken::local_sid_token(21),
-                            E::Builder::new_string("hello"),
-                        ),
-                    ]
-                    .into_iter(),
-                );
-                let expected = unordered_struct.as_struct();
-                assert_eq!(actual, expected);
-            }),
-        }
-    }
     // TODO add more tests to remove the separate Owned/Borrowed tests and only keep generic tests
 
     #[rstest]
@@ -1583,28 +1563,6 @@ mod generic_value_tests {
     #[case::borrowed_symbol_with_import_source(symbol_with_import_source_case::<BorrowedElement>())]
     #[case::owned_symbol_with_import_source_and_text(symbol_with_import_source_and_text_case::<OwnedElement>())]
     #[case::borrowed_symbol_with_import_source_and_text(symbol_with_import_source_and_text_case::<BorrowedElement>())]
-    #[case::owned_struct_with_local_sid(struct_with_local_sid_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_local_sid(struct_with_local_sid_case::<BorrowedElement>())]
-    #[case::owned_struct_with_different_local_sid(struct_with_different_local_sid_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_different_local_sid(struct_with_different_local_sid_case::<BorrowedElement>())]
-    #[case::owned_struct_with_import_source(struct_with_import_source_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_import_source(struct_with_import_source_case::<BorrowedElement>())]
-    #[case::owned_struct_with_import_source_not_equal(struct_with_import_source_not_equal_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_import_source_not_equal(struct_with_import_source_not_equal_case::<BorrowedElement>())]
-    #[case::owned_struct_with_multiple_fields(struct_with_multiple_fields_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_multiple_fields(struct_with_multiple_fields_case::<BorrowedElement>())]
-    #[case::owned_struct_with_unordered_multiple_fields(struct_with_unordered_multiple_fields_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_unordered_multiple_fields(struct_with_unordered_multiple_fields_case::<BorrowedElement>())]
-    #[case::owned_struct_with_different_length_multiple_fields(struct_with_different_length_multiple_fields_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_different_length_multiple_fields(struct_with_different_length_multiple_fields_case::<BorrowedElement>())]
-    #[case::owned_struct_with_multiple_fields_not_equal(struct_with_multiple_fields_not_equal_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_multiple_fields_not_equal(struct_with_multiple_fields_not_equal_case::<BorrowedElement>())]
-    #[case::owned_struct_with_text_and_duplicates(struct_with_text_and_duplicates_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_text_and_duplicates(struct_with_text_and_duplicates_case::<BorrowedElement>())]
-    #[case::owned_struct_with_unordered_text_and_duplicates(struct_with_unordered_text_and_duplicates_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_unordered_text_and_duplicates(struct_with_unordered_text_and_duplicates_case::<BorrowedElement>())]
-    #[case::owned_struct_with_unordered_no_text_and_duplicates(struct_with_unordered_no_text_and_duplicates_case::<OwnedElement>())]
-    #[case::borrowed_struct_with_unordered_no_text_and_duplicates(struct_with_unordered_no_text_and_duplicates_case::<BorrowedElement>())]
     fn element_accessors<E: Element>(#[case] input_case: Case<E>) {
         // table of negative assertions for each operation
         let neg_table: Vec<(ElemOp, &ElemAssertFunc<E>)> = vec![

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -838,8 +838,11 @@ mod generic_value_tests {
         }
     }
 
+    // A struct that defines input case for `struct_accessors` method
     struct CaseStruct<E: Element> {
+        // set of struct elements that are the same
         eq_annotations: Vec<E>,
+        // set of struct elements that are never equal to `eq_annotations`
         ne_annotations: Vec<E>,
     }
 
@@ -1074,6 +1077,18 @@ mod generic_value_tests {
                     ]
                     .into_iter(),
                 ),
+                // structs with sources
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::text_token("a").with_source("hello_table", 22),
+                            E::Builder::new_i64(1),
+                        ),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                    ]
+                    .into_iter(),
+                ),
             ],
             ne_annotations: vec![
                 // structs with different length
@@ -1101,6 +1116,18 @@ mod generic_value_tests {
                 E::Builder::new_struct(
                     vec![
                         (E::SymbolToken::text_token("a"), E::Builder::new_i64(2)),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
+                    ]
+                    .into_iter(),
+                ),
+                // structs with no texts but sources
+                E::Builder::new_struct(
+                    vec![
+                        (
+                            E::SymbolToken::local_sid_token(22).with_source("hello_table", 22),
+                            E::Builder::new_i64(1),
+                        ),
+                        (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
                         (E::SymbolToken::text_token("a"), E::Builder::new_i64(1)),
                     ]
                     .into_iter(),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -838,11 +838,11 @@ mod generic_value_tests {
         }
     }
 
-    // A struct that defines input case for `struct_accessors` method
+    /// A struct that defines input case for `struct_accessors` method
     struct CaseStruct<E: Element> {
-        // set of struct elements that are the same
+        /// set of struct elements that are the same
         eq_annotations: Vec<E>,
-        // set of struct elements that are never equal to `eq_annotations`
+        /// set of struct elements that are never equal to `eq_annotations`
         ne_annotations: Vec<E>,
     }
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -380,6 +380,10 @@ impl PartialEq for OwnedStruct {
         // check if both text_fields and no_text_fields have same length
         self.text_fields.len() == other.text_fields.len() && self.no_text_fields.len() == other.no_text_fields.len()
             // check if text_fields and no_text_fields are equal
+            // we need to test equality in both directions for both text_fields and no_text_fields
+            // A good example for this is annotated vs not annotated values in struct
+            //  { a:4, a:4 } vs. { a:4, a:a::4 } // returns true
+            //  { a:4, a:a::4 } vs. { a:4, a:4 } // returns false
             && self.eq_text_fields(other) && other.eq_text_fields(self)
             && self.eq_no_text_fields(other) && other.eq_no_text_fields(self)
     }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -377,7 +377,7 @@ impl Struct for OwnedStruct {
 
 impl PartialEq for OwnedStruct {
     fn eq(&self, other: &Self) -> bool {
-        // check if both test_fields and no_text_fields have same length
+        // check if both text_fields and no_text_fields have same length
         self.text_fields.len() == other.text_fields.len() && self.no_text_fields.len() == other.no_text_fields.len()
             // check if text_fields and no_text_fields are equal
             && self.eq_text_fields(other) && other.eq_text_fields(self)

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -276,6 +276,31 @@ pub struct OwnedStruct {
     no_text_fields: Vec<(OwnedSymbolToken, OwnedElement)>,
 }
 
+impl OwnedStruct {
+    fn eq_text_fields(&self, other: &Self) -> bool {
+        // check if both the text_fields have same (field_name,value) pairs
+        self.text_fields.iter().all(|(key, value)| {
+            value.iter().all(|(_my_s, my_v)| {
+                other
+                    .get_all(key)
+                    .find(|other_v| my_v == *other_v)
+                    .is_some()
+            }) && value.len() == other.get_all(key).count()
+        })
+    }
+
+    fn eq_no_text_fields(&self, other: &Self) -> bool {
+        // check if both the no_text_fields are same values
+        self.no_text_fields.iter().all(|(my_k, my_v)| {
+            other
+                .no_text_fields
+                .iter()
+                .find(|(other_k, other_v)| my_k == other_k && my_v == other_v)
+                .is_some()
+        })
+    }
+}
+
 impl<K, V> FromIterator<(K, V)> for OwnedStruct
 where
     K: Into<OwnedSymbolToken>,
@@ -352,23 +377,11 @@ impl Struct for OwnedStruct {
 
 impl PartialEq for OwnedStruct {
     fn eq(&self, other: &Self) -> bool {
-        // check if both the text_fields have same (field_name,value) pairs
-        self.text_fields.iter().all(|(key, value)| {
-            value.iter().all(|(_my_s, my_v)| {
-                other
-                    .get_all(key)
-                    .find(|other_v| my_v == *other_v)
-                    .is_some()
-            })
-        }) && self.no_text_fields.iter().all(|(my_k, my_v)| {
-            // check if both the no_text_fields have same values
-            other
-                .no_text_fields
-                .iter()
-                .find(|(other_k, other_v)| my_k == other_k && my_v == other_v)
-                .is_some()
-        }) && self.text_fields.len() == other.text_fields.len()
-            && self.no_text_fields.len() == other.no_text_fields.len()
+        // check if both test_fields and no_text_fields have same length
+        self.text_fields.len() == other.text_fields.len() && self.no_text_fields.len() == other.no_text_fields.len()
+            // check if text_fields and no_text_fields are equal
+            && self.eq_text_fields(other) && other.eq_text_fields(self)
+            && self.eq_no_text_fields(other) && other.eq_no_text_fields(self)
     }
 }
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -367,7 +367,8 @@ impl PartialEq for OwnedStruct {
                 .iter()
                 .find(|(other_k, other_v)| my_k == other_k && my_v == other_v)
                 .is_some()
-        })
+        }) && self.text_fields.len() == other.text_fields.len()
+            && self.no_text_fields.len() == other.no_text_fields.len()
     }
 }
 

--- a/tests/loader_test_vectors.rs
+++ b/tests/loader_test_vectors.rs
@@ -50,8 +50,6 @@ const NON_EQUIVS_SKIP_LIST: &[&str] = &[
     "ion-tests/iontestdata/good/non-equivs/floats.ion",
     // these have symbols with unknown text (amzn/ion-rust#219)
     "ion-tests/iontestdata/good/non-equivs/symbolTablesUnknownText.ion",
-    // this is a bug in our PartialEq (amzn/ion-rust#216)
-    "ion-tests/iontestdata/good/non-equivs/structs.ion",
 ];
 
 /// Concatenates two slices of string slices together.


### PR DESCRIPTION
*Issue #216 *

*Description of changes:*
This PR works on solving the issue with symmetry in `Struct` of `Value` API.

*Changes:*
- Added length check in the `PartialEq` of `...Struct` for symmetry.

*Tests:*
Added unittests for different length structs in `Value` API.