### PR TITLE
Makes IonDataSource report EOF reliably

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2021-05-07
+          toolchain: nightly-2021-08-30
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -299,7 +299,6 @@ mod tests {
 
         // TODO: IonResult should have a distinct `IncompleteData` error case
         //       https://github.com/amzn/ion-rust/issues/299
-        println!("{:?}", result);
         assert!(matches!(result, Err(IonError::DecodingError { .. })));
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -12,7 +12,6 @@ pub enum IonError {
     // TODO: Add an `IncompleteData` error variant that provides position information,
     //       what was being read, the number of bytes needed, etc.
     //       See: https://github.com/amzn/ion-rust/issues/299
-
     /// Indicates that an IO error was encountered while reading or writing.
     #[error("{source:?}")]
     IoError {

--- a/src/result.rs
+++ b/src/result.rs
@@ -9,6 +9,10 @@ pub type IonResult<T> = Result<T, IonError>;
 /// Represents the different types of high-level failures that might occur when reading Ion data.
 #[derive(Debug, Error)]
 pub enum IonError {
+    // TODO: Add an `IncompleteData` error variant that provides position information,
+    //       what was being read, the number of bytes needed, etc.
+    //       See: https://github.com/amzn/ion-rust/issues/299
+
     /// Indicates that an IO error was encountered while reading or writing.
     #[error("{source:?}")]
     IoError {


### PR DESCRIPTION
Prior to this commit, multiple methods in the IonDataSource trait would
either loop infinitely or return an `IoError` in the event of an
unexpected EOF.

This commit causes all of the methods in question to detect EOFs and
report them as a decoding error. Work needed to add a proper
IonError::IncompleteData enum variant is being tracked in #299.

Fixes #300.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
