### PR TITLE
Version bump for all crates to publish.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2021-04-24
+          toolchain: nightly-2021-05-07
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 
 [workspace]
@@ -26,16 +26,15 @@ members = [
 ]
 
 [dependencies]
-base64 = "^0.12.3"
-bigdecimal = "^0.2"
-bytes = "^0.4"
-chrono = "^0.4"
-delegate = "^0.5"
+base64 = "0.12"
+bigdecimal = "0.2"
+bytes = "0.4"
+chrono = "0.4"
+delegate = "0.5"
 thiserror = "1.0"
-nom = "6.1.0"
-num-bigint = "0.3.1"
-num-traits = "0.2.14"
-rstest = "0.7.0"
+nom = "6.1"
+num-bigint = "0.3"
+num-traits = "0.2"
 
 # NB: We use the tree dependency here for development and CI.
 #     Note that when publishing you should update the version
@@ -43,8 +42,10 @@ rstest = "0.7.0"
 ion-c-sys = { path = "./ion-c-sys", version = "0.4" }
 
 [dev-dependencies]
+rstest = "0.9"
+
 # Used by ion-tests integration
-walkdir = "^2.3"
+walkdir = "2.3"
 test-generator = "0.3"
 pretty-hex = "0.2"
 

--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -16,19 +16,19 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.4.9"
+version = "0.4.10"
 edition = "2018"
 
 [dependencies]
-paste = "1.0.0"
-num-bigint = "0.3.0"
-bigdecimal = "0.2.0"
-chrono = "0.4.13"
+paste = "1.0"
+num-bigint = "0.3"
+bigdecimal = "0.2"
+chrono = "0.4"
 
 [build-dependencies]
-cmake = "0.1.45"
-bindgen = "0.58.1"
+cmake = "0.1"
+bindgen = "0.58"
 
 [dev-dependencies]
-rstest = "0.7.0"
-rstest_reuse = "0.1.2"
+rstest = "0.9"
+rstest_reuse = "0.1"

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -16,11 +16,11 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.0.2"
+version = "0.0.3"
 edition = "2018"
 
 [dependencies]
-ion-rs = { path = "../", version = "0.5" }
+ion-rs = { path = "../", version = "0.6" }
 ion-c-sys = { path = "../ion-c-sys", version = "0.4" }
-digest = "0.9.0"
-sha2 = "0.9.3"
+digest = "0.9"
+sha2 = "0.9"


### PR DESCRIPTION
This gets `ion-rs` ready to publish for new APIs.

Patch level version bump for `ion-hash` and `ion-c-sys`.

Made the dependencies for all crates consistent.  Notably changed the
dependencies to `x.y` format over `x.y.z`.  The rationale for this
change is that we've been a bit rigid on patch versions and that has
caused some downstream compatibility woes.  If any particular crates we
depend on break semver, we can always add the patch version in for those
crates (and/or use tilde versions).

Another change is switching from `^x.y` to just `x.y` as these syntaxes
are the same as per the Cargo book and we had a mixture of both, so I
went with preferring the one that crates.io naturally suggests.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html

Also updates code coverage CI to use `nightly-2021-05-07`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
