### PR TITLE
Support NOP-padded data

### DIFF
--- a/ion-hash/src/type_qualifier.rs
+++ b/ion-hash/src/type_qualifier.rs
@@ -85,7 +85,7 @@ fn qualify_nullness<T>(value: Option<T>) -> u8 {
 }
 
 pub(crate) fn type_qualifier_null() -> TypeQualifier {
-    combine(IonTypeCode::NullOrWhitespace, 0x0F)
+    combine(IonTypeCode::NullOrNop, 0x0F)
 }
 
 pub(crate) fn type_qualifier_boolean(value: Option<bool>) -> TypeQualifier {

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -1112,7 +1112,7 @@ where
         if self.cursor.index_at_depth > 0 {
             // NOPs are not values, so bytes_read can be past the last consumed value (`end`).
             // This is an artifact of consuming NOP sleds with recursive `next()`, and could be
-            // fixed with refactoring. 
+            // fixed with refactoring.
             // `saturating_sub` avoids underflow by returning 0 if `position` > `end`.
             let bytes_to_skip = end.saturating_sub(position);
             self.skip_bytes(bytes_to_skip)

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -333,7 +333,7 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
                         bytes = number_of_bytes,
                         nop_range = nop_range,
                         over = nop_range.end - container_range.end,
-                        s = if number_of_bytes == 1 {""} else {"s"},
+                        s = if number_of_bytes == 1 { "" } else { "s" },
                         container_range = container_range,
                     ));
                 }

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -1105,15 +1105,16 @@ where
     }
 
     fn skip_current_value(&mut self) -> IonResult<()> {
-        let pos = self.cursor.bytes_read;
+        let position = self.cursor.bytes_read;
         let end = self.cursor.value.value_end_exclusive();
 
         // Don't skip a value if we haven't called `next()` at the current level
         if self.cursor.index_at_depth > 0 {
             // NOPs are not values, so bytes_read can be past the last consumed value (`end`).
             // This is an artifact of consuming NOP sleds with recursive `next()`, and could be
-            // fixed with refactoring.
-            let bytes_to_skip = end.saturating_sub(pos);
+            // fixed with refactoring. 
+            // `saturating_sub` avoids underflow by returning 0 if `position` > `end`.
+            let bytes_to_skip = end.saturating_sub(position);
             self.skip_bytes(bytes_to_skip)
         } else {
             Ok(())

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -367,8 +367,8 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
             };
             if header.is_nop() {
                 return decoding_error(&format!(
-                    // What helpful context could we include here?
-                    "Can't have NOP padding inside an annotation wrapper"
+                    "The annotation wrapper starting at byte {} contains NOP padding, which is illegal.",
+                    self.cursor.bytes_read
                 ));
             }
             self.cursor.value.header = header;

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -1967,7 +1967,6 @@ mod tests {
         cursor.step_in()?;
         assert_eq!(cursor.next()?, Some(Value(IonType::Integer, false)));
 
-        cursor.next()?;
         assert!(matches!(cursor.next(), Err(IonError::DecodingError { .. })));
 
         cursor.step_out()?;

--- a/src/binary/cursor.rs
+++ b/src/binary/cursor.rs
@@ -328,15 +328,13 @@ impl<R: IonDataSource> Cursor for BinaryIonCursor<R> {
                 if nop_range.end > container_range.end {
                     // This NOP is malformed, let's assemble data for error reporting
                     return decoding_error(&format!(
-                        "{bytes}-byte NOP padding on byte range [{nop_start}, {nop_end}) is {over} \
-                        byte{s} past container content range [{container_start}, {container_end})",
+                        "{bytes}-byte NOP padding on byte range {nop_range:?} is {over} \
+                        byte{s} past container content range {container_range:?}",
                         bytes = number_of_bytes,
-                        nop_start = nop_range.start,
-                        nop_end = nop_range.end,
+                        nop_range = nop_range,
                         over = nop_range.end - container_range.end,
                         s = if number_of_bytes == 1 {""} else {"s"},
-                        container_start = container_range.start,
-                        container_end = container_range.end,
+                        container_range = container_range,
                     ));
                 }
             }

--- a/src/binary/header.rs
+++ b/src/binary/header.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use crate::{
-    binary::{nibbles::nibbles_from_byte, IonTypeCode},
+    binary::{constants::v1_0::length_codes, nibbles::nibbles_from_byte, IonTypeCode},
     result::IonResult,
     types::IonType,
 };
@@ -30,6 +30,10 @@ impl Header {
             ion_type_code,
             length_code,
         })
+    }
+
+    pub fn is_nop(&self) -> bool {
+        self.ion_type_code == IonTypeCode::NullOrNop && self.length_code != length_codes::NULL
     }
 }
 

--- a/src/binary/type_code.rs
+++ b/src/binary/type_code.rs
@@ -16,22 +16,22 @@ use crate::types::IonType;
 /// section of the spec for more information.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum IonTypeCode {
-    NullOrWhitespace, // 0
-    Boolean,          // 1
-    PositiveInteger,  // 2
-    NegativeInteger,  // 3
-    Float,            // 4
-    Decimal,          // 5
-    Timestamp,        // 6
-    Symbol,           // 7
-    String,           // 8
-    Clob,             // 9
-    Blob,             // 10
-    List,             // 11
-    SExpression,      // 12
-    Struct,           // 13
-    Annotation,       // 14
-    Reserved,         // 15
+    NullOrNop,       // 0
+    Boolean,         // 1
+    PositiveInteger, // 2
+    NegativeInteger, // 3
+    Float,           // 4
+    Decimal,         // 5
+    Timestamp,       // 6
+    Symbol,          // 7
+    String,          // 8
+    Clob,            // 9
+    Blob,            // 10
+    List,            // 11
+    SExpression,     // 12
+    Struct,          // 13
+    Annotation,      // 14
+    Reserved,        // 15
 }
 
 impl TryFrom<IonTypeCode> for IonType {
@@ -41,7 +41,7 @@ impl TryFrom<IonTypeCode> for IonType {
     fn try_from(ion_type_code: IonTypeCode) -> Result<Self, Self::Error> {
         use IonTypeCode::*;
         let ion_type = match ion_type_code {
-            NullOrWhitespace => IonType::Null,
+            NullOrNop => IonType::Null,
             Boolean => IonType::Boolean,
             PositiveInteger | NegativeInteger => IonType::Integer,
             Float => IonType::Float,
@@ -73,7 +73,7 @@ impl TryFrom<u8> for IonTypeCode {
     fn try_from(type_code: u8) -> Result<Self, Self::Error> {
         use IonTypeCode::*;
         let ion_type_code = match type_code {
-            0 => NullOrWhitespace,
+            0 => NullOrNop,
             1 => Boolean,
             2 => PositiveInteger,
             3 => NegativeInteger,
@@ -102,7 +102,7 @@ impl IonTypeCode {
     pub const fn to_u8(self) -> u8 {
         use IonTypeCode::*;
         match self {
-            NullOrWhitespace => 0,
+            NullOrNop => 0,
             Boolean => 1,
             PositiveInteger => 2,
             NegativeInteger => 3,


### PR DESCRIPTION
*Description of changes:* 

Adds support for NOP padding in the binary cursor, as described in the [binary spec](https://amzn.github.io/ion-docs/docs/binary.html). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
