### PR TITLE
Adds streaming support to the text reader

### DIFF
--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,6 +1,8 @@
 pub(in crate::text) mod parsers;
 pub mod reader;
 pub mod writer;
+mod text_buffer;
+mod text_data_source;
 
 use crate::types::decimal::Decimal;
 use crate::types::timestamp::Timestamp;

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,8 +1,8 @@
 pub(in crate::text) mod parsers;
 pub mod reader;
-pub mod writer;
 mod text_buffer;
 mod text_data_source;
+pub mod writer;
 
 use crate::types::decimal::Decimal;
 use crate::types::timestamp::Timestamp;

--- a/src/text/parsers/containers.rs
+++ b/src/text/parsers/containers.rs
@@ -1,0 +1,117 @@
+use nom::IResult;
+use crate::text::TextStreamItem;
+use nom::combinator::{recognize, map};
+use nom::bytes::streaming::tag;
+use nom::branch::alt;
+
+/// Matches the beginning of a container and returns a [TextStreamItem] indicating its type.
+pub(crate) fn parse_container_start(input: &str) -> IResult<&str, TextStreamItem> {
+    alt((
+        recognize_struct_start,
+        recognize_list_start,
+        recognize_s_expression_start
+    ))(input)
+}
+
+/// Matches the beginning of a struct and returns a [TextStreamItem::StructStart].
+pub(crate) fn recognize_struct_start(input: &str) -> IResult<&str, TextStreamItem> {
+    map(
+        recognize(tag("{")),
+        |_matched_text| TextStreamItem::StructStart
+    )(input)
+}
+
+/// Matches the beginning of a list and returns a [TextStreamItem::ListStart].
+pub(crate) fn recognize_list_start(input: &str) -> IResult<&str, TextStreamItem> {
+    map(
+        recognize(tag("[")),
+        |_matched_text| TextStreamItem::ListStart
+    )(input)
+}
+
+/// Matches the beginning of an s-expression and returns a [TextStreamItem::SExpressionStart].
+pub(crate) fn recognize_s_expression_start(input: &str) -> IResult<&str, TextStreamItem> {
+    map(
+        recognize(tag("(")),
+        |_matched_text| TextStreamItem::SExpressionStart
+    )(input)
+}
+
+/// Matches the end of a container and returns a [TextStreamItem] indicating its type.
+pub(crate) fn parse_container_end(input: &str) -> IResult<&str, TextStreamItem> {
+    alt((
+        recognize_struct_end,
+        recognize_list_end,
+        recognize_s_expression_end
+    ))(input)
+}
+
+/// Matches the end of a struct and returns a [TextStreamItem::StructEnd].
+pub(crate) fn recognize_struct_end(input: &str) -> IResult<&str, TextStreamItem> {
+    map(
+        recognize(tag("}")),
+        |_matched_text| TextStreamItem::StructEnd
+    )(input)
+}
+
+/// Matches the end of a list and returns a [TextStreamItem::StructEnd].
+pub(crate) fn recognize_list_end(input: &str) -> IResult<&str, TextStreamItem> {
+    map(
+        recognize(tag("]")),
+        |_matched_text| TextStreamItem::ListEnd
+    )(input)
+}
+
+/// Matches the end of a list and returns a [TextStreamItem::StructEnd].
+pub(crate) fn recognize_s_expression_end(input: &str) -> IResult<&str, TextStreamItem> {
+    map(
+        recognize(tag(")")),
+        |_matched_text| TextStreamItem::SExpressionEnd
+    )(input)
+}
+
+#[cfg(test)]
+mod container_parsing_tests {
+    use rstest::*;
+    use crate::text::parsers::unit_test_support::{parse_test_err, parse_test_ok};
+    use crate::text::TextStreamItem;
+    use crate::text::parsers::containers::{parse_container_start, parse_container_end};
+
+    #[rstest]
+    #[case::start_of_struct("{", TextStreamItem::StructStart)]
+    #[case::start_of_list("[", TextStreamItem::ListStart)]
+    #[case::start_of_s_expression("(", TextStreamItem::SExpressionStart)]
+    fn test_parse_container_start_ok(#[case] text: &str, #[case] expected: TextStreamItem) {
+        parse_test_ok(parse_container_start, text, expected)
+    }
+
+    #[rstest]
+    #[case("5")]
+    #[case("true")]
+    #[case("foo")]
+    #[case("foo::{")]
+    #[case("\"hello\"")]
+    #[case("<")]
+    fn test_parse_container_start_err(#[case] text: &str) {
+        parse_test_err(parse_container_start, text)
+    }
+
+    #[rstest]
+    #[case::end_of_struct("}", TextStreamItem::StructEnd)]
+    #[case::end_of_list("]", TextStreamItem::ListEnd)]
+    #[case::end_of_s_expression(")", TextStreamItem::SExpressionEnd)]
+    fn test_parse_container_end_ok(#[case] text: &str, #[case] expected: TextStreamItem) {
+        parse_test_ok(parse_container_end, text, expected)
+    }
+
+    #[rstest]
+    #[case("5")]
+    #[case("true")]
+    #[case("foo")]
+    #[case("foo::{")]
+    #[case("\"hello\"")]
+    #[case("<")]
+    fn test_parse_container_end_err(#[case] text: &str) {
+        parse_test_err(parse_container_end, text)
+    }
+}

