### PR TITLE
Adds support for reading text annotations

### DIFF
--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -6,6 +6,7 @@ pub mod writer;
 
 use crate::types::decimal::Decimal;
 use crate::types::timestamp::Timestamp;
+use crate::value::owned::OwnedSymbolToken;
 use crate::IonType;
 
 /// Represents a single item encountered in a text Ion stream. The enum includes variants for each
@@ -20,8 +21,7 @@ pub(crate) enum TextStreamItem {
     Timestamp(Timestamp),
     // TODO: String(&str) will be possible if/when we add reusable buffers to the TextReader.
     String(String),
-    // TODO: This will be a Symbol(SymbolToken) when the SymbolToken API is implemented.
-    Symbol(String),
+    Symbol(OwnedSymbolToken),
     // TODO: [BC]lob(&[u8]) will be possible if/when we add reusable buffers to the TextReader.
     Blob(Vec<u8>),
     Clob(Vec<u8>),

--- a/src/text/parsers/symbol.rs
+++ b/src/text/parsers/symbol.rs
@@ -1,18 +1,20 @@
 use crate::text::parsers::stop_character;
 use crate::text::parsers::text_support::{escaped_char, escaped_newline, StringFragment};
 use crate::text::TextStreamItem;
+use crate::value::owned::{local_sid_token, text_token};
 use nom::branch::alt;
 use nom::bytes::streaming::is_not;
-use nom::character::streaming::{char, one_of, satisfy};
-use nom::combinator::{map, recognize, verify};
+use nom::bytes::streaming::tag;
+use nom::character::streaming::{char, digit1, one_of, satisfy};
+use nom::combinator::{map, map_opt, map_res, not, peek, recognize, verify};
 use nom::multi::{fold_many0, many0_count};
-use nom::sequence::{delimited, pair, terminated};
+use nom::sequence::{delimited, pair, preceded, terminated};
 use nom::IResult;
 
 /// Matches the text representation of a symbol value and returns the resulting [String]
 /// as a [TextStreamItem::Symbol].
 pub(crate) fn parse_symbol(input: &str) -> IResult<&str, TextStreamItem> {
-    alt((identifier, quoted_symbol))(input)
+    alt((symbol_id, identifier, quoted_symbol))(input)
 }
 
 /// Matches a quoted symbol (e.g. `'foo bar'`) and returns the resulting [String]
@@ -20,10 +22,7 @@ pub(crate) fn parse_symbol(input: &str) -> IResult<&str, TextStreamItem> {
 fn quoted_symbol(input: &str) -> IResult<&str, TextStreamItem> {
     map(
         delimited(char('\''), quoted_symbol_body, char('\'')),
-        |text| {
-            println!("Symbol text: {:?}", &text);
-            TextStreamItem::Symbol(text)
-        },
+        |text| TextStreamItem::Symbol(text_token(text)),
     )(input)
 }
 
@@ -62,12 +61,25 @@ fn quoted_symbol_fragment_without_escaped_text(input: &str) -> IResult<&str, Str
 /// Matches an identifier (e.g. `foo`) and returns the resulting [String]
 /// as a [TextStreamItem::Symbol].
 fn identifier(input: &str) -> IResult<&str, TextStreamItem> {
-    map(
+    map_opt(
         recognize(terminated(
             pair(identifier_initial_character, identifier_trailing_characters),
-            stop_character,
+            not(identifier_trailing_character),
         )),
-        |text| TextStreamItem::Symbol(text.to_owned()),
+        |text| {
+            // Ion defines a number of keywords that are syntactically indistinguishable from
+            // identifiers. Keywords take precedence; we must ensure that any identifier we find
+            // is not actually a keyword.
+            const KEYWORDS: &[&str] = &["true", "false", "nan", "null"];
+            // In many situations, this check will not be necessary. Another type's parser will
+            // recognize the keyword as its own. (For example, `parse_boolean` would match the input
+            // text `false`.) However, because symbols can appear in annotations and the check for
+            // annotations precedes the parsing for all other types, we need this extra verification.
+            if KEYWORDS.iter().find(|k| **k == text).is_some() {
+                return None;
+            }
+            Some(TextStreamItem::Symbol(text_token(text)))
+        },
     )(input)
 }
 
@@ -76,30 +88,79 @@ fn identifier_initial_character(input: &str) -> IResult<&str, char> {
     alt((one_of("$_"), satisfy(|c| c.is_ascii_alphabetic())))(input)
 }
 
+/// Matches any character that is legal in an identifier, though not necessarily at the beginning.
+fn identifier_trailing_character(input: &str) -> IResult<&str, char> {
+    alt((one_of("$_"), satisfy(|c| c.is_ascii_alphanumeric())))(input)
+}
+
 /// Matches characters that are legal in an identifier, though not necessarily at the beginning.
 fn identifier_trailing_characters(input: &str) -> IResult<&str, &str> {
-    recognize(many0_count(alt((
-        one_of("$_"),
-        satisfy(|c| c.is_ascii_alphanumeric()),
-    ))))(input)
+    recognize(many0_count(identifier_trailing_character))(input)
+}
+
+/// Matches a symbol ID in the format `$ID` (For example, `$0` or `$42`.)
+fn symbol_id(input: &str) -> IResult<&str, TextStreamItem> {
+    use crate::types::SymbolId;
+    map_res(
+        terminated(
+            // Discard a `$` and parse an integer representing the symbol ID.
+            // Note that symbol ID integers:
+            //   * CANNOT have underscores in them. For example: `$1_0` is considered an identifier.
+            //   * CAN have leading zeros. There's precedent for this in ion-java.
+            preceded(tag("$"), digit1),
+            // Peek at the next character to make sure it's unrelated to the symbol ID.
+            // The spec does not offer a formal definition of what ends a symbol ID.
+            // This checks for either a stop_character (which performs its own `peek()`)
+            // or an annotation delimiter ('::').
+            alt((
+                // Each of the parsers passed to `alt` must have the same return type. `stop_character`
+                // returns a char instead of a &str, so we use `recognize()` to get a &str instead.
+                recognize(stop_character),
+                peek(tag("::")),
+            )),
+        ),
+        |text| {
+            const RADIX: u32 = 10;
+            i64::from_str_radix(text, RADIX)
+                .map(|i| TextStreamItem::Symbol(local_sid_token(i as SymbolId)))
+        },
+    )(input)
 }
 
 #[cfg(test)]
 mod symbol_parsing_tests {
-    use crate::text::parsers::symbol::parse_symbol;
+    use super::*;
     use crate::text::parsers::unit_test_support::{parse_test_err, parse_test_ok};
-    use crate::text::TextStreamItem;
+    use crate::types::SymbolId;
+    use crate::value::owned::local_sid_token;
+    use rstest::*;
 
+    // Asserts that when parsed, the provided text produces a TextStreamItem::Symbol
+    // that contains the expected text.
     fn parse_equals(text: &str, expected: &str) {
         parse_test_ok(
             parse_symbol,
             text,
-            TextStreamItem::Symbol(expected.to_owned()),
+            TextStreamItem::Symbol(text_token(expected)),
+        )
+    }
+
+    // Asserts that when parsed, the provided text produces a TextStreamItem::Symbol
+    // that contains the expected local symbol ID.
+    fn parse_sid_equals(text: &str, expected: SymbolId) {
+        parse_test_ok(
+            symbol_id,
+            text,
+            TextStreamItem::Symbol(local_sid_token(expected)),
         )
     }
 
     fn parse_fails(text: &str) {
         parse_test_err(parse_symbol, text)
+    }
+
+    fn parse_sid_fails(text: &str) {
+        parse_test_err(symbol_id, text)
     }
 
     #[test]
@@ -136,5 +197,19 @@ mod symbol_parsing_tests {
         parse_fails(" foo ");
         // Cannot be the last thing in input (stream might be incomplete
         parse_fails("foo");
+    }
+
+    #[rstest]
+    #[case::sid_zero("$0 ", 0)]
+    #[case("$21 ", 21)]
+    #[case("$509 ", 509)]
+    //        v--- Symbol IDs can have leading zeros
+    #[case("$007 ", 7)]
+    #[case("$17305 ", 17_305)]
+    #[should_panic]
+    //              v--- Symbol IDs cannot have underscores in them
+    #[case::bad("$17_305 ", 17_305)]
+    fn text_parse_symbol_ids(#[case] text: &str, #[case] expected: SymbolId) {
+        parse_sid_equals(text, expected);
     }
 }

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -1,7 +1,10 @@
 use nom::branch::alt;
-use nom::combinator::opt;
-use nom::sequence::preceded;
-use nom::IResult;
+use nom::bytes::streaming::tag;
+use nom::character::complete::multispace0;
+use nom::combinator::map_opt;
+use nom::multi::many1;
+use nom::sequence::{delimited, pair, preceded};
+use nom::{IResult, Parser};
 
 use crate::text::parsers::blob::parse_blob;
 use crate::text::parsers::boolean::parse_boolean;
@@ -14,8 +17,8 @@ use crate::text::parsers::null::parse_null;
 use crate::text::parsers::string::parse_string;
 use crate::text::parsers::symbol::parse_symbol;
 use crate::text::parsers::timestamp::parse_timestamp;
-use crate::text::parsers::whitespace;
 use crate::text::TextStreamItem;
+use crate::value::owned::OwnedSymbolToken;
 
 /// Matches a TextStreamItem at the beginning of the given string.
 pub(crate) fn stream_item(input: &str) -> IResult<&str, TextStreamItem> {
@@ -35,8 +38,120 @@ pub(crate) fn stream_item(input: &str) -> IResult<&str, TextStreamItem> {
     ))(input)
 }
 
-/// Matches a TextStreamItem at the beginning of the given string. The TextStreamItem may be
-/// prefixed by whitespace.
-pub(crate) fn top_level_value(input: &str) -> IResult<&str, TextStreamItem> {
-    preceded(opt(whitespace), stream_item)(input)
+/// Matches a series of annotations and their associated TextStreamItem.
+pub(crate) fn annotated_stream_item(
+    input: &str,
+) -> IResult<&str, (Vec<OwnedSymbolToken>, TextStreamItem)> {
+    pair(parse_annotations, stream_item)(input)
+}
+
+/// Matches an optional series of annotations and a TextStreamItem at the beginning of the given
+/// string. If there are no annotations (or the TextStreamItem found cannot have annotations), the
+/// annotations [Vec] will be empty.
+pub(crate) fn top_level_stream_item(
+    input: &str,
+) -> IResult<&str, (Vec<OwnedSymbolToken>, TextStreamItem)> {
+    preceded(
+        // Allow any amount of whitespace followed by...
+        multispace0,
+        // either...
+        alt((
+            // An annotated value or...
+            annotated_stream_item,
+            // An empty Vec paired with an unannotated value.
+            // `Vec::new()` does not allocate, so calling this for each item is cheap.
+            stream_item.map(|x| (Vec::new(), x)),
+        )),
+    )(input)
+}
+
+/// Matches a series of '::'-delimited symbols used to annotate a value.
+pub(crate) fn parse_annotations(input: &str) -> IResult<&str, Vec<OwnedSymbolToken>> {
+    many1(parse_annotation)(input)
+}
+
+/// Matches a single symbol of any format (foo, 'foo', or $10) followed by a '::' delimiter.
+/// The delimiter can be preceded or trailed by any amount of whitespace.
+pub(crate) fn parse_annotation(input: &str) -> IResult<&str, OwnedSymbolToken> {
+    map_opt(
+        // 0+ spaces, a symbol ('quoted', identifier, or $id), 0+ spaces, '::'
+        delimited(multispace0, parse_symbol, annotation_delimiter),
+        |text_stream_item| {
+            // This should always be true because `parse_symbol` would not have matched an
+            // item if it were not a symbol.
+            if let TextStreamItem::Symbol(symbol) = text_stream_item {
+                return Some(symbol);
+            }
+            None
+        },
+    )(input)
+}
+
+fn annotation_delimiter(input: &str) -> IResult<&str, &str> {
+    preceded(multispace0, tag("::"))(input)
+}
+
+#[cfg(test)]
+// TODO: Move relevant tests from reader.rs to this module
+mod parse_top_level_value_tests {
+    use super::*;
+    use crate::types::SymbolId;
+    use crate::value::owned::{local_sid_token, text_token};
+    use rstest::*;
+
+    // Unit test helper; converts strings into OwnedSymbolTokens
+    fn text_tokens(strs: &[&str]) -> Vec<OwnedSymbolToken> {
+        return strs.iter().map(|s| text_token(*s)).collect();
+    }
+
+    #[rstest]
+    #[case::identifier_no_spaces("foo::", "foo")]
+    #[case::identifier_leading_spaces("   foo::", "foo")]
+    #[case::identifier_trailing_spaces("foo::   ", "foo")]
+    #[case::identifier_interstitial_spaces("foo   ::", "foo")]
+    #[case::identifier_all_spaces("   foo   ::   ", "foo")]
+    #[case::quoted_no_spaces("'foo'::", "foo")]
+    #[case::quoted_leading_spaces("   'foo'::", "foo")]
+    #[case::quoted_trailing_spaces("'foo'::   ", "foo")]
+    #[case::quoted_interstitial_spaces("'foo'   ::", "foo")]
+    #[case::quoted_all_spaces("   'foo'   ::   ", "foo")]
+    fn test_parse_annotation(#[case] text: &str, #[case] expected: &str) {
+        assert_eq!(parse_annotation(text).unwrap().1, text_token(expected));
+    }
+
+    #[rstest]
+    #[case::symbol_id_no_spaces("$10::", 10)]
+    #[case::symbol_id_leading_spaces("   $10::", 10)]
+    #[case::symbol_id_trailing_spaces("$10::   ", 10)]
+    #[case::symbol_id_interstitial_spaces("$10   ::", 10)]
+    #[case::symbol_id_all_spaces("   $10   ::   ", 10)]
+    fn test_parse_symbol_id_annotation(#[case] text: &str, #[case] expected: SymbolId) {
+        assert_eq!(parse_annotation(text).unwrap().1, local_sid_token(expected));
+    }
+
+    #[rstest]
+    // For these tests, the input text must end in an unrelated value so the parser knows that
+    // the first value is complete. For example, it's not possible to know whether this Ion data:
+    //     foo::bar::baz
+    // is the symbol 'baz' with the annotations 'foo' and 'bar', or if it's actually
+    // _three annotations_ on a value that we're still waiting to read from the stream.
+    // On the other hand, a parser looking at the same data with a trailing value like this:
+    //     foo::bar::baz END
+    // can easily tell that 'foo' and 'bar' are annotations and 'baz' is the value.
+    // Here, 'END' is simply an unrelated symbol value that the parser knows to ignore.
+    #[case("foo::bar::baz END", &["foo", "bar"], TextStreamItem::Symbol(text_token("baz")))]
+    #[case("foo::bar::baz END", &["foo", "bar"], TextStreamItem::Symbol(text_token("baz")))]
+    #[case("foo::'bar'::7 END", &["foo", "bar"], TextStreamItem::Integer(7))]
+    #[case("'foo'::'bar'::{ END", &["foo", "bar"], TextStreamItem::StructStart)]
+    #[case("'foo bar'::false END", &["foo bar"], TextStreamItem::Boolean(false))]
+    fn test_parse_annotated_value(
+        #[case] text: &str,
+        #[case] expected_annotations: &[&str],
+        #[case] expected_item: TextStreamItem,
+    ) {
+        assert_eq!(
+            annotated_stream_item(text).unwrap().1,
+            (text_tokens(expected_annotations), expected_item)
+        );
+    }
 }


### PR DESCRIPTION
* `parse_symbol` can now match text symbol IDs (e.g. `$23`)
* Symbols read from the stream are now represented as
  `OwnedSymbolToken`s instead of `String`s to allow for the case
  in which a given symbol's ID was found and the text has not yet
  been looked up.
* The reader's `next()` method now returns an `(annotations, item)`
  tuple instead of just an `item`. If there are no annotations on
  an item, the annotations Vec is empty.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
