### PR TITLE
Reorganizes text parsing modules

### DIFF
--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -54,8 +54,14 @@ impl TextStreamItem {
             TextStreamItem::ListStart => IonType::List,
             TextStreamItem::SExpressionStart => IonType::SExpression,
             TextStreamItem::StructStart => IonType::Struct,
-            _ => return None, // The remaining items are container ends, EndOfStream, etc.
+            _ => return None, // The remaining items are container ends, Comment, EndOfStream, etc.
         };
         Some(ion_type)
+    }
+
+    // Returns [true] if the stream item being returned represents either a scalar value or the
+    // beginning of a container.
+    pub fn is_value(&self) -> bool {
+        self.ion_type().is_some()
     }
 }

--- a/src/text/parsers/annotations.rs
+++ b/src/text/parsers/annotations.rs
@@ -1,0 +1,69 @@
+use crate::text::parsers::symbol::parse_symbol;
+use crate::text::TextStreamItem;
+use crate::value::owned::OwnedSymbolToken;
+use nom::branch::alt;
+use nom::bytes::streaming::tag;
+use nom::character::complete::multispace0;
+use nom::combinator::map_opt;
+use nom::multi::many1;
+use nom::sequence::{delimited, pair, preceded};
+use nom::{IResult, Parser};
+
+/// Matches a series of '::'-delimited symbols used to annotate a value.
+pub(crate) fn parse_annotations(input: &str) -> IResult<&str, Vec<OwnedSymbolToken>> {
+    many1(parse_annotation)(input)
+}
+
+/// Matches a single symbol of any format (foo, 'foo', or $10) followed by a '::' delimiter.
+/// The delimiter can be preceded or trailed by any amount of whitespace.
+pub(crate) fn parse_annotation(input: &str) -> IResult<&str, OwnedSymbolToken> {
+    map_opt(
+        // 0+ spaces, a symbol ('quoted', identifier, or $id), 0+ spaces, '::'
+        delimited(multispace0, parse_symbol, annotation_delimiter),
+        |text_stream_item| {
+            // This should always be true because `parse_symbol` would not have matched an
+            // item if it were not a symbol.
+            if let TextStreamItem::Symbol(symbol) = text_stream_item {
+                return Some(symbol);
+            }
+            None
+        },
+    )(input)
+}
+
+fn annotation_delimiter(input: &str) -> IResult<&str, &str> {
+    preceded(multispace0, tag("::"))(input)
+}
+
+#[cfg(test)]
+mod parse_annotations_tests {
+    use super::*;
+    use crate::types::SymbolId;
+    use crate::value::owned::{local_sid_token, text_token};
+    use rstest::*;
+
+    #[rstest]
+    #[case::identifier_no_spaces("foo::", "foo")]
+    #[case::identifier_leading_spaces("   foo::", "foo")]
+    #[case::identifier_trailing_spaces("foo::   ", "foo")]
+    #[case::identifier_interstitial_spaces("foo   ::", "foo")]
+    #[case::identifier_all_spaces("   foo   ::   ", "foo")]
+    #[case::quoted_no_spaces("'foo'::", "foo")]
+    #[case::quoted_leading_spaces("   'foo'::", "foo")]
+    #[case::quoted_trailing_spaces("'foo'::   ", "foo")]
+    #[case::quoted_interstitial_spaces("'foo'   ::", "foo")]
+    #[case::quoted_all_spaces("   'foo'   ::   ", "foo")]
+    fn test_parse_annotation(#[case] text: &str, #[case] expected: &str) {
+        assert_eq!(parse_annotation(text).unwrap().1, text_token(expected));
+    }
+
+    #[rstest]
+    #[case::symbol_id_no_spaces("$10::", 10)]
+    #[case::symbol_id_leading_spaces("   $10::", 10)]
+    #[case::symbol_id_trailing_spaces("$10::   ", 10)]
+    #[case::symbol_id_interstitial_spaces("$10   ::", 10)]
+    #[case::symbol_id_all_spaces("   $10   ::   ", 10)]
+    fn test_parse_symbol_id_annotation(#[case] text: &str, #[case] expected: SymbolId) {
+        assert_eq!(parse_annotation(text).unwrap().1, local_sid_token(expected));
+    }
+}

