### PR TITLE
Use new decimal encoding to fix #274

### DIFF
--- a/ion-hash/tests/ion_hash_tests.rs
+++ b/ion-hash/tests/ion_hash_tests.rs
@@ -85,9 +85,6 @@ const IGNORE_LIST: &[&'static str] = &[
     r#"{a:{d:[1,2,3],b:{c:5}},e:6}"#,
     // Uses md5 (not identity)
     r#"{Metrics:{'Event.Catchup':[{Value:0,Unit:ms}],'FanoutCache.Time':[{Value:1,Unit:ms}]}}"#,
-    // timestamps, broken because we always write out fractional seconds as nanoseconds
-    r#"2000-01-01T00:00:00.0Z"#,
-    r#"2000-01-01T00:00:00.00Z"#,
 ];
 
 fn should_ignore(test_name: &str) -> bool {


### PR DESCRIPTION
*Issue #, if available:* #273

*Description of changes:*

This commit uses the new decimal encoder to encode fractional timestamps
as a decimal. Two timestamp tests that were failing now pass!

-------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.