### PR TITLE
Rework ion-hash representations

### DIFF
--- a/ion-hash/src/lib.rs
+++ b/ion-hash/src/lib.rs
@@ -85,8 +85,9 @@ where
             | IonType::Symbol
             | IonType::String
             | IonType::Clob
-            | IonType::Blob => self.hash_scalar(elem),
-            IonType::List | IonType::SExpression | IonType::Struct => todo!(),
+            | IonType::Blob
+            | IonType::Struct => self.hash(elem),
+            IonType::List | IonType::SExpression => todo!(),
         };
         self.mark_end();
 
@@ -110,8 +111,8 @@ where
         self.hasher.update(tq.as_bytes());
     }
 
-    fn hash_scalar<E: Element + ?Sized>(&mut self, elem: &E) {
+    fn hash<E: Element + ?Sized>(&mut self, elem: &E) {
         self.hash_no_repr(elem);
-        representation::write_repr(elem, &mut self.hasher);
+        representation::update_with_representation(elem, &mut self.hasher);
     }
 }

--- a/ion-hash/src/lib.rs
+++ b/ion-hash/src/lib.rs
@@ -52,9 +52,11 @@ impl Markers {
 /// Provides Ion hash over arbitrary [`Element`] instances with a given
 /// [`Digest`] algorithm.
 ///
-/// The trait bounds are over the various subtraits that make up the `Digest`
-/// trait. The reason for this is we can't go from `Digest` to subtrait (e.g.
-/// `Update`) but can go the other way around!
+/// Note that [`Digest`] *does not imply* the following traits directly, but is
+/// a *convenience* trait for these other traits with a blanked implementation.
+/// This is the reason for this is we can't go from [`Digest`] to these
+/// traits (e.g. [`Update`]) but because of a blanket implementation, we can go
+/// the other way.
 pub struct IonHasher<D>
 where
     D: Update + FixedOutput + Reset + Clone + Default,

--- a/ion-hash/src/lib.rs
+++ b/ion-hash/src/lib.rs
@@ -77,7 +77,7 @@ where
     pub fn hash_element<E: Element + ?Sized>(mut self, elem: &E) -> IonResult<Output<D>> {
         self.mark_begin();
         match elem.ion_type() {
-            IonType::Null | IonType::Boolean => self.hash_no_repr(elem),
+            IonType::Null | IonType::Boolean => self.hash_type(elem),
             IonType::Integer
             | IonType::Float
             | IonType::Decimal
@@ -106,13 +106,13 @@ where
         self.hasher.update([Markers::E]);
     }
 
-    fn hash_no_repr<E: Element + ?Sized>(&mut self, elem: &E) {
+    fn hash_type<E: Element + ?Sized>(&mut self, elem: &E) {
         let tq = TypeQualifier::from_element(elem);
         self.hasher.update(tq.as_bytes());
     }
 
     fn hash<E: Element + ?Sized>(&mut self, elem: &E) {
-        self.hash_no_repr(elem);
+        self.hash_type(elem);
         representation::update_with_representation(elem, &mut self.hasher);
     }
 }

--- a/ion-hash/src/representation.rs
+++ b/ion-hash/src/representation.rs
@@ -21,7 +21,7 @@ pub(crate) fn write_repr<E: Element + ?Sized, D: Digest + Update>(elem: &E, hash
     let mut hasher = escaping(hasher);
 
     match elem.ion_type() {
-        IonType::Null | IonType::Boolean => todo!(),
+        IonType::Null | IonType::Boolean => {} // these types have no representation
         IonType::Integer => write_repr_integer(elem.as_any_int(), &mut hasher),
         IonType::Float => write_repr_float(elem.as_f64(), &mut hasher),
         IonType::Decimal | IonType::Timestamp | IonType::Symbol => todo!(),
@@ -66,13 +66,6 @@ fn write_repr_integer<U: Update>(value: Option<&AnyInt>, hasher: &mut UpdateEsca
     }
 }
 
-fn write_repr_string<U: Update>(value: Option<&str>, hasher: &mut UpdateEscaping<'_, U>) {
-    match value {
-        Some(s) => hasher.update(s.as_bytes()),
-        None => {}
-    }
-}
-
 /// Floats are encoded as big-endian octets of their IEEE-754 bit patterns,
 /// except for special cases: +-zero, +-inf and nan.
 fn write_repr_float<U: Update>(value: Option<f64>, hasher: &mut UpdateEscaping<'_, U>) {
@@ -99,5 +92,12 @@ fn write_repr_float<U: Update>(value: Option<f64>, hasher: &mut UpdateEscaping<'
 
             hasher.update(&v.to_be_bytes())
         }
+    }
+}
+
+fn write_repr_string<U: Update>(value: Option<&str>, hasher: &mut UpdateEscaping<'_, U>) {
+    match value {
+        Some(s) => hasher.update(s.as_bytes()),
+        None => {}
     }
 }

--- a/ion-hash/src/type_qualifier.rs
+++ b/ion-hash/src/type_qualifier.rs
@@ -76,8 +76,8 @@ impl TypeQualifier {
             /*IonType::Clob => Clob,
             IonType::Blob => Blob,
             IonType::List => List,
-            IonType::SExpression => SExpression,
-            IonType::Struct => Struct,*/
+            IonType::SExpression => SExpression,*/
+            IonType::Struct => combine(Struct, 0),
             _ => todo!(),
         }
     }

--- a/ion-hash/src/type_qualifier.rs
+++ b/ion-hash/src/type_qualifier.rs
@@ -77,7 +77,7 @@ impl TypeQualifier {
             IonType::Blob => Blob,
             IonType::List => List,
             IonType::SExpression => SExpression,*/
-            IonType::Struct => combine(Struct, 0),
+            /*IonType::Struct => combine(Struct, 0),*/
             _ => todo!(),
         }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,7 +11,7 @@ pub mod timestamp;
 
 use crate::result::{illegal_operation, IonError};
 use ion_c_sys::ION_TYPE;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt};
 
 /// Represents the Ion data type of a given value. To learn more about each data type,
 /// read [the Ion Data Model](http://amzn.github.io/ion-docs/docs/spec.html#the-ion-data-model)
@@ -31,6 +31,30 @@ pub enum IonType {
     List,
     SExpression,
     Struct,
+}
+
+impl fmt::Display for IonType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                IonType::Null => "null",
+                IonType::Boolean => "boolean",
+                IonType::Integer => "integer",
+                IonType::Float => "float",
+                IonType::Decimal => "decimal",
+                IonType::Timestamp => "timestamp",
+                IonType::Symbol => "symbol",
+                IonType::String => "string",
+                IonType::Clob => "clob",
+                IonType::Blob => "blob",
+                IonType::List => "list",
+                IonType::SExpression => "sexp",
+                IonType::Struct => "struct",
+            }
+        )
+    }
 }
 
 impl IonType {


### PR DESCRIPTION
Before this commit, every `Element` visited during ion hash computation
would need to allocate a vector: because each element type can be
represented by a variable number of bytes! For example, a boolean has no
representation while a string is representated by its UTF8 bytes.

This commit fixes that by having the representation implementation write
to the digester directly. For some types (like a BigInt) we will still
need a variable length vector. But in other cases, we now no longer need
to allocate.

While implementing this, I wanted to make the escape method also not
require allocation. This is a simple case of wrapping the `update`
method to maybe write two bytes per byte written. However, because we
were dependent on the `Digest` trait, writing the wrapper required
wrapping all of those methods. In this commit, we move away from the
`Digest` trait and rather use the traits that *make up* that trait. This
means the escaping wrapper just needs to worry about `update`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.