### PR TITLE
 Adds a `read_decimal` method to the binary reader

### DIFF
--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -49,7 +49,7 @@ fn read_all_values<R: IonDataSource>(cursor: &mut BinaryIonCursor<R>) -> IonResu
                         let _float = cursor.read_f64()?.unwrap();
                     }
                     Decimal => {
-                        let _decimal = cursor.read_big_decimal()?.unwrap();
+                        let _decimal = cursor.read_decimal()?.unwrap();
                     }
                     Timestamp => {
                         let _timestamp = cursor.read_timestamp()?.unwrap();

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -1258,7 +1258,7 @@ mod tests {
     fn test_read_decimal_positive_exponent() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x52, 0x81, 0x02]);
         assert_eq!(cursor.next()?, Some(Value(IonType::Decimal, false)));
-        assert_eq!(cursor.read_big_decimal()?, Some(20.into()));
+        assert_eq!(cursor.read_decimal()?, Some(20.into()));
         Ok(())
     }
 

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -1142,10 +1142,10 @@ mod tests {
     use crate::binary::cursor::BinaryIonCursor;
     use crate::cursor::{Cursor, StreamItem, StreamItem::*};
     use crate::result::IonResult;
+    use crate::types::decimal::Decimal;
     use crate::types::timestamp::Timestamp;
     use crate::types::IonType;
     use std::convert::TryInto;
-    use crate::types::decimal::Decimal;
 
     type TestDataSource = io::Cursor<Vec<u8>>;
 
@@ -1242,10 +1242,7 @@ mod tests {
     fn test_read_decimal_zero() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x50]);
         assert_eq!(cursor.next()?, Some(Value(IonType::Decimal, false)));
-        assert_eq!(
-            cursor.read_decimal()?,
-            Some(Decimal::new(0, 0))
-        );
+        assert_eq!(cursor.read_decimal()?, Some(Decimal::new(0, 0)));
         Ok(())
     }
 
@@ -1253,10 +1250,7 @@ mod tests {
     fn test_read_decimal_negative_zero() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x52, 0x80, 0x80]);
         assert_eq!(cursor.next()?, Some(Value(IonType::Decimal, false)));
-        assert_eq!(
-            cursor.read_decimal()?,
-            Some(Decimal::negative_zero())
-        );
+        assert_eq!(cursor.read_decimal()?, Some(Decimal::negative_zero()));
         Ok(())
     }
 

--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -16,7 +16,7 @@ pub struct Int {
     value: IntStorage,
     // [IntStorage] is not capable of natively representing negative zero. We track the sign
     // of the value separately so we can distinguish between 0 and -0.
-    is_negative: bool
+    is_negative: bool,
 }
 
 impl Int {
@@ -26,7 +26,7 @@ impl Int {
             return Ok(Int {
                 size_in_bytes: 0,
                 value: 0,
-                is_negative: false
+                is_negative: false,
             });
         } else if length > MAX_INT_SIZE_IN_BYTES {
             return decoding_error(format!(
@@ -57,7 +57,7 @@ impl Int {
         Ok(Int {
             size_in_bytes: length,
             value: magnitude * sign,
-            is_negative: sign == -1
+            is_negative: sign == -1,
         })
     }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -4,6 +4,7 @@ use crate::types::timestamp::Timestamp;
 use crate::types::{IonType, SymbolId};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, FixedOffset};
+use crate::types::decimal::Decimal;
 
 /**
  * This trait captures the format-agnostic parser functionality needed to navigate within an Ion
@@ -56,8 +57,16 @@ pub trait Cursor {
     /// If the current value is a float, returns its value as an f64; otherwise, returns None.
     fn read_f64(&mut self) -> IonResult<Option<f64>>;
 
-    /// If the current value is a decimal, returns its value as an BigDecimal; otherwise,
+    /// If the current value is a decimal, returns its value as a [Decimal]; otherwise,
     /// returns None.
+    fn read_decimal(&mut self) -> IonResult<Option<Decimal>>;
+
+    /// If the current value is a decimal, returns its value as a BigDecimal; otherwise,
+    /// returns None.
+    #[deprecated(
+        since="0.6.1",
+        note="Please use the `read_decimal` method instead."
+    )]
     fn read_big_decimal(&mut self) -> IonResult<Option<BigDecimal>>;
 
     /// If the current value is a string, returns its value as a String; otherwise, returns None.

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,10 +1,10 @@
 use crate::data_source::IonDataSource;
 use crate::result::IonResult;
+use crate::types::decimal::Decimal;
 use crate::types::timestamp::Timestamp;
 use crate::types::{IonType, SymbolId};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, FixedOffset};
-use crate::types::decimal::Decimal;
 
 /**
  * This trait captures the format-agnostic parser functionality needed to navigate within an Ion
@@ -64,8 +64,8 @@ pub trait Cursor {
     /// If the current value is a decimal, returns its value as a BigDecimal; otherwise,
     /// returns None.
     #[deprecated(
-        since="0.6.1",
-        note="Please use the `read_decimal` method instead."
+        since = "0.6.1",
+        note = "Please use the `read_decimal` method instead."
     )]
     fn read_big_decimal(&mut self) -> IonResult<Option<BigDecimal>>;
 


### PR DESCRIPTION
This patch adds a `read_decimal` method to the binary reader
alongside the existing `read_big_decimal` method, which is now
deprecated. Fixes #309.

It also adds an `is_negative` flag to the `Int` encoding primitive,
allowing it to represent negative zero when necessary. Fixes #9.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
