### PR TITLE
Adds a `write_timestamp` method to the text writer

### DIFF
--- a/src/text/writer.rs
+++ b/src/text/writer.rs
@@ -519,7 +519,10 @@ mod tests {
             .with_hms(15, 45, 11)
             .build_at_offset(2 * 60)
             .expect("building timestamp failed");
-        writer_test(|w| w.write_timestamp(&timestamp), "2000-08-22T15:45:11+02:00\n");
+        writer_test(
+            |w| w.write_timestamp(&timestamp),
+            "2000-08-22T15:45:11+02:00\n",
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR adds a `write_timestamp` method alongside the existing
`write_datetime` method, which is now marked deprecated. This
allows users to write an Ion timestamp in textwith full fidelity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
