### PR TITLE
 Adds `write_timestamp` to binary writer

### DIFF
--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -571,7 +571,7 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
         let builder = builder.with_hour_and_minute(hour, minute);
         if self.finished_reading_value() {
             let timestamp = if is_known_offset {
-                builder.build_at_offset(offset_minutes)
+                builder.build_utc_fields_at_offset(offset_minutes)
             } else {
                 builder.build_at_unknown_offset()
             }?;
@@ -584,7 +584,7 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
         let builder = builder.with_second(second);
         if self.finished_reading_value() {
             let timestamp = if is_known_offset {
-                builder.build_at_offset(offset_minutes)
+                builder.build_utc_fields_at_offset(offset_minutes)
             } else {
                 builder.build_at_unknown_offset()
             }?;
@@ -607,7 +607,7 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
         let builder = builder
             .with_fractional_seconds(Decimal::new(subsecond_coefficient, subsecond_exponent));
         let timestamp = if is_known_offset {
-            builder.build_at_offset(offset_minutes)
+            builder.build_utc_fields_at_offset(offset_minutes)
         } else {
             builder.build_at_unknown_offset()
         }?;

--- a/src/binary/writer.rs
+++ b/src/binary/writer.rs
@@ -844,8 +844,7 @@ mod writer_tests {
                     let reader_value = read_fn(reader)?
                         .expect("Reader expected another value but the stream was empty.");
                     assert_eq!(
-                        reader_value,
-                        *value,
+                        reader_value, *value,
                         "Value read back in (left) was not equal to the original value (right)"
                     );
                 }

--- a/src/binary/writer.rs
+++ b/src/binary/writer.rs
@@ -469,6 +469,10 @@ impl<W: Write> BinarySystemWriter<W> {
     }
 
     /// Writes an Ion timestamp with the specified value.
+    #[deprecated(
+        since = "0.6.1",
+        note = "Please use the `write_timestamp` method instead."
+    )]
     pub fn write_datetime(&mut self, value: &DateTime<FixedOffset>) -> IonResult<()> {
         self.write_scalar(|enc_buffer| {
             // TODO: Currently this clones the Chrono type so we can make a
@@ -476,7 +480,15 @@ impl<W: Write> BinarySystemWriter<W> {
             // However, this API (`write_datetime`) is probably also not quite
             // right.
             let timestamp: Timestamp = value.clone().into();
-            let _ = enc_buffer.encode_timestamp_value(&timestamp);
+            let _ = enc_buffer.encode_timestamp_value(&timestamp)?;
+            Ok(())
+        })
+    }
+
+    /// Writes an Ion timestamp with the specified value.
+    pub fn write_timestamp(&mut self, value: &Timestamp) -> IonResult<()> {
+        self.write_scalar(|enc_buffer| {
+            let _ = enc_buffer.encode_timestamp_value(&value)?;
             Ok(())
         })
     }
@@ -777,9 +789,9 @@ impl<W: Write> BinarySystemWriter<W> {
 mod writer_tests {
     use std::fmt::Debug;
 
-    use chrono::ParseResult;
-
     use crate::{BinaryIonCursor, Reader};
+
+    use rstest::*;
 
     use super::*;
 
@@ -831,7 +843,11 @@ mod writer_tests {
                     assert_eq!(reader.next()?, Some((ion_type, false)));
                     let reader_value = read_fn(reader)?
                         .expect("Reader expected another value but the stream was empty.");
-                    assert_eq!(reader_value, *value);
+                    assert_eq!(
+                        reader_value,
+                        *value,
+                        "Value read back in (left) was not equal to the original value (right)"
+                    );
                 }
                 Ok(())
             },
@@ -902,26 +918,44 @@ mod writer_tests {
         )
     }
 
-    #[test]
-    fn binary_writer_timestamps() -> IonResult<()> {
-        let iso_8601_strings = [
-            "2000-01-01T00:00:00+00:00",
-            "2021-01-08T14:12:36+00:00",
-            "2021-01-08T14:12:36-05:00",
-            "2021-01-08T14:12:36.888-05:00",
-            "2021-01-08T14:12:36.888888-05:00",
-            "2021-01-08T14:12:36.888888888-05:00",
-        ];
-        let values: Vec<DateTime<FixedOffset>> = iso_8601_strings
-            .iter()
-            .map(|s| DateTime::parse_from_rfc3339(s))
-            .map(ParseResult::unwrap)
-            .collect();
+    #[rstest]
+    #[case("2000-01-01T00:00:00+00:00")]
+    #[case("2021-01-08T14:12:36+00:00")]
+    #[case("2021-01-08T14:12:36-05:00")]
+    #[case("2021-01-08T14:12:36.888-05:00")]
+    #[case("2021-01-08T14:12:36.888888-05:00")]
+    #[case("2021-01-08T14:12:36.888888888-05:00")]
+    fn binary_writer_datetimes(#[case] rfc3339_datetime: &str) -> IonResult<()> {
+        let datetime = DateTime::parse_from_rfc3339(rfc3339_datetime).unwrap();
         binary_writer_scalar_test(
-            &values,
+            &[datetime],
             IonType::Timestamp,
-            |writer, v| writer.write_datetime(v),
+            |writer, v| {
+                #[allow(deprecated)] // `write_datetime` is deprecated
+                writer.write_datetime(v)
+            },
             |reader| reader.read_datetime(),
+        )
+    }
+
+    #[rstest]
+    #[case::year(Timestamp::with_year(2021).build().unwrap())]
+    #[case::year_month(Timestamp::with_year(2021).with_month(1).build().unwrap())]
+    #[case::year_month_day(Timestamp::with_ymd(2021, 1, 8).build().unwrap())]
+    #[case::ymd_hm_unknown(Timestamp::with_ymd(2021, 1, 8).with_hour_and_minute(14, 12).build_at_unknown_offset().unwrap())]
+    #[case::ymd_hm_est(Timestamp::with_ymd(2021, 1, 8).with_hour_and_minute(14, 12).build_at_offset(-5 * 60).unwrap())]
+    #[case::ymd_hms_unknown(Timestamp::with_ymd(2021, 1, 8).with_hms(14, 12, 36).build_at_unknown_offset().unwrap())]
+    #[case::ymd_hms_est(Timestamp::with_ymd(2021, 1, 8).with_hms(14, 12, 36).build_at_offset(-5 * 60).unwrap())]
+    #[case::ymd_hms_millis_unknown(Timestamp::with_ymd(2021, 1, 8).with_hms(14, 12, 36).with_milliseconds(888).build_at_unknown_offset().unwrap())]
+    #[case::ymd_hms_millis_est(Timestamp::with_ymd(2021, 1, 8).with_hms(14, 12, 36).with_milliseconds(888).build_at_offset(-5 * 60).unwrap())]
+    #[case::ymd_hms_nanos_unknown(Timestamp::with_ymd(2021, 1, 8).with_hms(14, 12, 36).with_nanoseconds(888888888).build_at_unknown_offset().unwrap())]
+    #[case::ymd_hms_nanos_est(Timestamp::with_ymd(2021, 1, 8).with_hms(14, 12, 36).with_nanoseconds(888888888).build_at_offset(-5 * 60).unwrap())]
+    fn binary_writer_timestamps(#[case] timestamp: Timestamp) -> IonResult<()> {
+        binary_writer_scalar_test(
+            &[timestamp],
+            IonType::Timestamp,
+            |writer, v| writer.write_timestamp(v),
+            |reader| reader.read_timestamp(),
         )
     }
 

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,7 +1,7 @@
 use crate::result::{illegal_operation, illegal_operation_raw, IonError, IonResult};
 use crate::types::decimal::Decimal;
 use crate::types::magnitude::Magnitude;
-use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, TimeZone, Timelike};
+use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, TimeZone, Timelike, LocalResult};
 use ion_c_sys::timestamp::{IonDateTime, TSOffsetKind, TSPrecision};
 use std::convert::TryInto;
 use std::fmt::Debug;