--- a/src/text/parsers/containers.rs
+++ b/src/text/parsers/containers.rs
@@ -1,40 +1,37 @@
-use nom::IResult;
 use crate::text::TextStreamItem;
-use nom::combinator::{recognize, map};
-use nom::bytes::streaming::tag;
 use nom::branch::alt;
+use nom::bytes::streaming::tag;
+use nom::combinator::{map, recognize};
+use nom::IResult;
 
 /// Matches the beginning of a container and returns a [TextStreamItem] indicating its type.
 pub(crate) fn parse_container_start(input: &str) -> IResult<&str, TextStreamItem> {
     alt((
         recognize_struct_start,
         recognize_list_start,
-        recognize_s_expression_start
+        recognize_s_expression_start,
     ))(input)
 }
 
 /// Matches the beginning of a struct and returns a [TextStreamItem::StructStart].
 pub(crate) fn recognize_struct_start(input: &str) -> IResult<&str, TextStreamItem> {
-    map(
-        recognize(tag("{")),
-        |_matched_text| TextStreamItem::StructStart
-    )(input)
+    map(recognize(tag("{")), |_matched_text| {
+        TextStreamItem::StructStart
+    })(input)
 }
 
 /// Matches the beginning of a list and returns a [TextStreamItem::ListStart].
 pub(crate) fn recognize_list_start(input: &str) -> IResult<&str, TextStreamItem> {
-    map(
-        recognize(tag("[")),
-        |_matched_text| TextStreamItem::ListStart
-    )(input)
+    map(recognize(tag("[")), |_matched_text| {
+        TextStreamItem::ListStart
+    })(input)
 }
 
 /// Matches the beginning of an s-expression and returns a [TextStreamItem::SExpressionStart].
 pub(crate) fn recognize_s_expression_start(input: &str) -> IResult<&str, TextStreamItem> {
-    map(
-        recognize(tag("(")),
-        |_matched_text| TextStreamItem::SExpressionStart
-    )(input)
+    map(recognize(tag("(")), |_matched_text| {
+        TextStreamItem::SExpressionStart
+    })(input)
 }
 
 /// Matches the end of a container and returns a [TextStreamItem] indicating its type.
