### PR TITLE
Adds comment parsing to the text reader

### DIFF
--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -31,6 +31,7 @@ pub(crate) enum TextStreamItem {
     SExpressionEnd,
     StructStart,
     StructEnd,
+    Comment,
     EndOfStream,
 }
 

--- a/src/text/parsers/comments.rs
+++ b/src/text/parsers/comments.rs
@@ -1,0 +1,71 @@
+use crate::text::TextStreamItem;
+use nom::branch::alt;
+use nom::bytes::streaming::{is_not, tag, take_until};
+use nom::combinator::map;
+use nom::sequence::{delimited, preceded};
+use nom::IResult;
+
+/// Matches a `/* multiline */` or `// rest-of-line` comment.
+pub(crate) fn parse_comment(input: &str) -> IResult<&str, TextStreamItem> {
+    map(alt((rest_of_line_comment, multiline_comment)), |_text| {
+        TextStreamItem::Comment
+    })(input)
+}
+
+/// Matches a rest-of-line comment. Returns the text of the comment without the leading "//".
+/// If no closing newline is found, this will return `Incomplete`.
+fn rest_of_line_comment(input: &str) -> IResult<&str, &str> {
+    preceded(
+        // Matches a leading "//"...
+        tag("//"),
+        // ...followed by any characters that are not a '\r' or '\n'.
+        is_not("\r\n"), // Note that this will not consume the newline.
+    )(input)
+}
+
+/// Matches a multiline comment. Returns the text of the comment without the
+/// delimiting "/*" and "*/". If no closing "*/" is found, this will return `Incomplete`.
+fn multiline_comment(input: &str) -> IResult<&str, &str> {
+    delimited(
+        // Matches a leading "/*"
+        tag("/*"),
+        // Any number of non-"*/" characters
+        take_until("*/"),
+        // and then a closing "*/"
+        tag("*/"),
+    )(input)
+}
+
+#[cfg(test)]
+pub(crate) mod comment_parser_tests {
+    use super::*;
+    use crate::text::TextStreamItem;
+    use rstest::*;
+
+    #[rstest]
+    #[case("//hello!\n", "hello!")]
+    #[case("//😎 😎 😎\n", "😎 😎 😎")]
+    #[should_panic]
+    #[case("// no newline ", "<should panic>")]
+    fn test_parse_rest_of_line_comment(#[case] text: &str, #[case] expected: &str) {
+        assert_eq!(rest_of_line_comment(text).unwrap().1, expected);
+    }
+
+    #[rstest]
+    #[case("/*hello!*/", "hello!")]
+    #[case("/*foo\nbar\nbaz*/", "foo\nbar\nbaz")]
+    #[should_panic]
+    #[case("/* no closing tag", "<should panic>")]
+    fn test_parse_multiline_comment(#[case] text: &str, #[case] expected: &str) {
+        assert_eq!(multiline_comment(text).unwrap().1, expected);
+    }
+
+    #[rstest]
+    #[case("//hello!\n")]
+    #[case("//😎 😎 😎\n")]
+    #[case("/*hello!*/")]
+    #[case("/*foo\nbar\nbaz*/")]
+    fn test_parse_comment(#[case] text: &str) {
+        assert_eq!(parse_comment(text).unwrap().1, TextStreamItem::Comment);
+    }
+}

--- a/src/text/parsers/mod.rs
+++ b/src/text/parsers/mod.rs
@@ -11,6 +11,7 @@ use nom::IResult;
 pub(crate) mod blob;
 pub(crate) mod boolean;
 pub(crate) mod clob;
+mod comments;
 pub(crate) mod containers;
 pub(crate) mod decimal;
 pub(crate) mod float;

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -9,6 +9,7 @@ use nom::{IResult, Parser};
 use crate::text::parsers::blob::parse_blob;
 use crate::text::parsers::boolean::parse_boolean;
 use crate::text::parsers::clob::parse_clob;
+use crate::text::parsers::comments::parse_comment;
 use crate::text::parsers::containers::{parse_container_end, parse_container_start};
 use crate::text::parsers::decimal::parse_decimal;
 use crate::text::parsers::float::parse_float;
@@ -35,6 +36,7 @@ pub(crate) fn stream_item(input: &str) -> IResult<&str, TextStreamItem> {
         parse_clob,
         parse_container_start,
         parse_container_end,
+        parse_comment,
     ))(input)
 }
 


### PR DESCRIPTION
This PR defines new parser rules for handling rest-of-line and
multiline comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
