### PR TITLE
Refactor out `raw::i64_magnitude`

### DIFF
--- a/ion-hash/src/representation.rs
+++ b/ion-hash/src/representation.rs
@@ -7,10 +7,10 @@
 //! and not speed.
 
 use ion_rs::{
+    binary,
     value::{AnyInt, Element},
     IonType,
 };
-use num_bigint::BigInt;
 
 // TODO: Finish ion-rust's binary writer and factor it such that the binary
 // representations can be written by the "raw" writer (ref. the Java
@@ -39,16 +39,16 @@ pub trait Representation {
 
 impl Representation for Option<&AnyInt> {
     fn repr(&self) -> BinaryRepr {
-        fn bigint_repr(b: &BigInt) -> Vec<u8> {
-            b.magnitude().to_bytes_be()
-        }
-
         match self {
             Some(AnyInt::I64(v)) => match v {
                 0 => None,
-                _ => Some(bigint_repr(&BigInt::from(*v))),
+                _ => {
+                    let magnitude = v.abs() as u64;
+                    let magnitude_bytes = binary::uint::magnitude_to_bytes(magnitude);
+                    Some(magnitude_bytes.as_ref().into())
+                }
             },
-            Some(AnyInt::BigInt(b)) => Some(bigint_repr(b)),
+            Some(AnyInt::BigInt(b)) => Some(b.magnitude().to_bytes_be()),
             None => None,
         }
     }

--- a/ion-hash/src/representation.rs
+++ b/ion-hash/src/representation.rs
@@ -44,8 +44,8 @@ impl Representation for Option<&AnyInt> {
                 0 => None,
                 _ => {
                     let magnitude = v.abs() as u64;
-                    let magnitude_bytes = binary::uint::magnitude_to_bytes(magnitude);
-                    Some(magnitude_bytes.as_ref().into())
+                    let encoded = binary::uint::encode_uint(magnitude);
+                    Some(encoded.as_ref().into())
                 }
             },
             Some(AnyInt::BigInt(b)) => Some(b.magnitude().to_bytes_be()),

--- a/ion-hash/src/representation.rs
+++ b/ion-hash/src/representation.rs
@@ -45,7 +45,7 @@ impl Representation for Option<&AnyInt> {
                 _ => {
                     let magnitude = v.abs() as u64;
                     let encoded = binary::uint::encode_uint(magnitude);
-                    Some(encoded.as_ref().into())
+                    Some(encoded.as_bytes().into())
                 }
             },
             Some(AnyInt::BigInt(b)) => Some(b.magnitude().to_bytes_be()),

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -12,7 +12,7 @@ use crate::{
         constants::v1_0::length_codes,
         header::{create_header_byte_jump_table, Header},
         int::Int,
-        uint::UInt,
+        uint::DecodedUInt,
         var_int::VarInt,
         var_uint::VarUInt,
         IonTypeCode,
@@ -836,14 +836,14 @@ where
     // Useful when the entire value (all bytes after the type/length header) are represented by
     // a single UInt. (i.e. Integer and Symbol)
     #[inline(always)]
-    fn read_value_as_uint(&mut self) -> IonResult<UInt> {
+    fn read_value_as_uint(&mut self) -> IonResult<DecodedUInt> {
         let number_of_bytes = self.cursor.value.value_length;
         self.read_uint(number_of_bytes)
     }
 
     #[inline(always)]
-    fn read_uint(&mut self, number_of_bytes: usize) -> IonResult<UInt> {
-        let uint = UInt::read(&mut self.data_source, number_of_bytes)?;
+    fn read_uint(&mut self, number_of_bytes: usize) -> IonResult<DecodedUInt> {
+        let uint = DecodedUInt::read(&mut self.data_source, number_of_bytes)?;
         self.cursor.bytes_read += uint.size_in_bytes();
         Ok(uint)
     }

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -7,7 +7,7 @@ mod header;
 mod int;
 mod nibbles;
 mod type_code;
-mod uint;
+pub mod uint;
 mod var_int;
 mod var_uint;
 pub mod writer;

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -11,14 +11,14 @@ const MAX_UINT_SIZE_IN_BYTES: usize = mem::size_of::<UIntStorage>();
 /// [UInt and Int Fields](http://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields)
 /// section of the binary Ion spec for more details.
 #[derive(Debug)]
-pub struct UInt {
+pub struct DecodedUInt {
     size_in_bytes: usize,
     value: UIntStorage,
 }
 
-impl UInt {
+impl DecodedUInt {
     /// Reads a UInt with `length` bytes from the provided data source.
-    pub fn read<R: IonDataSource>(data_source: &mut R, length: usize) -> IonResult<UInt> {
+    pub fn read<R: IonDataSource>(data_source: &mut R, length: usize) -> IonResult<DecodedUInt> {
         if length > MAX_UINT_SIZE_IN_BYTES {
             return decoding_error(format!(
                 "Found a {}-byte UInt. Max supported size is {} bytes.",
@@ -40,7 +40,7 @@ impl UInt {
             magnitude |= byte;
         }
 
-        Ok(UInt {
+        Ok(DecodedUInt {
             size_in_bytes: length,
             value: magnitude,
         })
@@ -48,8 +48,8 @@ impl UInt {
 
     /// Encodes the provided `magnitude` as a UInt and writes it to the provided `sink`.
     pub fn write_u64<W: Write>(sink: &mut W, magnitude: u64) -> IonResult<usize> {
-        let magnitude_bytes = magnitude_to_bytes(magnitude);
-        let bytes_to_write = magnitude_bytes.as_ref();
+        let encoded = encode_uint(magnitude);
+        let bytes_to_write = encoded.as_ref();
 
         sink.write_all(bytes_to_write)?;
         Ok(bytes_to_write.len())
@@ -69,18 +69,25 @@ impl UInt {
     }
 }
 
-/// The big-endian, compact slice of bytes for a `u64`.  Leading zero octets are
-/// not part of the representation.
-///
-/// This type exists to avoid heap allocation.
-pub struct U64Magnitude {
-    magnitude_bytes: [u8; mem::size_of::<u64>()],
+/// The big-endian, compact slice of bytes for a `u64`. Leading zero octets are
+/// not part of the representation.
+#[derive(Copy, Clone, Debug)]
+pub struct EncodedUInt {
+    be_bytes: [u8; mem::size_of::<u64>()],
     first_occupied_byte: usize,
 }
 
-impl AsRef<[u8]> for U64Magnitude {
+impl EncodedUInt {
+    /// Returns the slice view of the encoded UInt.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.be_bytes[self.first_occupied_byte..]
+    }
+}
+
+impl AsRef<[u8]> for EncodedUInt {
+    /// The same as [`as_bytes`].
     fn as_ref(&self) -> &[u8] {
-        &self.magnitude_bytes[self.first_occupied_byte..]
+        self.as_bytes()
     }
 }
 
@@ -88,28 +95,30 @@ impl AsRef<[u8]> for U64Magnitude {
 ///
 /// ```
 /// use ion_rs::binary::uint;
-/// use std::convert::AsRef;
 ///
-/// let repr = uint::magnitude_to_bytes(5u64);
-/// assert_eq!(&[0x05], repr.as_ref());
+/// let repr = uint::encode_uint(5u64);
+/// assert_eq!(&[0x05], repr.as_bytes());
+///
+/// let two_bytes = uint::encode_uint(256u64);
+/// assert_eq!(&[0x01, 0x00], two_bytes.as_bytes());
 /// ```
-pub fn magnitude_to_bytes(magnitude: u64) -> U64Magnitude {
+pub fn encode_uint(magnitude: u64) -> EncodedUInt {
     // We can divide the number of leading zero bits by 8
     // to to get the number of leading zero bytes.
-    let empty_leading_bytes: u32 = magnitude.leading_zeros() >> 3;
+    let empty_leading_bytes: u32 = magnitude.leading_zeros() / 8;
     let first_occupied_byte = empty_leading_bytes as usize;
 
     let magnitude_bytes: [u8; mem::size_of::<u64>()] = magnitude.to_be_bytes();
 
-    U64Magnitude {
-        magnitude_bytes,
+    EncodedUInt {
+        be_bytes: magnitude_bytes,
         first_occupied_byte,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::UInt;
+    use super::DecodedUInt;
     use std::io::Cursor;
 
     const READ_ERROR_MESSAGE: &str = "Failed to read a UInt from the provided cursor.";
@@ -118,7 +127,7 @@ mod tests {
     #[test]
     fn test_read_one_byte_uint() {
         let data = &[0b1000_0000];
-        let uint = UInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let uint = DecodedUInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(uint.size_in_bytes(), 1);
         assert_eq!(uint.value(), 128);
     }
@@ -126,7 +135,7 @@ mod tests {
     #[test]
     fn test_read_two_byte_uint() {
         let data = &[0b0111_1111, 0b1111_1111];
-        let uint = UInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let uint = DecodedUInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(uint.size_in_bytes(), 2);
         assert_eq!(uint.value(), 32_767);
     }
@@ -134,7 +143,7 @@ mod tests {
     #[test]
     fn test_read_three_byte_uint() {
         let data = &[0b0011_1100, 0b1000_0111, 0b1000_0001];
-        let uint = UInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let uint = DecodedUInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(uint.size_in_bytes(), 3);
         assert_eq!(uint.value(), 3_966_849);
     }
@@ -142,7 +151,7 @@ mod tests {
     #[test]
     fn test_read_uint_overflow() {
         let data = &[0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01];
-        let _uint = UInt::read(&mut Cursor::new(data), data.len())
+        let _uint = DecodedUInt::read(&mut Cursor::new(data), data.len())
             .expect_err("This should have failed due to overflow.");
     }
 
@@ -150,7 +159,7 @@ mod tests {
     fn test_write_eight_byte_uint() {
         let value = 0x01_23_45_67_89_AB_CD_EF;
         let mut buffer: Vec<u8> = vec![];
-        UInt::write_u64(&mut buffer, value).expect(WRITE_ERROR_MESSAGE);
+        DecodedUInt::write_u64(&mut buffer, value).expect(WRITE_ERROR_MESSAGE);
         let expected_bytes = &[0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF];
         assert_eq!(expected_bytes, buffer.as_slice());
     }
@@ -159,7 +168,7 @@ mod tests {
     fn test_write_five_byte_uint() {
         let value = 0x01_23_45_67_89;
         let mut buffer: Vec<u8> = vec![];
-        UInt::write_u64(&mut buffer, value).expect(WRITE_ERROR_MESSAGE);
+        DecodedUInt::write_u64(&mut buffer, value).expect(WRITE_ERROR_MESSAGE);
         let expected_bytes = &[0x01, 0x23, 0x45, 0x67, 0x89];
         assert_eq!(expected_bytes, buffer.as_slice());
     }
@@ -168,7 +177,7 @@ mod tests {
     fn test_write_three_byte_uint() {
         let value = 0x01_23_45;
         let mut buffer: Vec<u8> = vec![];
-        UInt::write_u64(&mut buffer, value).expect(WRITE_ERROR_MESSAGE);
+        DecodedUInt::write_u64(&mut buffer, value).expect(WRITE_ERROR_MESSAGE);
         let expected_bytes: &[u8] = &[0x01, 0x23, 0x45];
         assert_eq!(expected_bytes, buffer.as_slice());
     }
@@ -177,7 +186,7 @@ mod tests {
     fn test_write_uint_zero() {
         let value = 0x00;
         let mut buffer: Vec<u8> = vec![];
-        UInt::write_u64(&mut buffer, value).expect(WRITE_ERROR_MESSAGE);
+        DecodedUInt::write_u64(&mut buffer, value).expect(WRITE_ERROR_MESSAGE);
         let expected_bytes: &[u8] = &[];
         assert_eq!(expected_bytes, buffer.as_slice());
     }

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -69,9 +69,8 @@ impl UInt {
     }
 }
 
-/// The result of the [`magnitude_to_bytes`] function. The fields are private;
-/// users must go through `as_ref()` to see the slice that ignores leading
-/// zeros.
+/// The big-endian, compact slice of bytes for a `u64`.  Leading zero octets are
+/// not part of the representation.
 ///
 /// This type exists to avoid heap allocation.
 pub struct U64Magnitude {

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -70,7 +70,7 @@ impl DecodedUInt {
 }
 
 /// The big-endian, compact slice of bytes for a `u64`. Leading zero octets are
-/// not part of the representation.
+/// not part of the representation.
 #[derive(Copy, Clone, Debug)]
 pub struct EncodedUInt {
     be_bytes: [u8; mem::size_of::<u64>()],

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -69,8 +69,11 @@ impl DecodedUInt {
     }
 }
 
-/// The big-endian, compact slice of bytes for a `u64`. Leading zero octets are
-/// not part of the representation.
+/// The big-endian, compact slice of bytes for a UInt (`u64`). Leading zero
+/// octets are not part of the representation. See the [spec] for more
+/// information.
+///
+/// [spec]: https://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields
 #[derive(Copy, Clone, Debug)]
 pub struct EncodedUInt {
     be_bytes: [u8; mem::size_of::<u64>()],

--- a/src/binary/writer.rs
+++ b/src/binary/writer.rs
@@ -410,7 +410,7 @@ impl<W: Write> BinarySystemWriter<W> {
         self.write_scalar(|enc_buffer| {
             let magnitude = value.abs() as u64;
             let encoded = uint::encode_uint(magnitude);
-            let bytes_to_write = encoded.as_ref();
+            let bytes_to_write = encoded.as_bytes();
 
             // The encoded length will never be larger than 8 bytes, so it will
             // always fit in the Int's type descriptor byte.


### PR DESCRIPTION
This commit refactors the code that produces the "magnitude" subfield
out of `BinarySystemWriter`, allowing the code to be re-used in
ion-hash.

The implementation returns a I64Magnitude type rather than a slice. This
avoids an allocation (Vec, for example).

ion-hash now avoids i64 -> BigInt as a result of this change.

-------

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.