@@ -42,40 +39,35 @@ pub(crate) fn parse_container_end(input: &str) -> IResult<&str, TextStreamItem> 
     alt((
         recognize_struct_end,
         recognize_list_end,
-        recognize_s_expression_end
+        recognize_s_expression_end,
     ))(input)
 }
 
 /// Matches the end of a struct and returns a [TextStreamItem::StructEnd].
 pub(crate) fn recognize_struct_end(input: &str) -> IResult<&str, TextStreamItem> {
-    map(
-        recognize(tag("}")),
-        |_matched_text| TextStreamItem::StructEnd
-    )(input)
+    map(recognize(tag("}")), |_matched_text| {
+        TextStreamItem::StructEnd
+    })(input)
 }
 
 /// Matches the end of a list and returns a [TextStreamItem::StructEnd].
 pub(crate) fn recognize_list_end(input: &str) -> IResult<&str, TextStreamItem> {
-    map(
-        recognize(tag("]")),
-        |_matched_text| TextStreamItem::ListEnd
-    )(input)
+    map(recognize(tag("]")), |_matched_text| TextStreamItem::ListEnd)(input)
 }
 
 /// Matches the end of a list and returns a [TextStreamItem::StructEnd].
 pub(crate) fn recognize_s_expression_end(input: &str) -> IResult<&str, TextStreamItem> {
-    map(
-        recognize(tag(")")),
-        |_matched_text| TextStreamItem::SExpressionEnd
-    )(input)
+    map(recognize(tag(")")), |_matched_text| {
+        TextStreamItem::SExpressionEnd
+    })(input)
 }
 
 #[cfg(test)]
 mod container_parsing_tests {
-    use rstest::*;
+    use crate::text::parsers::containers::{parse_container_end, parse_container_start};
     use crate::text::parsers::unit_test_support::{parse_test_err, parse_test_ok};
     use crate::text::TextStreamItem;
-    use crate::text::parsers::containers::{parse_container_start, parse_container_end};
+    use rstest::*;
 
     #[rstest]
     #[case::start_of_struct("{", TextStreamItem::StructStart)]

--- a/src/text/parsers/mod.rs
+++ b/src/text/parsers/mod.rs
@@ -20,6 +20,8 @@ pub(crate) mod string;
 pub(crate) mod symbol;
 pub(crate) mod text_support;
 pub(crate) mod timestamp;
+pub(crate) mod containers;
+pub(crate) mod top_level;
 
 // ===== The functions below are used by several modules and live here for common access. =====
 

--- a/src/text/parsers/mod.rs
+++ b/src/text/parsers/mod.rs
@@ -11,6 +11,7 @@ use nom::IResult;
 pub(crate) mod blob;
 pub(crate) mod boolean;
 pub(crate) mod clob;
+pub(crate) mod containers;
 pub(crate) mod decimal;
 pub(crate) mod float;
 pub(crate) mod integer;
@@ -20,7 +21,6 @@ pub(crate) mod string;
 pub(crate) mod symbol;
 pub(crate) mod text_support;
 pub(crate) mod timestamp;
-pub(crate) mod containers;
 pub(crate) mod top_level;
 
 // ===== The functions below are used by several modules and live here for common access. =====

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -1,0 +1,42 @@
+use nom::branch::alt;
+use nom::combinator::opt;
+use nom::IResult;
+use nom::sequence::preceded;
+
+use crate::text::parsers::blob::parse_blob;
+use crate::text::parsers::boolean::parse_boolean;
+use crate::text::parsers::clob::parse_clob;
+use crate::text::parsers::containers::{parse_container_end, parse_container_start};
+use crate::text::parsers::decimal::parse_decimal;
+use crate::text::parsers::float::parse_float;
+use crate::text::parsers::integer::parse_integer;
+use crate::text::parsers::null::parse_null;
+use crate::text::parsers::string::parse_string;
+use crate::text::parsers::symbol::parse_symbol;
+use crate::text::parsers::timestamp::parse_timestamp;
+use crate::text::parsers::whitespace;
+use crate::text::TextStreamItem;
+
+/// Matches a TextStreamItem at the beginning of the given string.
+pub(crate) fn stream_item(input: &str) -> IResult<&str, TextStreamItem> {
+    alt((
+        parse_null,
+        parse_boolean,
+        parse_integer,
+        parse_float,
+        parse_decimal,
+        parse_timestamp,
+        parse_string,
+        parse_symbol,
+        parse_blob,
+        parse_clob,
+        parse_container_start,
+        parse_container_end
+    ))(input)
+}
+
+/// Matches a TextStreamItem at the beginning of the given string. The TextStreamItem may be
+/// prefixed by whitespace.
+pub(crate) fn top_level_value(input: &str) -> IResult<&str, TextStreamItem> {
+    preceded(opt(whitespace), stream_item)(input)
+}

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -1,7 +1,7 @@
 use nom::branch::alt;
 use nom::combinator::opt;
-use nom::IResult;
 use nom::sequence::preceded;
+use nom::IResult;
 
 use crate::text::parsers::blob::parse_blob;
 use crate::text::parsers::boolean::parse_boolean;
@@ -31,7 +31,7 @@ pub(crate) fn stream_item(input: &str) -> IResult<&str, TextStreamItem> {
         parse_blob,
         parse_clob,
         parse_container_start,
-        parse_container_end
+        parse_container_end,
     ))(input)
 }
 

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -17,10 +17,10 @@ use crate::text::TextStreamItem;
 pub struct TextReader<T: TextIonDataSource> {
     buffer: TextBuffer<T::TextSource>,
     current_item: Option<TextStreamItem>,
-    bytes_read: usize
+    bytes_read: usize,
 }
 