--- a/src/text/parsers/annotations.rs
+++ b/src/text/parsers/annotations.rs
@@ -1,13 +1,13 @@
+use nom::bytes::streaming::tag;
+use nom::character::streaming::multispace0;
+use nom::combinator::map_opt;
+use nom::multi::many1;
+use nom::sequence::{delimited, preceded};
+use nom::IResult;
+
 use crate::text::parsers::symbol::parse_symbol;
 use crate::text::TextStreamItem;
 use crate::value::owned::OwnedSymbolToken;
-use nom::branch::alt;
-use nom::bytes::streaming::tag;
-use nom::character::complete::multispace0;
-use nom::combinator::map_opt;
-use nom::multi::many1;
-use nom::sequence::{delimited, pair, preceded};
-use nom::{IResult, Parser};
 
 /// Matches a series of '::'-delimited symbols used to annotate a value.
 pub(crate) fn parse_annotations(input: &str) -> IResult<&str, Vec<OwnedSymbolToken>> {
@@ -37,10 +37,12 @@ fn annotation_delimiter(input: &str) -> IResult<&str, &str> {
 
 #[cfg(test)]
 mod parse_annotations_tests {
-    use super::*;
+    use rstest::*;
+
     use crate::types::SymbolId;
     use crate::value::owned::{local_sid_token, text_token};
-    use rstest::*;
+
+    use super::*;
 
     #[rstest]
     #[case::identifier_no_spaces("foo::", "foo")]

--- a/src/text/parsers/mod.rs
+++ b/src/text/parsers/mod.rs
@@ -8,6 +8,7 @@ use nom::character::streaming::{one_of, satisfy};
 use nom::combinator::peek;
 use nom::IResult;
 
+pub(crate) mod annotations;
 pub(crate) mod blob;
 pub(crate) mod boolean;
 pub(crate) mod clob;
@@ -18,6 +19,7 @@ pub(crate) mod float;
 pub(crate) mod integer;
 pub(crate) mod null;
 pub(crate) mod numeric_support;
+pub(crate) mod stream_item;
 pub(crate) mod string;
 pub(crate) mod symbol;
 pub(crate) mod text_support;

--- a/src/text/parsers/stream_item.rs
+++ b/src/text/parsers/stream_item.rs
@@ -1,0 +1,49 @@
+use crate::text::parsers::annotations::parse_annotations;
+use nom::branch::alt;
+use nom::bytes::streaming::tag;
+use nom::character::complete::multispace0;
+use nom::combinator::map_opt;
+use nom::multi::many1;
+use nom::sequence::{delimited, pair, preceded};
+use nom::{IResult, Parser};
+
+use crate::text::parsers::blob::parse_blob;
+use crate::text::parsers::boolean::parse_boolean;
+use crate::text::parsers::clob::parse_clob;
+use crate::text::parsers::comments::parse_comment;
+use crate::text::parsers::containers::{parse_container_end, parse_container_start};
+use crate::text::parsers::decimal::parse_decimal;
+use crate::text::parsers::float::parse_float;
+use crate::text::parsers::integer::parse_integer;
+use crate::text::parsers::null::parse_null;
+use crate::text::parsers::string::parse_string;
+use crate::text::parsers::symbol::parse_symbol;
+use crate::text::parsers::timestamp::parse_timestamp;
+use crate::text::TextStreamItem;
+use crate::value::owned::OwnedSymbolToken;
+
+/// Matches a TextStreamItem at the beginning of the given string.
+pub(crate) fn stream_item(input: &str) -> IResult<&str, TextStreamItem> {
+    alt((
+        parse_null,
+        parse_boolean,
+        parse_integer,
+        parse_float,
+        parse_decimal,
+        parse_timestamp,
+        parse_string,
+        parse_symbol,
+        parse_blob,
+        parse_clob,
+        parse_container_start,
+        parse_container_end,
+        parse_comment,
+    ))(input)
+}
+
+/// Matches a series of annotations and their associated TextStreamItem.
+pub(crate) fn annotated_stream_item(
+    input: &str,
+) -> IResult<&str, (Vec<OwnedSymbolToken>, TextStreamItem)> {
+    pair(parse_annotations, stream_item)(input)
+}

--- a/src/text/parsers/stream_item.rs
+++ b/src/text/parsers/stream_item.rs
@@ -1,12 +1,8 @@
-use crate::text::parsers::annotations::parse_annotations;
 use nom::branch::alt;
-use nom::bytes::streaming::tag;
-use nom::character::complete::multispace0;
-use nom::combinator::map_opt;
-use nom::multi::many1;
-use nom::sequence::{delimited, pair, preceded};
-use nom::{IResult, Parser};
+use nom::sequence::pair;
+use nom::IResult;
 
+use crate::text::parsers::annotations::parse_annotations;
 use crate::text::parsers::blob::parse_blob;
 use crate::text::parsers::boolean::parse_boolean;
 use crate::text::parsers::clob::parse_clob;

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -1,3 +1,4 @@
+use crate::text::parsers::annotations::parse_annotations;
 use nom::branch::alt;
 use nom::bytes::streaming::tag;
 use nom::character::complete::multispace0;
@@ -15,37 +16,12 @@ use crate::text::parsers::decimal::parse_decimal;
 use crate::text::parsers::float::parse_float;
 use crate::text::parsers::integer::parse_integer;
 use crate::text::parsers::null::parse_null;
+use crate::text::parsers::stream_item::{annotated_stream_item, stream_item};
 use crate::text::parsers::string::parse_string;
 use crate::text::parsers::symbol::parse_symbol;
 use crate::text::parsers::timestamp::parse_timestamp;
 use crate::text::TextStreamItem;
 use crate::value::owned::OwnedSymbolToken;
-
-/// Matches a TextStreamItem at the beginning of the given string.
-pub(crate) fn stream_item(input: &str) -> IResult<&str, TextStreamItem> {
-    alt((
-        parse_null,
-        parse_boolean,
-        parse_integer,
-        parse_float,
-        parse_decimal,
-        parse_timestamp,
-        parse_string,
-        parse_symbol,
-        parse_blob,
-        parse_clob,
-        parse_container_start,
-        parse_container_end,
-        parse_comment,
-    ))(input)
-}
-
-/// Matches a series of annotations and their associated TextStreamItem.
-pub(crate) fn annotated_stream_item(
-    input: &str,
-) -> IResult<&str, (Vec<OwnedSymbolToken>, TextStreamItem)> {
-    pair(parse_annotations, stream_item)(input)
-}
 
 /// Matches an optional series of annotations and a TextStreamItem at the beginning of the given
 /// string. If there are no annotations (or the TextStreamItem found cannot have annotations), the
@@ -67,38 +43,13 @@ pub(crate) fn top_level_stream_item(
     )(input)
 }
 
-/// Matches a series of '::'-delimited symbols used to annotate a value.
-pub(crate) fn parse_annotations(input: &str) -> IResult<&str, Vec<OwnedSymbolToken>> {
-    many1(parse_annotation)(input)
-}
-
-/// Matches a single symbol of any format (foo, 'foo', or $10) followed by a '::' delimiter.
-/// The delimiter can be preceded or trailed by any amount of whitespace.
-pub(crate) fn parse_annotation(input: &str) -> IResult<&str, OwnedSymbolToken> {
-    map_opt(
-        // 0+ spaces, a symbol ('quoted', identifier, or $id), 0+ spaces, '::'
-        delimited(multispace0, parse_symbol, annotation_delimiter),
-        |text_stream_item| {
-            // This should always be true because `parse_symbol` would not have matched an
-            // item if it were not a symbol.
-            if let TextStreamItem::Symbol(symbol) = text_stream_item {
-                return Some(symbol);
-            }
-            None
-        },
-    )(input)
-}
-
-fn annotation_delimiter(input: &str) -> IResult<&str, &str> {
-    preceded(multispace0, tag("::"))(input)
-}
-
 #[cfg(test)]
-// TODO: Move relevant tests from reader.rs to this module
-mod parse_top_level_value_tests {
+mod parse_stream_item_tests {
     use super::*;
+    use crate::text::parsers::unit_test_support::parse_unwrap;
     use crate::types::SymbolId;
     use crate::value::owned::{local_sid_token, text_token};
+    use crate::IonType;
     use rstest::*;
 
     // Unit test helper; converts strings into OwnedSymbolTokens
@@ -106,29 +57,48 @@ mod parse_top_level_value_tests {
         return strs.iter().map(|s| text_token(*s)).collect();
     }
 
-    #[rstest]
-    #[case::identifier_no_spaces("foo::", "foo")]
-    #[case::identifier_leading_spaces("   foo::", "foo")]
-    #[case::identifier_trailing_spaces("foo::   ", "foo")]
-    #[case::identifier_interstitial_spaces("foo   ::", "foo")]
-    #[case::identifier_all_spaces("   foo   ::   ", "foo")]
-    #[case::quoted_no_spaces("'foo'::", "foo")]
-    #[case::quoted_leading_spaces("   'foo'::", "foo")]
-    #[case::quoted_trailing_spaces("'foo'::   ", "foo")]
-    #[case::quoted_interstitial_spaces("'foo'   ::", "foo")]
-    #[case::quoted_all_spaces("   'foo'   ::   ", "foo")]
-    fn test_parse_annotation(#[case] text: &str, #[case] expected: &str) {
-        assert_eq!(parse_annotation(text).unwrap().1, text_token(expected));
-    }
+    #[test]
+    fn test_detect_stream_item_types() {
+        let expect_option_type = |text: &str, expected: Option<IonType>| {
+            let value = parse_unwrap(stream_item, text);
+            assert_eq!(expected, value.ion_type());
+        };
 
-    #[rstest]
-    #[case::symbol_id_no_spaces("$10::", 10)]
-    #[case::symbol_id_leading_spaces("   $10::", 10)]
-    #[case::symbol_id_trailing_spaces("$10::   ", 10)]
-    #[case::symbol_id_interstitial_spaces("$10   ::", 10)]
-    #[case::symbol_id_all_spaces("   $10   ::   ", 10)]
-    fn test_parse_symbol_id_annotation(#[case] text: &str, #[case] expected: SymbolId) {
-        assert_eq!(parse_annotation(text).unwrap().1, local_sid_token(expected));
+        let expect_type = |text: &str, expected_ion_type: IonType| {
+            expect_option_type(text, Some(expected_ion_type))
+        };
+
+        let expect_no_type = |text: &str| expect_option_type(text, None);
+
+        expect_type("null ", IonType::Null);
+        expect_type("null.timestamp ", IonType::Timestamp);
+        expect_type("null.list ", IonType::List);
+        expect_type("true ", IonType::Boolean);
+        expect_type("false ", IonType::Boolean);
+        expect_type("5 ", IonType::Integer);
+        expect_type("-5 ", IonType::Integer);
+        expect_type("5.0 ", IonType::Decimal);
+        expect_type("-5.0 ", IonType::Decimal);
+        expect_type("5.0d0 ", IonType::Decimal);
+        expect_type("-5.0d0 ", IonType::Decimal);
+        expect_type("5.0e0 ", IonType::Float);
+        expect_type("-5.0e1_024 ", IonType::Float);
+        expect_type("\"foo\"", IonType::String);
+        expect_type("'''foo''' 1", IonType::String);
+        expect_type("foo ", IonType::Symbol);
+        expect_type("'foo bar baz' ", IonType::Symbol);
+        expect_type("2021T ", IonType::Timestamp);
+        expect_type("2021-02T ", IonType::Timestamp);
+        expect_type("2021-02-08T ", IonType::Timestamp);
+        expect_type("2021-02-08T12:30Z ", IonType::Timestamp);
+        expect_type("2021-02-08T12:30:02-00:00 ", IonType::Timestamp);
+        expect_type("2021-02-08T12:30:02.111-00:00 ", IonType::Timestamp);
+        expect_type("{{\"hello\"}}", IonType::Clob);
+
+        // End of...
+        expect_no_type("} "); // struct
+        expect_no_type("] "); // list
+        expect_no_type(") "); // s-expression
     }
 
     #[rstest]
@@ -146,7 +116,7 @@ mod parse_top_level_value_tests {
     #[case("foo::'bar'::7 END", &["foo", "bar"], TextStreamItem::Integer(7))]
     #[case("'foo'::'bar'::{ END", &["foo", "bar"], TextStreamItem::StructStart)]
     #[case("'foo bar'::false END", &["foo bar"], TextStreamItem::Boolean(false))]
-    fn test_parse_annotated_value(
+    fn test_parse_annotated_stream_item(
         #[case] text: &str,
         #[case] expected_annotations: &[&str],
         #[case] expected_item: TextStreamItem,

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -1,25 +1,9 @@
-use crate::text::parsers::annotations::parse_annotations;
+use crate::text::parsers::stream_item::{annotated_stream_item, stream_item};
 use nom::branch::alt;
-use nom::bytes::streaming::tag;
 use nom::character::complete::multispace0;
-use nom::combinator::map_opt;
-use nom::multi::many1;
-use nom::sequence::{delimited, pair, preceded};
+use nom::sequence::preceded;
 use nom::{IResult, Parser};
 
-use crate::text::parsers::blob::parse_blob;
-use crate::text::parsers::boolean::parse_boolean;
-use crate::text::parsers::clob::parse_clob;
-use crate::text::parsers::comments::parse_comment;
-use crate::text::parsers::containers::{parse_container_end, parse_container_start};
-use crate::text::parsers::decimal::parse_decimal;
-use crate::text::parsers::float::parse_float;
-use crate::text::parsers::integer::parse_integer;
-use crate::text::parsers::null::parse_null;
-use crate::text::parsers::stream_item::{annotated_stream_item, stream_item};
-use crate::text::parsers::string::parse_string;
-use crate::text::parsers::symbol::parse_symbol;
-use crate::text::parsers::timestamp::parse_timestamp;
 use crate::text::TextStreamItem;
 use crate::value::owned::OwnedSymbolToken;
 
@@ -45,12 +29,13 @@ pub(crate) fn top_level_stream_item(
 
 #[cfg(test)]
 mod parse_stream_item_tests {
-    use super::*;
-    use crate::text::parsers::unit_test_support::parse_unwrap;
-    use crate::types::SymbolId;
-    use crate::value::owned::{local_sid_token, text_token};
-    use crate::IonType;
     use rstest::*;
+
+    use crate::text::parsers::unit_test_support::parse_unwrap;
+    use crate::value::owned::text_token;
+    use crate::IonType;
+
+    use super::*;
 
     // Unit test helper; converts strings into OwnedSymbolTokens
     fn text_tokens(strs: &[&str]) -> Vec<OwnedSymbolToken> {

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -161,8 +161,6 @@ impl<T: TextIonDataSource> TextReader<T> {
 #[cfg(test)]
 mod reader_tests {
     use crate::result::IonResult;
-    use crate::text::parsers::top_level::stream_item;
-    use crate::text::parsers::unit_test_support::parse_unwrap;
     use crate::text::reader::TextReader;
     use crate::text::TextStreamItem;
     use crate::types::decimal::Decimal;

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -352,48 +352,4 @@ mod reader_tests {
         );
         Ok(())
     }
-
-    #[test]
-    fn test_detect_stream_item_types() {
-        let expect_option_type = |text: &str, expected: Option<IonType>| {
-            let value = parse_unwrap(stream_item, text);
-            assert_eq!(expected, value.ion_type());
-        };
-
-        let expect_type = |text: &str, expected_ion_type: IonType| {
-            expect_option_type(text, Some(expected_ion_type))
-        };
-
-        let expect_no_type = |text: &str| expect_option_type(text, None);
-
-        expect_type("null ", IonType::Null);
-        expect_type("null.timestamp ", IonType::Timestamp);
-        expect_type("null.list ", IonType::List);
-        expect_type("true ", IonType::Boolean);
-        expect_type("false ", IonType::Boolean);
-        expect_type("5 ", IonType::Integer);
-        expect_type("-5 ", IonType::Integer);
-        expect_type("5.0 ", IonType::Decimal);
-        expect_type("-5.0 ", IonType::Decimal);
-        expect_type("5.0d0 ", IonType::Decimal);
-        expect_type("-5.0d0 ", IonType::Decimal);
-        expect_type("5.0e0 ", IonType::Float);
-        expect_type("-5.0e1_024 ", IonType::Float);
-        expect_type("\"foo\"", IonType::String);
-        expect_type("'''foo''' 1", IonType::String);
-        expect_type("foo ", IonType::Symbol);
-        expect_type("'foo bar baz' ", IonType::Symbol);
-        expect_type("2021T ", IonType::Timestamp);
-        expect_type("2021-02T ", IonType::Timestamp);
-        expect_type("2021-02-08T ", IonType::Timestamp);
-        expect_type("2021-02-08T12:30Z ", IonType::Timestamp);
-        expect_type("2021-02-08T12:30:02-00:00 ", IonType::Timestamp);
-        expect_type("2021-02-08T12:30:02.111-00:00 ", IonType::Timestamp);
-        expect_type("{{\"hello\"}}", IonType::Clob);
-
-        // End of...
-        expect_no_type("} "); // struct
-        expect_no_type("] "); // list
-        expect_no_type(") "); // s-expression
-    }
 }


### PR DESCRIPTION
**This PR contains no logic changes, it only reorganizes some of the text parsing functions and their corresponding unit tests.**

* Creates an `annotations` module and relocates the
  relevant parser functions to it.
* Moves `top_level_stream_item` unit tests from the
  `reader` module to the `stream_item` module.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
