### PR TITLE
Updates `ion-c` to pick up static buffer bug.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ ion-c-sys = { path = "./ion-c-sys", version = "0.4" }
 # Used by ion-tests integration
 walkdir = "^2.3"
 test-generator = "0.3"
+pretty-hex = "0.2"
 
 [profile.release]
 lto = true

--- a/tests/loader_test_vectors.rs
+++ b/tests/loader_test_vectors.rs
@@ -5,6 +5,7 @@ use ion_rs::value::dumper::{Dumper, FixedDumper, Format, TextKind};
 use ion_rs::value::loader::{loader, Loader};
 use ion_rs::value::owned::OwnedElement;
 use ion_rs::value::{Element, Sequence, SymbolToken};
+use pretty_hex::*;
 use std::fs::read;
 use std::path::MAIN_SEPARATOR as PATH_SEPARATOR;
 use test_generator::test_resources;
@@ -147,7 +148,7 @@ where
     dumper.write_all(source_elements)?;
     let output = dumper.finish()?;
     let new_elements = loader().load_all(output)?;
-    assert_eq!(*source_elements, new_elements);
+    assert_eq!(*source_elements, new_elements, "{:?}", output.hex_dump());
     Ok(new_elements)
 }
 


### PR DESCRIPTION
See amzn/ion-c#241 for the underlying fix around thread-safety and
`clob` (and probably `string`) escape generation for text using a global
buffer.

Also adds some `pretty-hex` crate to make printing the buffer in round
trip `Element` tests to make it easier to debug.

Fixes #238.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