@@ -300,6 +300,7 @@ impl PartialEq for Timestamp {
 // See the unit tests for usage examples.
 #[derive(Debug, Clone, Default)]
 struct TimestampBuilder {
+    fields_are_utc: bool,
     precision: Precision,
     offset: Option<i32>,
     year: u16,
@@ -381,34 +382,82 @@ impl TimestampBuilder {
         Ok(datetime)
     }
 
+    // A [NaiveDateTime] has no offset. This function attempts to apply the provided offset to the
+    // NaiveDateTime, producing a DateTime<FixedOffset>. If the offset is invalid or the combination
+    // of offset and datetime would produce an invalid Timestamp, this function will return Err.
+    fn apply_offset(
+        offset_minutes: i32,
+        fields_are_utc: bool,
+        datetime: NaiveDateTime) -> IonResult<DateTime<FixedOffset>> {
+        // The chrono APIs express their DateTime offsets in seconds, but the Ion APIs use minutes.
+        const SECONDS_PER_MINUTE: i32 = 60;
+        let offset_seconds = offset_minutes * SECONDS_PER_MINUTE;
+        let offset = FixedOffset::east_opt(offset_seconds).ok_or_else(|| {
+            illegal_operation_raw(format!("specified offset ({} minutes) is invalid", offset_minutes))
+        })?;
+
+        // If the fields of the datetime are UTC, constructing a DateTime<FixedOffset> is guaranteed
+        // to succeed. Return it directly.
+        if fields_are_utc {
+            return Ok(offset.from_utc_datetime(&datetime));
+        }
+
+        // Otherwise, apply the offset to our (local) NaiveDateTime and make sure the resulting
+        // DateTime<FixedOffset> is valid.
+        return match offset.from_local_datetime(&datetime) {
+            LocalResult::None => {
+                illegal_operation(
+                    format!(
+                        "specified offset/datetime pair is invalid (offset={}, datetime={})",
+                        offset_minutes,
+                        datetime
+                    )
+                )
+            },
+            LocalResult::Single(datetime) => Ok(datetime),
+            LocalResult::Ambiguous(_min, _max) => {
+                illegal_operation(
+                    format!(
+                        "specified offset/datetime pair produces an ambiguous timestamp (offset={}, datetime={})",
+                        offset_minutes,
+                        datetime
+                    )
+                )
+            }
+        }
+    }
+
     /// Attempt to construct a [Timestamp] using the values configured on the [TimestampBuilder].
     /// If any of the individual fields are invalid (for example, a `month` value that is greater
     /// than `12`) or if the resulting timestamp would represent a non-existent point in time
     /// (like those bypassed by daylight saving time), this method will return an `Err(IonError)`.
     fn build(mut self) -> IonResult<Timestamp> {
-        if let Some(offset) = self.offset {
-            // Our builder stores the offset in minutes difference from UTC.
-            // We're about to convert to the chrono type which uses seconds.
-            // Both values consider positive to mean Eastern Hemisphere.
-            let offset = FixedOffset::east_opt(offset * 60).ok_or_else(|| {
-                illegal_operation_raw(format!("specified offset ('{}') is invalid", offset))
-            })?;
-            let mut datetime: DateTime<FixedOffset> = offset.ymd(0, 1, 1).and_hms_nano(0, 0, 0, 0);
-            datetime = self.configure_datetime(datetime)?;
-            let mut timestamp = Timestamp::from_datetime(datetime, self.precision);
-            if self.precision == Precision::FractionalSeconds {
-                timestamp.fractional_seconds = self.fractional_seconds;
-            }
-            Ok(timestamp)
+        // Start with a clean slate NaiveDateTime that we can configure. (These are cheap to copy.)
+        let mut datetime: NaiveDateTime = NaiveDate::from_ymd(0, 1, 1)
+            .and_hms_nano(0, 0, 0, 0);
+        // Set all of the time fields on the datetime using the data from our TimestampBuilder
+        datetime = self.configure_datetime(datetime)?;
+        // If the timestamp we're building has a known offset...
+        let mut timestamp: Timestamp = if let Some(offset_minutes) = self.offset {
+            // ...apply the offset to our NaiveDateTime, producing a DateTime<FixedOffset>
+            let datetime_with_offset: DateTime<FixedOffset> = Self::apply_offset(
+                offset_minutes,
+                self.fields_are_utc,
+                datetime
+            )?;
+            // ...and convert the DateTime<FixedOffset> into a full Timestamp.
+            Timestamp::from_datetime(datetime_with_offset, self.precision)
         } else {
-            let mut datetime: NaiveDateTime = NaiveDate::from_ymd(0, 1, 1).and_hms_nano(0, 0, 0, 0);
-            datetime = self.configure_datetime(datetime)?;
-            let mut timestamp = Timestamp::from_datetime(datetime, self.precision);
-            if self.precision == Precision::FractionalSeconds {
-                timestamp.fractional_seconds = self.fractional_seconds;
-            }
-            Ok(timestamp)
+            // Otherwise, there's not a known offset. We can directly convert our NaiveDateTime
+            // into a full Timestamp.
+            Timestamp::from_datetime(datetime, self.precision)
+        };
+
+        // Copy the fractional seconds from the builder to the Timestamp.
+        if self.precision == Precision::FractionalSeconds {
+            timestamp.fractional_seconds = self.fractional_seconds;
         }
+        Ok(timestamp)
     }
 }
 
@@ -532,6 +581,13 @@ impl SecondSetter {
         self.into_builder().build()
     }
 
+    /// Like [build_at_offset], but the fields provided for each time unit are understood
+    /// to be in UTC rather than in the local time of the specified offset.
+    pub fn build_utc_fields_at_offset(mut self, offset_minutes: i32) -> IonResult<Timestamp> {
+        self.builder.fields_are_utc = true;
+        self.build_at_offset(offset_minutes)
+    }
+
     pub fn build_at_unknown_offset(mut self) -> IonResult<Timestamp> {
         self.builder.offset = None;
         self.into_builder().build()
@@ -595,6 +651,13 @@ impl FractionalSecondSetter {
     pub fn build_at_offset(mut self, offset_minutes: i32) -> IonResult<Timestamp> {
         self.builder.offset = Some(offset_minutes);
         self.into_builder().build()
+    }
+
+    /// Like [build_at_offset], but the fields provided for each time unit are understood
+    /// to be in UTC rather than in the local time of the specified offset.
+    pub fn build_utc_fields_at_offset(mut self, offset_minutes: i32) -> IonResult<Timestamp> {
+        self.builder.fields_are_utc = true;
+        self.build_at_offset(offset_minutes)
     }
 
     pub fn build_at_unknown_offset(mut self) -> IonResult<Timestamp> {
@@ -799,6 +862,30 @@ mod timestamp_tests {
         let builder = Timestamp::with_ymd_hms(2021, 2, 5, 16, 43, 51);
         let timestamp1 = builder.clone().build_at_offset(5 * 60)?;
         let timestamp2 = builder.clone().build_at_offset(5 * 60)?;
+        assert_eq!(timestamp1, timestamp2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_timestamps_from_utc_and_local_hm_fields_at_same_offset_are_equal() -> IonResult<()> {
+        // Builder 1 specifies its time fields in the local time of the specified offset
+        let builder1 = Timestamp::with_ymd(2021, 2, 5).with_hour_and_minute(11, 43);
+        let timestamp1 = builder1.build_at_offset(-5 * 60)?;
+        // Builder 2 specifies its time fields in UTC and expects the offset to be applied afterwards
+        let builder2 = Timestamp::with_ymd(2021, 2, 5).with_hour_and_minute(16, 43);
+        let timestamp2 = builder2.build_utc_fields_at_offset(-5 * 60)?;
+        assert_eq!(timestamp1, timestamp2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_timestamps_from_utc_and_local_hms_fields_at_same_offset_are_equal() -> IonResult<()> {
+        // Builder 1 specifies its time fields in the local time of the specified offset
+        let builder1 = Timestamp::with_ymd_hms(2021, 2, 5, 11, 43, 51);
+        let timestamp1 = builder1.build_at_offset(-5 * 60)?;
+        // Builder 2 specifies its time fields in UTC and expects the offset to be applied afterwards
+        let builder2 = Timestamp::with_ymd_hms(2021, 2, 5, 16, 43, 51);
+        let timestamp2 = builder2.build_utc_fields_at_offset(-5 * 60)?;
         assert_eq!(timestamp1, timestamp2);
         Ok(())
     }


### PR DESCRIPTION
* Adds a `write_timestamp` method to the binary writer alongside
  `write_datetime`, which is now deprecated.
* Fixes a bug in `read_timestamp` that caused timestamps with
  offsets to constructed incorrectly. Binary Ion encodes each
  time unit field in UTC; prior to this patch, the reader would
  treat those fields as local time. This required adding a
  method to the TimestampBuilder API to allow callers to specify
  that their time units were in UTC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
