### PR TITLE
Adds codecov.yml.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 5%
+    patch:
+      default:
+        target: 85%
+        threshold: 5%


### PR DESCRIPTION
Specifically makes coverage targets fixed, especially given how
unreliable `grcov` seems to be.

Tested with:

`curl --data-binary @.github/codecov.yml https://codecov.io/validate`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
