### PR TITLE
Move ion-hash implementation behind traits

### DIFF
--- a/ion-hash/src/element_hasher.rs
+++ b/ion-hash/src/element_hasher.rs
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+//! Provides [`ElementHasher`], a single-use IonHash implementation for an
+//! [`Element`].
+
+use std::io;
+
+use digest::{FixedOutput, Output, Reset, Update};
+use ion_rs::result::IonResult;
+use ion_rs::value::Element;
+
+use crate::representation::RepresentationEncoder;
+use crate::type_qualifier::TypeQualifier;
+use crate::Markers;
+
+pub(crate) struct ElementHasher<D>
+where
+    D: Update + FixedOutput + Reset + Clone + Default,
+{
+    pub(crate) digest: D,
+}
+
+impl<D> ElementHasher<D>
+where
+    D: Update + FixedOutput + Reset + Clone + Default,
+{
+    pub(crate) fn new(digest: D) -> ElementHasher<D> {
+        ElementHasher { digest }
+    }
+
+    pub(crate) fn hash_element<E>(mut self, elem: &E) -> IonResult<Output<D>>
+    where
+        E: Element + ?Sized,
+    {
+        self.update_serialized_bytes(elem)?;
+        Ok(self.digest.finalize_fixed())
+    }
+
+    /// Implements the "serialized bytes" transform as described in the spec. The
+    /// bytes are written to `hasher` (as opposed to returned) for performance
+    /// reasons (avoid allocations for DSTs).
+    pub(crate) fn update_serialized_bytes<E>(&mut self, elem: &E) -> IonResult<()>
+    where
+        E: Element + ?Sized,
+    {
+        self.mark_begin();
+        self.update_type_qualifier_and_representation(elem)?;
+        // TODO: Annotations
+        self.mark_end();
+
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn mark_begin(&mut self) {
+        self.digest.update([Markers::B]);
+    }
+
+    #[inline]
+    pub(crate) fn mark_end(&mut self) {
+        self.digest.update([Markers::E]);
+    }
+
+    pub(crate) fn update_type_qualifier_and_representation<E>(&mut self, elem: &E) -> IonResult<()>
+    where
+        E: Element + ?Sized,
+    {
+        let tq = TypeQualifier::from_element(elem);
+        self.digest.update(tq.as_bytes());
+        self.update_with_representation(elem)
+    }
+
+    /// Escapes various markers as per the spec. Allocates a temporary array to
+    /// do so.
+    pub(crate) fn update_escaping(&mut self, data: impl AsRef<[u8]>) {
+        let mut escaped = vec![];
+
+        for byte in data.as_ref() {
+            if let Markers::B | Markers::E | Markers::ESC = *byte {
+                escaped.extend(&[Markers::ESC, *byte]);
+            } else {
+                escaped.extend(&[*byte]);
+            }
+        }
+
+        self.digest.update(escaped);
+    }
+}
+
+/// The ion-rust crate uses the `io::Write` trait as a sink for writing
+/// representations. This implementation provides compatibility with the
+/// `Digest` trait (represented as a set of "sub"-traits). We have no need of an
+/// intermediate buffer!
+impl<D> io::Write for ElementHasher<D>
+where
+    D: Update + FixedOutput + Reset + Clone + Default,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.update_escaping(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/ion-hash/src/lib.rs
+++ b/ion-hash/src/lib.rs
@@ -16,17 +16,16 @@
 //! # }
 //! ```
 
-use std::io;
-
 use digest::{FixedOutput, Output, Reset, Update};
 use ion_rs::result::IonResult;
 use ion_rs::value::Element;
 
-use representation::RepresentationEncoder;
 // TODO: Make sha2 an optional dependency.
 use sha2::Sha256;
-use type_qualifier::TypeQualifier;
 
+use element_hasher::ElementHasher;
+
+mod element_hasher;
 mod representation;
 mod type_qualifier;
 
@@ -47,15 +46,25 @@ impl Markers {
     const ESC: u8 = 0x0C;
 }
 
+/// This trait mostly exists to extend the [`Digest`] trait to support Ion Hash.
+/// See [`hash_element`].
 pub trait IonHasher<E>
 where
     E: Element + ?Sized,
 {
     type Output;
 
+    /// Returns the Ion Hash of the given [`Element`].
     fn hash_element(elem: &E) -> IonResult<Self::Output>;
 }
 
+/// Implements [`IonHasher`] for any type that implements `Digest`.
+///
+/// Note: the `Digest` trait is implemented for types that implement a set of
+/// traits. You should read the `D` generic as `Digest`. The reason we list the
+/// subtraits here is that implementors have much less work to do if they
+/// implment the subtraits only, as the blanket impls in the `digest` crate take
+/// care of assembly.
 impl<E, D> IonHasher<E> for D
 where
     E: Element + ?Sized,
@@ -63,110 +72,9 @@ where
 {
     type Output = digest::Output<D>;
 
-    // TODO: In the fullness of time, we will have a IonHashReader and a
-    // IonHashWriter. This will allow reading/writing a value *while* computing a
-    // hash. For now, we provide a standalone hasher using the Element API.
     /// Provides Ion hash over arbitrary [`Element`] instances with a given
     /// [`Digest`] algorithm.
-    ///
-    /// Note that [`Digest`] *does not imply* the following traits directly, but is
-    /// a *convenience* trait for these other traits with a blanked implementation.
-    /// This is the reason for this is we can't go from [`Digest`] to these
-    /// traits (e.g. [`Update`]) but because of a blanket implementation, we can go
-    /// the other way.
     fn hash_element(elem: &E) -> IonResult<Self::Output> {
         ElementHasher::new(D::default()).hash_element(elem)
-    }
-}
-
-struct ElementHasher<D>
-where
-    D: Update + FixedOutput + Reset + Clone + Default,
-{
-    pub(crate) digest: D,
-}
-
-impl<D> ElementHasher<D>
-where
-    D: Update + FixedOutput + Reset + Clone + Default,
-{
-    fn new(digest: D) -> ElementHasher<D> {
-        ElementHasher { digest }
-    }
-
-    fn hash_element<E>(mut self, elem: &E) -> IonResult<Output<D>>
-    where
-        E: Element + ?Sized,
-    {
-        self.update_serialized_bytes(elem)?;
-        Ok(self.digest.finalize_fixed())
-    }
-
-    /// Implements the "serialized bytes" transform as described in the spec. The
-    /// bytes are written to `hasher` (as opposed to returned) for performance
-    /// reasons (avoid allocations for DSTs).
-    fn update_serialized_bytes<E>(&mut self, elem: &E) -> IonResult<()>
-    where
-        E: Element + ?Sized,
-    {
-        self.mark_begin();
-        self.update_type_qualifier_and_representation(elem)?;
-        // TODO: Annotations
-        self.mark_end();
-
-        Ok(())
-    }
-
-    #[inline]
-    fn mark_begin(&mut self) {
-        self.digest.update([Markers::B]);
-    }
-
-    #[inline]
-    fn mark_end(&mut self) {
-        self.digest.update([Markers::E]);
-    }
-
-    fn update_type_qualifier_and_representation<E>(&mut self, elem: &E) -> IonResult<()>
-    where
-        E: Element + ?Sized,
-    {
-        let tq = TypeQualifier::from_element(elem);
-        self.digest.update(tq.as_bytes());
-        self.update_with_representation(elem)
-    }
-
-    /// Escapes various markers as per the spec. Allocates a temporary array to
-    /// do so.
-    fn update_escaping(&mut self, data: impl AsRef<[u8]>) {
-        let mut escaped = vec![];
-
-        for byte in data.as_ref() {
-            if let Markers::B | Markers::E | Markers::ESC = *byte {
-                escaped.extend(&[Markers::ESC, *byte]);
-            } else {
-                escaped.extend(&[*byte]);
-            }
-        }
-
-        self.digest.update(escaped);
-    }
-}
-
-/// The ion-rust crate uses the `io::Write` trait as a sink for writing
-/// representations. This implementation provides compatibility with the
-/// `Digest` trait (represented as a set of "sub"-traits). We have no need of an
-/// intermediate buffer!
-impl<D> io::Write for ElementHasher<D>
-where
-    D: Update + FixedOutput + Reset + Clone + Default,
-{
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.update_escaping(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
     }
 }

--- a/ion-hash/src/lib.rs
+++ b/ion-hash/src/lib.rs
@@ -16,6 +16,8 @@
 //! # }
 //! ```
 
+use std::io;
+
 use digest::{FixedOutput, Output, Reset, Update};
 use ion_rs::result::IonResult;
 use ion_rs::value::Element;
@@ -45,27 +47,16 @@ impl Markers {
     const ESC: u8 = 0x0C;
 }
 
-pub trait ElementHasher<E>
+pub trait IonHasher<E>
 where
     E: Element + ?Sized,
 {
     type Output;
 
     fn hash_element(elem: &E) -> IonResult<Self::Output>;
-
-    /// Implements the "serialized bytes" transform as described in the spec. The
-    /// bytes are written to `hasher` (as opposed to returned) for performance
-    /// reasons (avoid allocations for DSTs).
-    fn update_serialized_bytes(&mut self, elem: &E) -> IonResult<()>;
-
-    fn mark_begin(&mut self);
-
-    fn mark_end(&mut self);
-
-    fn update_type_qualifier_and_representation(&mut self, elem: &E) -> IonResult<()>;
 }
 
-impl<E, D> ElementHasher<E> for D
+impl<E, D> IonHasher<E> for D
 where
     E: Element + ?Sized,
     D: Update + FixedOutput + Reset + Clone + Default,
@@ -84,36 +75,98 @@ where
     /// traits (e.g. [`Update`]) but because of a blanket implementation, we can go
     /// the other way.
     fn hash_element(elem: &E) -> IonResult<Self::Output> {
-        let mut hasher = D::default();
-        hasher.update_serialized_bytes(elem)?;
-        Ok(hasher.finalize_fixed())
+        ElementHasher::new(D::default()).hash_element(elem)
+    }
+}
+
+struct ElementHasher<D>
+where
+    D: Update + FixedOutput + Reset + Clone + Default,
+{
+    pub(crate) digest: D,
+}
+
+impl<D> ElementHasher<D>
+where
+    D: Update + FixedOutput + Reset + Clone + Default,
+{
+    fn new(digest: D) -> ElementHasher<D> {
+        ElementHasher { digest }
+    }
+
+    fn hash_element<E>(mut self, elem: &E) -> IonResult<Output<D>>
+    where
+        E: Element + ?Sized,
+    {
+        self.update_serialized_bytes(elem)?;
+        Ok(self.digest.finalize_fixed())
     }
 
     /// Implements the "serialized bytes" transform as described in the spec. The
     /// bytes are written to `hasher` (as opposed to returned) for performance
     /// reasons (avoid allocations for DSTs).
-    fn update_serialized_bytes(&mut self, elem: &E) -> IonResult<()> {
-        ElementHasher::<E>::mark_begin(self); // :puke:
+    fn update_serialized_bytes<E>(&mut self, elem: &E) -> IonResult<()>
+    where
+        E: Element + ?Sized,
+    {
+        self.mark_begin();
         self.update_type_qualifier_and_representation(elem)?;
         // TODO: Annotations
-        ElementHasher::<E>::mark_end(self);
+        self.mark_end();
 
         Ok(())
     }
 
     #[inline]
     fn mark_begin(&mut self) {
-        self.update([Markers::B]);
+        self.digest.update([Markers::B]);
     }
 
     #[inline]
     fn mark_end(&mut self) {
-        self.update([Markers::E]);
+        self.digest.update([Markers::E]);
     }
 
-    fn update_type_qualifier_and_representation(&mut self, elem: &E) -> IonResult<()> {
+    fn update_type_qualifier_and_representation<E>(&mut self, elem: &E) -> IonResult<()>
+    where
+        E: Element + ?Sized,
+    {
         let tq = TypeQualifier::from_element(elem);
-        self.update(tq.as_bytes());
+        self.digest.update(tq.as_bytes());
         self.update_with_representation(elem)
+    }
+
+    /// Escapes various markers as per the spec. Allocates a temporary array to
+    /// do so.
+    fn update_escaping(&mut self, data: impl AsRef<[u8]>) {
+        let mut escaped = vec![];
+
+        for byte in data.as_ref() {
+            if let Markers::B | Markers::E | Markers::ESC = *byte {
+                escaped.extend(&[Markers::ESC, *byte]);
+            } else {
+                escaped.extend(&[*byte]);
+            }
+        }
+
+        self.digest.update(escaped);
+    }
+}
+
+/// The ion-rust crate uses the `io::Write` trait as a sink for writing
+/// representations. This implementation provides compatibility with the
+/// `Digest` trait (represented as a set of "sub"-traits). We have no need of an
+/// intermediate buffer!
+impl<D> io::Write for ElementHasher<D>
+where
+    D: Update + FixedOutput + Reset + Clone + Default,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.update_escaping(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }

--- a/ion-hash/src/lib.rs
+++ b/ion-hash/src/lib.rs
@@ -18,8 +18,9 @@
 
 use digest::{FixedOutput, Output, Reset, Update};
 use ion_rs::result::IonResult;
-use ion_rs::{value::Element, IonType};
+use ion_rs::value::Element;
 
+use representation::RepresentationEncoder;
 // TODO: Make sha2 an optional dependency.
 use sha2::Sha256;
 use type_qualifier::TypeQualifier;
@@ -30,7 +31,7 @@ mod type_qualifier;
 /// Utility to hash an [`Element`] using SHA-256 as the hash function.
 // TODO: Make this conditional on some feature flag
 pub fn sha256<E: Element + ?Sized>(elem: &E) -> IonResult<Output<Sha256>> {
-    hash_element::<E, Sha256>(elem)
+    Sha256::hash_element(elem)
 }
 
 /// Bytes markers as per the spec.
@@ -44,76 +45,75 @@ impl Markers {
     const ESC: u8 = 0x0C;
 }
 
-// TODO: In the fullness of time, we will have a IonHashReader and a
-// IonHashWriter. This will allow reading/writing a value *while* computing a
-// hash. For now, we provide a standalone hasher using the Element API.
-/// Provides Ion hash over arbitrary [`Element`] instances with a given
-/// [`Digest`] algorithm.
-///
-/// Note that [`Digest`] *does not imply* the following traits directly, but is
-/// a *convenience* trait for these other traits with a blanked implementation.
-/// This is the reason for this is we can't go from [`Digest`] to these
-/// traits (e.g. [`Update`]) but because of a blanket implementation, we can go
-/// the other way.
-pub fn hash_element<E, D>(elem: &E) -> IonResult<Output<D>>
+pub trait ElementHasher<E>
+where
+    E: Element + ?Sized,
+{
+    type Output;
+
+    fn hash_element(elem: &E) -> IonResult<Self::Output>;
+
+    /// Implements the "serialized bytes" transform as described in the spec. The
+    /// bytes are written to `hasher` (as opposed to returned) for performance
+    /// reasons (avoid allocations for DSTs).
+    fn update_serialized_bytes(&mut self, elem: &E) -> IonResult<()>;
+
+    fn mark_begin(&mut self);
+
+    fn mark_end(&mut self);
+
+    fn update_type_qualifier_and_representation(&mut self, elem: &E) -> IonResult<()>;
+}
+
+impl<E, D> ElementHasher<E> for D
 where
     E: Element + ?Sized,
     D: Update + FixedOutput + Reset + Clone + Default,
 {
-    let mut hasher = D::default();
-    update_serialized_bytes(elem, &mut hasher)?;
-    Ok(hasher.finalize_fixed())
-}
+    type Output = digest::Output<D>;
 
-/// Implements the "serialized bytes" transform as described in the spec. The
-/// bytes are written to `hasher` (as opposed to returned) for performance
-/// reasons (avoid allocations for DSTs).
-fn update_serialized_bytes<E, D>(elem: &E, hasher: &mut D) -> IonResult<()>
-where
-    E: Element + ?Sized,
-    D: Update + FixedOutput + Reset + Clone + Default,
-{
-    mark_begin(hasher);
-    match elem.ion_type() {
-        IonType::Null | IonType::Boolean => update_type_qualifier(elem, hasher),
-        IonType::Integer
-        | IonType::Float
-        | IonType::Decimal
-        | IonType::Timestamp
-        | IonType::Symbol
-        | IonType::String
-        | IonType::Clob
-        | IonType::Blob
-        | IonType::Struct
-        | IonType::List
-        | IonType::SExpression => update_type_qualifier_and_representation(elem, hasher)?,
-    };
-    // TODO: Annotations
-    mark_end(hasher);
+    // TODO: In the fullness of time, we will have a IonHashReader and a
+    // IonHashWriter. This will allow reading/writing a value *while* computing a
+    // hash. For now, we provide a standalone hasher using the Element API.
+    /// Provides Ion hash over arbitrary [`Element`] instances with a given
+    /// [`Digest`] algorithm.
+    ///
+    /// Note that [`Digest`] *does not imply* the following traits directly, but is
+    /// a *convenience* trait for these other traits with a blanked implementation.
+    /// This is the reason for this is we can't go from [`Digest`] to these
+    /// traits (e.g. [`Update`]) but because of a blanket implementation, we can go
+    /// the other way.
+    fn hash_element(elem: &E) -> IonResult<Self::Output> {
+        let mut hasher = D::default();
+        hasher.update_serialized_bytes(elem)?;
+        Ok(hasher.finalize_fixed())
+    }
 
-    Ok(())
-}
+    /// Implements the "serialized bytes" transform as described in the spec. The
+    /// bytes are written to `hasher` (as opposed to returned) for performance
+    /// reasons (avoid allocations for DSTs).
+    fn update_serialized_bytes(&mut self, elem: &E) -> IonResult<()> {
+        ElementHasher::<E>::mark_begin(self); // :puke:
+        self.update_type_qualifier_and_representation(elem)?;
+        // TODO: Annotations
+        ElementHasher::<E>::mark_end(self);
 
-#[inline]
-fn mark_begin<U: Update>(hasher: &mut U) {
-    hasher.update([Markers::B]);
-}
+        Ok(())
+    }
 
-#[inline]
-fn mark_end<U: Update>(hasher: &mut U) {
-    hasher.update([Markers::E]);
-}
+    #[inline]
+    fn mark_begin(&mut self) {
+        self.update([Markers::B]);
+    }
 
-fn update_type_qualifier<E: Element + ?Sized, U: Update>(elem: &E, hasher: &mut U) {
-    let tq = TypeQualifier::from_element(elem);
-    hasher.update(tq.as_bytes());
-}
+    #[inline]
+    fn mark_end(&mut self) {
+        self.update([Markers::E]);
+    }
 
-fn update_type_qualifier_and_representation<E, D>(elem: &E, hasher: &mut D) -> IonResult<()>
-where
-    E: Element + ?Sized,
-    D: Update + FixedOutput + Reset + Clone + Default,
-{
-    update_type_qualifier(elem, hasher);
-    representation::update_with_representation(elem, hasher)
+    fn update_type_qualifier_and_representation(&mut self, elem: &E) -> IonResult<()> {
+        let tq = TypeQualifier::from_element(elem);
+        self.update(tq.as_bytes());
+        self.update_with_representation(elem)
+    }
 }

--- a/ion-hash/src/representation.rs
+++ b/ion-hash/src/representation.rs
@@ -6,8 +6,8 @@
 //! instead. This implementation fills in that gap, and is focused on coverage
 //! and not speed.
 
+use crate::element_hasher::ElementHasher;
 use crate::type_qualifier::type_qualifier_symbol;
-use crate::ElementHasher;
 use digest::{FixedOutput, Output, Reset, Update};
 use ion_rs::binary::{self, decimal::DecimalBinaryEncoder, timestamp::TimestampBinaryEncoder};
 use ion_rs::types::decimal::Decimal;

--- a/ion-hash/tests/ion_hash_tests.rs
+++ b/ion-hash/tests/ion_hash_tests.rs
@@ -2,7 +2,7 @@
 
 use digest::consts::U4096;
 use digest::{FixedOutput, Reset, Update};
-use ion_hash;
+use ion_hash::ElementHasher;
 use ion_rs::result::{illegal_operation, IonResult};
 use ion_rs::value::reader::{element_reader, ElementReader};
 use ion_rs::value::*;
@@ -177,7 +177,7 @@ fn test_case<E1: Element, E2: Element>(input: &E1, expect: &E2) -> IonResult<()>
     let strukt = expect.as_struct().expect("`expect` should be a struct");
     let expected = expected_hash(strukt)?;
 
-    let result = ion_hash::hash_element::<E1, IdentityDigest>(input)?;
+    let result = IdentityDigest::hash_element(input)?;
 
     // Ignore trailing empty bytes caused by the identity digest producing a
     // variable sized result. Without this, any test failure will write lots of

--- a/ion-hash/tests/ion_hash_tests.rs
+++ b/ion-hash/tests/ion_hash_tests.rs
@@ -2,7 +2,7 @@
 
 use digest::consts::U4096;
 use digest::{FixedOutput, Reset, Update};
-use ion_hash::ElementHasher;
+use ion_hash::IonHasher;
 use ion_rs::result::{illegal_operation, IonResult};
 use ion_rs::value::reader::{element_reader, ElementReader};
 use ion_rs::value::*;


### PR DESCRIPTION
Before this commit, we were passing around a sink (that implements
digest or write) as a `&mut` "out" parameter. Ugly in general, but even
more so given we had to repeat the `Digest` subtraits over and over.

Now, we have two traits (split simply for code organization). One trait
handles the overall hashing orchestration, while another handles the
representation. Other than some funny business with calling syntax, this
worked out pretty nicely!

Note that I absolutely have _not_ thought through the traits
nicely (i.e. "are we happy with the public/private split?" was not a
consideration). Rather, I focused on the mechanical refactoring to see
if this was worth it. There are loads of doc/comments that don't make
sense anymore that I'll fix up shortly!

-------

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.