-impl <T: TextIonDataSource> TextReader<T> {
+impl<T: TextIonDataSource> TextReader<T> {
     fn new(input: T) -> TextReader<T> {
         let text_source = input.to_text_ion_data_source();
         TextReader {
@@ -55,9 +55,10 @@ impl <T: TextIonDataSource> TextReader<T> {
                         // If load_next_line() returns Ok(0), we've reached end of our input.
                         // TODO: If we reach the end of our input and everything left in the buffer
                         //       is whitespace or a comment, we should report EOF instead of an error.
-                        return decoding_error(
-                            format!("Unexpected end of input on line {}", self.buffer.lines_loaded())
-                        );
+                        return decoding_error(format!(
+                            "Unexpected end of input on line {}",
+                            self.buffer.lines_loaded()
+                        ));
                     }
                     continue;
                 }
@@ -67,19 +68,17 @@ impl <T: TextIonDataSource> TextReader<T> {
                     self.buffer.consume(bytes_consumed);
                     self.bytes_read += bytes_consumed;
                     break 'parse item;
-                },
+                }
                 Err(e) => {
                     // Return an error that contains the text currently in the buffer (i.e. what we
                     // were attempting to parse with `top_level_value`.)
                     // TODO: We probably don't want to surface the nom error directly.
-                    return decoding_error(
-                        format!(
-                            "Parsing error occurred near line {}: '{}': '{}'",
-                            self.buffer.lines_loaded(),
-                            self.buffer.remaining_text(),
-                            e
-                        )
-                    );
+                    return decoding_error(format!(
+                        "Parsing error occurred near line {}: '{}': '{}'",
+                        self.buffer.lines_loaded(),
+                        self.buffer.remaining_text(),
+                        e
+                    ));
                 }
             };
         };
