### PR TITLE
Renames `Loader` and `Dumper to `ElementReader` and `ElementWriter`.

### DIFF
--- a/ion-hash/src/lib.rs
+++ b/ion-hash/src/lib.rs
@@ -4,11 +4,11 @@
 //!
 //! ## Examples
 //! ```rust
-//! use ion_rs::value::loader::{self, Loader};
+//! use ion_rs::value::reader::{self, ElementReader};
 //! use ion_rs::result::IonResult;
 //!
 //! # fn main() -> IonResult<()> {
-//!   let loader = loader::loader();
+//!   let loader = reader::element_reader();
 //!   let elem = loader.iterate_over(b"\"hello world\"")?.next().unwrap()?;
 //!   let digest = ion_hash::sha256(&elem);
 //!   println!("{:?}", digest);

--- a/ion-hash/tests/ion_hash_tests.rs
+++ b/ion-hash/tests/ion_hash_tests.rs
@@ -3,7 +3,7 @@
 use digest::{consts::U256, generic_array::GenericArray, Digest, Output};
 use ion_hash::{self, IonHasher};
 use ion_rs::result::IonResult;
-use ion_rs::value::loader::{loader, Loader};
+use ion_rs::value::reader::{element_reader, ElementReader};
 use ion_rs::value::*;
 use std::fs::read;
 
@@ -84,7 +84,7 @@ fn ion_hash_tests() -> IonResult<()> {
 
 fn test_file(file_name: &str) -> IonResult<()> {
     let data = read(file_name)?;
-    let elems = loader().load_all(&data)?;
+    let elems = element_reader().read_all(&data)?;
     test_all(elems)
 }
 

--- a/src/value/reader.rs
+++ b/src/value/reader.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! Provides utility to load Ion data into [`Element`](super::Element) from different sources such
+//! Provides APIs to read Ion data into [`Element`](super::Element) from different sources such
 //! as slices or files.
 
 use crate::result::{decoding_error, IonResult};
@@ -17,7 +17,7 @@ use super::owned::text_token;
 //      we could make it generic with generic associated types or just have a lifetime
 //      scoped implementation
 
-/// Loads Ion data into [`Element`](super::Element) instances.
+/// Reads Ion data into [`Element`](super::Element) instances.
 ///
 /// ## Notes
 /// Users of this trait should not assume any particular implementation of [`Element`](super::Element).
@@ -26,7 +26,7 @@ use super::owned::text_token;
 ///
 /// [gat]: https://rust-lang.github.io/rfcs/1598-generic_associated_types.html
 /// [et]:https://rust-lang.github.io/rfcs/2071-impl-trait-existential-types.html
-pub trait Loader {
+pub trait ElementReader {
     /// Parses Ion over a given slice of data and yields each top-level value as
     /// an [`Element`](super::Element) instance.
     ///
@@ -44,7 +44,7 @@ pub trait Loader {
     /// Parses given Ion over a given slice into an [`Vec`] returning an
     /// [`IonError`](crate::result::IonError) if any error occurs during the parse.
     #[inline]
-    fn load_all(&self, data: &[u8]) -> IonResult<Vec<OwnedElement>> {
+    fn read_all(&self, data: &[u8]) -> IonResult<Vec<OwnedElement>> {
         self.iterate_over(data)?.collect()
     }
 
@@ -52,7 +52,7 @@ pub trait Loader {
     /// Returns [`IonError`](crate::result::IonError) if any error occurs during the parse
     /// or there is more than one top-level [`Element`](super::Element) in the data.
     #[inline]
-    fn load_one(&self, data: &[u8]) -> IonResult<OwnedElement> {
+    fn read_one(&self, data: &[u8]) -> IonResult<OwnedElement> {
         let mut iter = self.iterate_over(data)?;
         match iter.next() {
             Some(Ok(elem)) => {
@@ -200,9 +200,9 @@ impl<'a> Iterator for IonCReaderIterator<'a> {
     }
 }
 
-struct IonCLoader {}
+struct IonCElementReader;
 
-impl Loader for IonCLoader {
+impl ElementReader for IonCElementReader {
     fn iterate_over<'a, 'b>(
         &'a self,
         data: &'b [u8],
@@ -216,13 +216,13 @@ impl Loader for IonCLoader {
     }
 }
 
-/// Returns an implementation defined [`Loader`] instance.
-pub fn loader() -> impl Loader {
-    IonCLoader {}
+/// Returns an implementation defined [`ElementReader`] instance.
+pub fn element_reader() -> impl ElementReader {
+    IonCElementReader {}
 }
 
 #[cfg(test)]
-mod loader_tests {
+mod reader_tests {
     use super::*;
     use crate::types::timestamp::Timestamp as TS;
     use crate::value::owned::OwnedValue::*;
@@ -238,20 +238,6 @@ mod loader_tests {
     use num_bigint::BigInt;
     use rstest::*;
     use std::str::FromStr;
-
-    #[inline]
-    fn load_all(input: &[u8]) -> IonResult<Vec<OwnedElement>> {
-        loader().iterate_over(input)?.collect()
-    }
-
-    #[inline]
-    fn single(input: &[u8]) -> IonResult<OwnedElement> {
-        let loader = loader();
-        let mut iter = loader.iterate_over(input)?;
-        let first = iter.next().unwrap();
-        assert_eq!(None, iter.next());
-        first
-    }
 
     #[rstest]
     #[case::nulls(
@@ -430,18 +416,18 @@ mod loader_tests {
             })
             .collect(),
     )]
-    fn load_and_compare(
+    fn read_and_compare(
         #[case] input: &[u8],
         #[case] expected: Vec<OwnedElement>,
     ) -> IonResult<()> {
-        let actual = load_all(input)?;
+        let actual = element_reader().read_all(input)?;
         assert_eq!(expected, actual);
         Ok(())
     }
 
     #[test]
-    fn load_nan() -> IonResult<()> {
-        let actual = single(b"nan")?;
+    fn read_nan() -> IonResult<()> {
+        let actual = element_reader().read_one(b"nan")?;
         assert!(actual.as_f64().unwrap().is_nan());
         Ok(())
     }
@@ -483,12 +469,12 @@ mod loader_tests {
             Err(IonCError::from(ion_error_code_IERR_INVALID_STATE).into())
         ]
     )]
-    /// Like load_and_compare, but against results (which makes it easier to test for errors).
-    fn load_expect(
+    /// Like read_and_compare, but against results (which makes it easier to test for errors).
+    fn read_and_expect(
         #[case] input: &[u8],
         #[case] expected: Vec<IonResult<OwnedElement>>,
     ) -> IonResult<()> {
-        let actual: Vec<_> = loader().iterate_over(input)?.collect();
+        let actual: Vec<_> = element_reader().iterate_over(input)?.collect();
         assert_eq!(expected, actual);
         Ok(())
     }


### PR DESCRIPTION
* Renames the `value::loader` module to `value::reader`.
* Renames the `value::dumper` module to `value::writer`.
* Renames various references to dump/dumper and load/loader.
* Renames `loader_test_vectors.rs` to `element_test_vectors`.
* Minor API cleanup to match the new names.

Fixes #251 and #243.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