@@ -90,7 +89,6 @@ impl <T: TextIonDataSource> TextReader<T> {
 
 #[cfg(test)]
 mod reader_tests {
-    use crate::IonType;
     use crate::result::IonResult;
     use crate::text::parsers::top_level::stream_item;
     use crate::text::parsers::unit_test_support::parse_unwrap;
@@ -98,6 +96,7 @@ mod reader_tests {
     use crate::text::TextStreamItem;
     use crate::types::decimal::Decimal;
     use crate::types::timestamp::Timestamp;
+    use crate::IonType;
 
     #[test]
     fn test_text_read_multiple_top_level_values() {
@@ -124,10 +123,8 @@ mod reader_tests {
         next_is(TextStreamItem::Float(5.0f64));
         next_is(TextStreamItem::Decimal(Decimal::new(55, -1)));
         next_is(TextStreamItem::Timestamp(
-            Timestamp::with_ymd(2021, 9, 25)
-            .build()
-            .unwrap())
-        );
+            Timestamp::with_ymd(2021, 9, 25).build().unwrap(),
+        ));
         next_is(TextStreamItem::Symbol("foo".to_string()));
         next_is(TextStreamItem::String("hello".to_string()));
         next_is(TextStreamItem::StructStart);

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -63,10 +63,16 @@ impl<T: TextIonDataSource> TextReader<T> {
                     continue;
                 }
                 Ok((remaining_text, item)) => {
+                    // Our parser successfully matched a stream item.
+                    // Note the length of the text that remains after parsing.
                     let length_after_parse = remaining_text.len();
+                    // The difference in length tells us how many bytes were part of the
+                    // text representation of the value that we found.
                     let bytes_consumed = length_before_parse - length_after_parse;
+                    // Discard `bytes_consumed` bytes from the TextBuffer.
                     self.buffer.consume(bytes_consumed);
                     self.bytes_read += bytes_consumed;
+                    // Break out of the read/parse loop, returning the stream item that we matched.
                     break 'parse item;
                 }
                 Err(e) => {

--- a/src/text/text_buffer.rs
+++ b/src/text/text_buffer.rs
@@ -1,0 +1,255 @@
+use std::io::BufRead;
+use std::io;
+
+/// A text buffer that pulls more bytes from the input source as needed.
+///
+/// A parser reading from a text stream should use the [load_next_line] method to pull text into
+/// the buffer from the input source. The text currently in the buffer can be accessed via the
+/// [remaining_text] method. When a portion of that text has been processed, the user can discard it
+/// with the [consume] method. If the buffer does not contain enough data to represent a full value,
+/// more data can be pulled into the buffer with [load_next_line]; this additional text will be
+/// visible in the next call to [remaining_text].
+pub(crate) struct TextBuffer<R: BufRead> {
+    // The input source to read from (an io::Cursor, BufReader, File, etc)
+    input: R,
+    // The line we're in the process of parsing.
+    line: String,
+    // How much of the current line we've already parsed.
+    line_offset: usize,
+    // The 1-based index of the line currently being read.
+    // When the LineBuffer is first constructed and no lines
+    // have been read from input, this value is 0.
+    line_number: usize,
+    // Whether `input` above has reached EOF.
+    is_exhausted: bool,
+}
+
+impl <R: BufRead> TextBuffer<R> {
+
+    /// Constructs a new LineBuffer that will pull lines of text from the provided input.
+    pub fn new(input: R) -> Self {
+        Self {
+            input,
+            line: String::with_capacity(128),
+            line_offset: 0,
+            line_number: 0,
+            is_exhausted: false
+        }
+    }
+
+    /// Returns the trailing portion of the buffer that has not yet been marked as read via the
+    /// [consume] method.
+    pub fn remaining_text(&self) -> &str {
+        &self.line[self.line_offset..]
+    }
+
+    /// Returns the number of lines that have been loaded from input. The number returned may be:
+    /// * Greater than the number of lines that have been marked read via [consume].
+    /// * Less than the number of lines that have been requested via [load_next_line] and
+    ///   [load_next_n_lines] if the input stream was exhausted.
+    pub fn lines_loaded(&self) -> usize {
+        self.line_number
+    }
+
+    /// Returns [true] if the buffer is empty and the end of the input source has been reached;
+    /// otherwise, returns false.
+    pub fn is_exhausted(&self) -> bool {
+        self.remaining_text().len() == 0 && self.is_exhausted
+    }
+
+    /// Discards [number_of_bytes] bytes from the remaining line.
+    /// If [number_of_bytes] would cause the remaining bytes to be invalid UTF8,
+    /// this method will panic.
+    /// If [number_of_bytes] is greater than the number of bytes remaining in the current line,
+    /// this method will panic.
+    pub fn consume(&mut self, number_of_bytes: usize) {
+        let remaining_line = self.remaining_text();
+        assert!(
+            number_of_bytes <= remaining_line.len(),
+            "Cannot consume() more bytes than are left in the current line."
+        );
+        assert!(
+            remaining_line.is_char_boundary(number_of_bytes),
+            "Cannot consume() a number of bytes that will leave invalid UTF8 in the current line."
+        );
+        self.line_offset += number_of_bytes;
+    }
+
+    /// Reads the next line of text from input, appending it to the end of the buffer.
+    /// If the input is exhausted (i.e. is at EOF), returns Ok(0).
+    pub fn load_next_line(&mut self) -> io::Result<usize> {
+        self.load_next_n_lines(1)
+    }
+
+    /// Reads the next [number_of_lines] lines of text from input, appending each one to the end of
+    /// the buffer. If fewer than [number_of_lines] remains in the input, the buffer will load as
+    /// many as possible. If the input is exhausted (i.e. is at EOF), returns Ok(0).
+    pub fn load_next_n_lines(&mut self, number_of_lines: usize) -> io::Result<usize> {
+        self.restack_remaining_text();
+        let mut total_bytes_read = 0;
+        for _ in 0..number_of_lines {
+            let bytes_read = self.input.read_line(&mut self.line)?;
+            if bytes_read == 0 {
+                self.is_exhausted = true;
+                return Ok(total_bytes_read);
+            }
+            // The last line of `self.input` can have bytes that don't end in '\n'
+            if self.line.ends_with('\n') {
+                self.line_number += 1;
+            }
+            total_bytes_read += bytes_read;
+        }
+        Ok(total_bytes_read)
+    }
+
+    /// Removes the part of the current line that has already been consumed and moves any remaining
+    /// text back to the beginning of the buffer.
+    fn restack_remaining_text(&mut self) {
+        if self.line_offset == 0 {
+            // Nothing to do.
+            return;
+        }
+        let remaining_bytes = self.remaining_text().len();
+        unsafe {
+            // The `copy_within()` method below is unsafe.
+            // https://doc.rust-lang.org/std/primitive.slice.html#method.copy_within
+            // The invariants enforced by the `consume` method guarantee that this will behave safely.
+            // Copy the remaining text from the end of the String to the beginning of the String.
+            self.line.as_bytes_mut().copy_within(self.line_offset.., 0);
+            // Truncate the String to drop any data.
+            self.line.truncate(remaining_bytes)
+        }
+        self.line_offset = 0;
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod text_buffer_tests {
+    use super::*;
+    use std::io;
+
+    fn text_buffer(text: &str) -> TextBuffer<io::Cursor<&str>> {
+        let input = io::Cursor::new(text);
+        TextBuffer::new(input)
+    }
+
+    #[test]
+    fn test_restack() {
+        // This test accesses TextBuffer internals, which isn't typical for a unit tests.
+        // However, the restack() function uses `unsafe` code and so warrants additional scrutiny.
+        let mut buffer = text_buffer("foo\nbar\nbaz\nquux\n");
+        assert_eq!(buffer.load_next_line().unwrap(), 4);
+        assert_eq!(buffer.remaining_text(), "foo\n");
+        assert_eq!(buffer.line_offset, 0);
+        buffer.consume(2);
+        assert_eq!(buffer.remaining_text(), "o\n");
+        assert_eq!(buffer.line_offset, 2);
+        buffer.restack_remaining_text();
+        assert_eq!(buffer.line_offset, 0);
+        assert_eq!(buffer.remaining_text(), "o\n");
+    }
+
+    #[test]
+    fn test_empty_restack() {
+        // This test accesses TextBuffer internals, which isn't typical for a unit tests.
+        // However, the restack() function uses `unsafe` code and so warrants additional scrutiny.
+        let mut buffer = text_buffer("foo\nbar\nbaz\nquux\n");
+        assert_eq!(buffer.load_next_line().unwrap(), 4);
+        assert_eq!(buffer.remaining_text(), "foo\n");
+        assert_eq!(buffer.line_offset, 0);
+        buffer.consume(4);
+        assert_eq!(buffer.remaining_text(), "");
+        assert_eq!(buffer.line_offset, 4);
+        buffer.restack_remaining_text();
+        assert_eq!(buffer.line_offset, 0);
+        assert_eq!(buffer.remaining_text(), "");
+    }
+
+    #[test]
+    fn test_consume() {
+        let mut buffer = text_buffer("foo bar baz quux");
+        buffer.load_next_line().unwrap();
+        assert_eq!(buffer.remaining_text(), "foo bar baz quux");
+        buffer.consume(4);
+        assert_eq!(buffer.remaining_text(), "bar baz quux");
+        buffer.consume(5);
+        assert_eq!(buffer.remaining_text(), "az quux");
+        buffer.consume(6);
+        assert_eq!(buffer.remaining_text(), "x");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_consume_err_illegal_utf8_offset() {
+        let mut buffer = text_buffer("😎");
+        buffer.load_next_line().unwrap();
+        // This jumps into the middle of the emoji.
+        // If it were to succeed, the next call to remaining_text() would panic.
+        buffer.consume(1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_consume_err_too_many_bytes() {
+        let mut buffer = text_buffer("foo");
+        buffer.load_next_line().unwrap();
+        // There are only 3 bytes in the buffer.
+        // We cannot consume more bytes than are available.
+        buffer.consume(75);
+    }
+
+    #[test]
+    fn test_load_next_line() {
+        let mut buffer = text_buffer("foo\nbar\nbaz\nquux\n");
+        assert_eq!(buffer.load_next_line().unwrap(), 4);
+        assert_eq!(buffer.remaining_text(), "foo\n");
+        assert_eq!(buffer.load_next_line().unwrap(), 4);
+        assert_eq!(buffer.remaining_text(), "foo\nbar\n");
+        assert_eq!(buffer.load_next_line().unwrap(), 4);
+        assert_eq!(buffer.remaining_text(), "foo\nbar\nbaz\n");
+        assert_eq!(buffer.load_next_line().unwrap(), 5);
+        assert_eq!(buffer.remaining_text(), "foo\nbar\nbaz\nquux\n");
+        // EOF is indicated by Ok(0); no bytes were read.
+        assert_eq!(buffer.load_next_line().unwrap(), 0);
+        // Calling load_next_line() after EOF continues to result in Ok(0)
+        assert_eq!(buffer.load_next_line().unwrap(), 0);
+        assert_eq!(buffer.load_next_line().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_load_next_n_lines() {
+        let mut buffer = text_buffer("foo\nbar\nbaz\nquux\n");
+        assert_eq!(buffer.load_next_n_lines(3).unwrap(), 12);
+        assert_eq!(buffer.remaining_text(), "foo\nbar\nbaz\n");
+        assert_eq!(buffer.lines_loaded(), 3);
+        // There's only one line left, but we request two.
+        // load_next_n_lines() should report success, saying that 5 bytes were read.
+        assert_eq!(buffer.load_next_n_lines(2).unwrap(), 5);
+        // If we check lines_loaded(), however, we can see that only 4 total lines have been loaded.
+        assert_eq!(buffer.lines_loaded(), 4);
+        // If we ask for more data, it will report Ok(0) bytes read: EOF.
+        assert_eq!(buffer.load_next_n_lines(2).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_is_exhausted() {
+        let mut buffer = text_buffer("foo\nbar\n");
+        assert_eq!(buffer.load_next_line().unwrap(), 4);
+        assert_eq!(buffer.remaining_text(), "foo\n");
+        buffer.consume(4);
+        // The buffer itself is empty, but input has not reached EOF yet.
+        assert_eq!(buffer.is_exhausted(), false);
+        // Load another line
+        assert_eq!(buffer.load_next_line().unwrap(), 4);
+        // Now input is at EOF, but the buffer contains text.
+        assert_eq!(buffer.is_exhausted(), false);
+        // Consume the bytes in the buffer
+        buffer.consume(4);
+        // Now the buffer is empty. Looking ahead, we can tell that the input is empty,
+        // but we have to try to load another line to actually encounter EOF.
+        assert_eq!(buffer.is_exhausted(), false);
+        assert_eq!(buffer.load_next_line().unwrap(), 0);
+        // Now the buffer is empty and the input has hit EOF.
+        assert_eq!(buffer.is_exhausted(), true);
+    }
+}

--- a/src/text/text_buffer.rs
+++ b/src/text/text_buffer.rs
@@ -1,5 +1,5 @@
-use std::io::BufRead;
 use std::io;
+use std::io::BufRead;
 
 /// A text buffer that pulls more bytes from the input source as needed.
 ///
@@ -24,8 +24,7 @@ pub(crate) struct TextBuffer<R: BufRead> {
     is_exhausted: bool,
 }
 
-impl <R: BufRead> TextBuffer<R> {
-
+impl<R: BufRead> TextBuffer<R> {
     /// Constructs a new LineBuffer that will pull lines of text from the provided input.
     pub fn new(input: R) -> Self {
         Self {
@@ -33,7 +32,7 @@ impl <R: BufRead> TextBuffer<R> {
             line: String::with_capacity(128),
             line_offset: 0,
             line_number: 0,
-            is_exhausted: false
+            is_exhausted: false,
         }
     }
 

--- a/src/text/text_data_source.rs
+++ b/src/text/text_data_source.rs
@@ -17,7 +17,7 @@ impl TextIonDataSource for String {
     }
 }
 
-impl <'a> TextIonDataSource for &'a str {
+impl<'a> TextIonDataSource for &'a str {
     type TextSource = io::Cursor<Self>;
 
     fn to_text_ion_data_source(self) -> Self::TextSource {
@@ -25,7 +25,7 @@ impl <'a> TextIonDataSource for &'a str {
     }
 }
 
-impl <'a> TextIonDataSource for &'a &[u8] {
+impl<'a> TextIonDataSource for &'a &[u8] {
     type TextSource = io::Cursor<Self>;
 
     fn to_text_ion_data_source(self) -> Self::TextSource {
@@ -33,7 +33,7 @@ impl <'a> TextIonDataSource for &'a &[u8] {
     }
 }
 
-impl <T: io::Read> TextIonDataSource for BufReader<T> {
+impl<T: io::Read> TextIonDataSource for BufReader<T> {
     type TextSource = Self;
 
     fn to_text_ion_data_source(self) -> Self::TextSource {

--- a/src/text/text_data_source.rs
+++ b/src/text/text_data_source.rs
@@ -1,0 +1,42 @@
+use std::io;
+use std::io::{BufRead, BufReader};
+
+/// Types that implement this trait can be converted into an implementation of [io::BufRead],
+/// allowing them to be passed to the [TextReader::new] constructor. This allows [TextReader::new]
+/// to support reading Strings, &str slices, &[u8] slices, files, etc.
+pub trait TextIonDataSource {
+    type TextSource: BufRead;
+    fn to_text_ion_data_source(self) -> Self::TextSource;
+}
+
+impl TextIonDataSource for String {
+    type TextSource = io::Cursor<Self>;
+
+    fn to_text_ion_data_source(self) -> Self::TextSource {
+        io::Cursor::new(self)
+    }
+}
+
+impl <'a> TextIonDataSource for &'a str {
+    type TextSource = io::Cursor<Self>;
+
+    fn to_text_ion_data_source(self) -> Self::TextSource {
+        io::Cursor::new(self)
+    }
+}
+
+impl <'a> TextIonDataSource for &'a &[u8] {
+    type TextSource = io::Cursor<Self>;
+
+    fn to_text_ion_data_source(self) -> Self::TextSource {
+        io::Cursor::new(self)
+    }
+}
+
+impl <T: io::Read> TextIonDataSource for BufReader<T> {
+    type TextSource = Self;
+
+    fn to_text_ion_data_source(self) -> Self::TextSource {
+        self
+    }
+}


### PR DESCRIPTION
This PR allows a `TextReader` to be created from a variety of text
data sources, including `String`, `&str`, `&[u8]`, and `BufReader`.
Support for other types can be addede by implementing the
`TextIonDataSource` trait.

It also introduces the `TextBuffer`, a type which can pull text
into a buffer `n` lines at a time and discard bytes as they're
processed. This enables the reader to process its input in a
streaming fashion, holding a modest amount of data in memory at
a time.

The patch adds parsing logic to detect the beginnings and endings of
the various container types. However, it does not add logic for
stepping into/out of those containers.

Finally, by leveraging the above features, the existing
proto-`TextReader` can now iterate over a text Ion stream containing
multiple top-level values. If it encounters an error, it can report
the line of input that caused it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
