### PR TITLE
Adds container parsing rules to the text reader

### DIFF
--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -26,21 +26,16 @@ pub(crate) enum TextStreamItem {
     Blob(Vec<u8>),
     Clob(Vec<u8>),
     ListStart,
-    ListEnd,
     SExpressionStart,
-    SExpressionEnd,
     StructStart,
-    StructEnd,
-    Comment,
-    EndOfStream,
 }
 
 impl TextStreamItem {
     /// Returns the IonType associated with the TextStreamItem in question. If the TextStreamItem
     /// does not represent a scalar value or the beginning of a container, [ion_type] will return
     /// [None].
-    pub fn ion_type(&self) -> Option<IonType> {
-        let ion_type = match self {
+    pub fn ion_type(&self) -> IonType {
+        match self {
             TextStreamItem::Null(ion_type) => *ion_type,
             TextStreamItem::Boolean(_) => IonType::Boolean,
             TextStreamItem::Integer(_) => IonType::Integer,
@@ -54,14 +49,6 @@ impl TextStreamItem {
             TextStreamItem::ListStart => IonType::List,
             TextStreamItem::SExpressionStart => IonType::SExpression,
             TextStreamItem::StructStart => IonType::Struct,
-            _ => return None, // The remaining items are container ends, Comment, EndOfStream, etc.
-        };
-        Some(ion_type)
-    }
-
-    // Returns [true] if the stream item being returned represents either a scalar value or the
-    // beginning of a container.
-    pub fn is_value(&self) -> bool {
-        self.ion_type().is_some()
+        }
     }
 }

--- a/src/text/parsers/mod.rs
+++ b/src/text/parsers/mod.rs
@@ -77,22 +77,26 @@ pub(crate) fn whitespace(input: &str) -> IResult<&str, &str> {
 #[cfg(test)]
 pub(crate) mod unit_test_support {
     use nom::{Finish, IResult};
-
-    use crate::text::TextStreamItem;
-
-    /// A type alias for the function signature used by each parsing module's entry point.
-    type TestParser = fn(&str) -> IResult<&str, TextStreamItem>;
+    use std::fmt::Debug;
 
     /// Uses `parser` to parse the provided `text` and then asserts that the output is equal
     /// to `expected`.
-    pub(crate) fn parse_test_ok(parser: TestParser, text: &str, expected: TextStreamItem) {
+    pub(crate) fn parse_test_ok<'a, T, P>(parser: P, text: &'a str, expected: T)
+    where
+        T: Debug + PartialEq,
+        P: Fn(&'a str) -> IResult<&'a str, T>,
+    {
         let actual = parse_unwrap(parser, text);
         assert_eq!(actual, expected);
     }
 
     /// Uses `parser` to parse the provided `text` expecting it to fail. If it succeeds, this
     /// method will panic and display the value that was read.
-    pub(crate) fn parse_test_err(parser: TestParser, text: &str) {
+    pub(crate) fn parse_test_err<'a, T, P>(parser: P, text: &'a str)
+    where
+        T: Debug,
+        P: Fn(&'a str) -> IResult<&'a str, T>,
+    {
         let parsed = parser(text);
         if parsed.is_ok() {
             panic!(
@@ -105,7 +109,11 @@ pub(crate) mod unit_test_support {
 
     /// Uses `parser` to parse the provided `text` and then unwraps the resulting value.
     /// If parsing fails, this method will panic.
-    pub(crate) fn parse_unwrap(parser: TestParser, text: &str) -> TextStreamItem {
+    pub(crate) fn parse_unwrap<'a, T, P>(parser: P, text: &'a str) -> T
+    where
+        T: Debug + PartialEq,
+        P: Fn(&'a str) -> IResult<&'a str, T>,
+    {
         let parsed = parser(text);
         if parsed.is_err() {
             panic!(

--- a/src/text/parsers/stream_item.rs
+++ b/src/text/parsers/stream_item.rs
@@ -6,7 +6,7 @@ use crate::text::parsers::annotations::parse_annotations;
 use crate::text::parsers::blob::parse_blob;
 use crate::text::parsers::boolean::parse_boolean;
 use crate::text::parsers::clob::parse_clob;
-use crate::text::parsers::containers::{parse_container_end, parse_container_start};
+use crate::text::parsers::containers::parse_container_start;
 use crate::text::parsers::decimal::parse_decimal;
 use crate::text::parsers::float::parse_float;
 use crate::text::parsers::integer::parse_integer;
@@ -31,7 +31,6 @@ pub(crate) fn stream_item(input: &str) -> IResult<&str, TextStreamItem> {
         parse_blob,
         parse_clob,
         parse_container_start,
-        parse_container_end,
     ))(input)
 }
 

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -44,16 +44,10 @@ mod parse_stream_item_tests {
 
     #[test]
     fn test_detect_stream_item_types() {
-        let expect_option_type = |text: &str, expected: Option<IonType>| {
-            let value = parse_unwrap(stream_item, text);
-            assert_eq!(expected, value.ion_type());
-        };
-
         let expect_type = |text: &str, expected_ion_type: IonType| {
-            expect_option_type(text, Some(expected_ion_type))
+            let value = parse_unwrap(stream_item, text);
+            assert_eq!(expected_ion_type, value.ion_type());
         };
-
-        let expect_no_type = |text: &str| expect_option_type(text, None);
 
         expect_type("null ", IonType::Null);
         expect_type("null.timestamp ", IonType::Timestamp);
@@ -79,11 +73,6 @@ mod parse_stream_item_tests {
         expect_type("2021-02-08T12:30:02-00:00 ", IonType::Timestamp);
         expect_type("2021-02-08T12:30:02.111-00:00 ", IonType::Timestamp);
         expect_type("{{\"hello\"}}", IonType::Clob);
-
-        // End of...
-        expect_no_type("} "); // struct
-        expect_no_type("] "); // list
-        expect_no_type(") "); // s-expression
     }
 
     #[rstest]

--- a/src/text/reader.rs
+++ b/src/text/reader.rs
@@ -1,6 +1,10 @@
 use nom::Err::Incomplete;
+use nom::IResult;
 
 use crate::result::{decoding_error, IonResult};
+use crate::text::parsers::containers::{
+    list_item_or_end, s_expression_item_or_end, struct_field_name_or_end, struct_stream_item,
+};
 use crate::text::parsers::top_level::top_level_stream_item;
 use crate::text::text_buffer::TextBuffer;
 use crate::text::text_data_source::TextIonDataSource;
@@ -39,17 +43,98 @@ impl<T: TextIonDataSource> TextReader<T> {
 
     //TODO: TextStreamItem is an internal data type and should not be part of the public API.
     //      This method is currently private and only usable in this module's unit tests.
-    fn next(&mut self) -> IonResult<(Vec<OwnedSymbolToken>, TextStreamItem)> {
+    fn next(&mut self) -> IonResult<Option<(Vec<OwnedSymbolToken>, TextStreamItem)>> {
+        // TODO: When the reader eventually tracks what containers we've stepped into or out of,
+        //       this method will call the appropriate parser.
+        self.next_top_level_item()
+    }
+
+    /// Assumes that the reader is at the top level and attempts to parse the next value or IVM in
+    /// the stream.
+    fn next_top_level_item(
+        &mut self,
+    ) -> IonResult<Option<(Vec<OwnedSymbolToken>, TextStreamItem)>> {
+        match self.parse_next(top_level_stream_item) {
+            Ok(Some(item)) => Ok(Some(item)),
+            Ok(None) => {
+                // The top level is the only depth at which EOF is legal. If we encounter an EOF,
+                // double check that the buffer doesn't actually have a value in it. See the
+                // comments in [parse_stream_item_at_eof] for a detailed explanation of this.
+                self.parse_stream_item_at_eof()
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Assumes that the reader is inside a list and attempts to parse the next value.
+    /// If the next token in the stream is an end-of-list delimiter (`]`), returns Ok(None).
+    fn next_list_item(&mut self) -> IonResult<Option<(Vec<OwnedSymbolToken>, TextStreamItem)>> {
+        self.parse_expected("a list", list_item_or_end)
+    }
+
+    /// Assumes that the reader is inside an s-expression and attempts to parse the next value.
+    /// If the next token in the stream is an end-of-s-expression delimiter (`)`), returns Ok(None).
+    fn next_s_expression_item(
+        &mut self,
+    ) -> IonResult<Option<(Vec<OwnedSymbolToken>, TextStreamItem)>> {
+        self.parse_expected("an s-expression", s_expression_item_or_end)
+    }
+
+    /// Assumes that the reader is inside an struct and attempts to parse the next field name.
+    /// If the next token in the stream is an end-of-struct delimiter (`}`), returns Ok(None).
+    fn next_struct_field_name(&mut self) -> IonResult<Option<OwnedSymbolToken>> {
+        // If there isn't another value, this returns Ok(None).
+        self.parse_expected("a struct field name", struct_field_name_or_end)
+    }
+
+    /// Assumes that the reader is inside a struct AND that a field has already been successfully
+    /// parsed from input using [next_struct_field_name] and attempts to parse the next value.
+    /// In this input position, only a value (or whitespace/comments) are legal. Anything else
+    /// (including EOF) will result in a decoding error.
+    fn next_struct_item(&mut self) -> IonResult<(Vec<OwnedSymbolToken>, TextStreamItem)> {
+        // Only called after a call to [next_struct_field_name] that returns Some(field_name).
+        // It is not legal for a field name to be followed by a '}' or EOF.
+        // If there isn't another value, returns an Err.
+        self.parse_expected("a struct field value", struct_stream_item)
+    }
+
+    /// Attempts to parse the next entity from the stream using the provided parser.
+    /// Returns a decoding error if EOF is encountered while parsing.
+    /// If the parser encounters an error, it will be returned as-is.
+    fn parse_expected<P, O>(&mut self, entity_name: &str, parser: P) -> IonResult<O>
+    where
+        P: Fn(&str) -> IResult<&str, O>,
+    {
+        match self.parse_next(parser) {
+            Ok(Some(item)) => Ok(item),
+            Ok(None) => decoding_error(format!(
+                "Unexpected end of input while reading {} on line {}: '{}'",
+                entity_name,
+                self.buffer.lines_loaded(),
+                self.buffer.remaining_text()
+            )),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Attempts to parse the next entity from the stream using the provided parser.
+    /// If there isn't enough data in the buffer for the parser to match its input conclusively,
+    /// more data will be loaded into the buffer and the parser will be called again.
+    /// If EOF is encountered, returns `Ok(None)`.
+    fn parse_next<P, O>(&mut self, parser: P) -> IonResult<Option<O>>
+    where
+        P: Fn(&str) -> IResult<&str, O>,
+    {
         if self.is_eof {
-            return Ok((Vec::new(), TextStreamItem::EndOfStream));
+            return Ok(None);
         }
 
-        let (annotations, stream_item) = 'parse: loop {
+        let item = 'parse: loop {
             // Note the number of bytes currently in the text buffer
             let length_before_parse = self.buffer.remaining_text().len();
             // Invoke the top_level_value() parser; this will attempt to recognize the next item
             // in the stream and return a &str slice containing the remaining, not-yet-parsed text.
-            match top_level_stream_item(self.buffer.remaining_text()) {
+            match parser(self.buffer.remaining_text()) {
                 // If `top_level_value` returns 'Incomplete', there wasn't enough text in the buffer
                 // to match the next item. No syntax errors have been encountered (yet?), but we
                 // need to load more text into the buffer before we try to parse it again.
@@ -64,11 +149,11 @@ impl<T: TextIonDataSource> TextReader<T> {
                         // The buffer had an `Incomplete` value in it; now that we know we're at EOF,
                         // we can determine whether the buffer's contents should actually be
                         // considered complete.
-                        return self.parse_stream_item_at_eof();
+                        return Ok(None);
                     }
                     continue;
                 }
-                Ok((remaining_text, (annotations, item))) => {
+                Ok((remaining_text, item)) => {
                     // Our parser successfully matched a stream item.
                     // Note the length of the text that remains after parsing.
                     let length_after_parse = remaining_text.len();
@@ -79,7 +164,7 @@ impl<T: TextIonDataSource> TextReader<T> {
                     self.buffer.consume(bytes_consumed);
                     self.bytes_read += bytes_consumed;
                     // Break out of the read/parse loop, returning the stream item that we matched.
-                    break 'parse (annotations, item);
+                    break 'parse item;
                 }
                 Err(e) => {
                     // Return an error that contains the text currently in the buffer (i.e. what we
@@ -96,22 +181,25 @@ impl<T: TextIonDataSource> TextReader<T> {
             };
         };
 
-        Ok((annotations, stream_item))
+        Ok(Some(item))
     }
 
     // Parses the contents of the text buffer again with the knowledge that we're at the end of the
     // input stream. This allows us to resolve a number of ambiguous cases.
     // For a detailed description of the problem that this addresses, please see:
     // https://github.com/amzn/ion-rust/issues/318
-    fn parse_stream_item_at_eof(&mut self) -> IonResult<(Vec<OwnedSymbolToken>, TextStreamItem)> {
-        // Get a reference to the buffer's backing String. We're at EOF, so we'll never use this
-        // text buffer again; we can modify it without risk. Re-using this buffer avoids allocating
-        // a new string for EOF, which is guaranteed to happen once per stream.
-        let buffer = self.buffer.inner();
+    // This method should only be called when the reader is at the top level. An EOF at any other
+    // depth is an error.
+    fn parse_stream_item_at_eof(
+        &mut self,
+    ) -> IonResult<Option<(Vec<OwnedSymbolToken>, TextStreamItem)>> {
+        // An arbitrary, cheap-to-parse Ion value that we append to the buffer when its contents at
+        // EOF are ambiguous.
+        const SENTINEL_ION_TEXT: &str = "\n0\n";
         // Make a note of the buffer's length; we're about to modify it.
-        let original_length = buffer.len();
-        // Append a newline and an arbitrary value (here: 0) to the buffer.
-        buffer.push_str("\n0\n");
+        let original_length = self.buffer.remaining_text().len();
+        // Append our sentinel value to the end of the input buffer.
+        self.buffer.inner().push_str(SENTINEL_ION_TEXT);
         // If the buffer contained a value, the newline will indicate that the contents of the
         // buffer were complete. For example:
         // * the integer `7` becomes `7\n`; it wasn't the first digit in a truncated `755`.
@@ -126,35 +214,46 @@ impl<T: TextIonDataSource> TextReader<T> {
         //   there aren't any more long-form string segments in the sequence.
         //
         // Attempt to parse the updated buffer.
-        match top_level_stream_item(self.buffer.remaining_text()) {
+        let item = match top_level_stream_item(self.buffer.remaining_text()) {
             Ok(("\n", (annotations, TextStreamItem::Integer(0)))) if annotations.len() == 0 => {
                 // We found the unannotated zero that we appended to the end of the buffer.
                 // The "\n" in this pattern is the unparsed text left in the buffer,
                 // which indicates that our 0 was parsed.
-                Ok((Vec::new(), TextStreamItem::EndOfStream))
+                Ok(None)
             }
             Ok((_remaining_text, (annotations, item))) => {
                 // We found something else. The zero is still in the buffer; we can leave it there.
                 // The reader's `is_eof` flag has been set, so the text buffer will never be used
                 // again. Return the value we found.
-                Ok((annotations, item))
+                Ok(Some((annotations, item)))
             }
             Err(Incomplete(_needed)) => {
-                return decoding_error(format!(
+                decoding_error(format!(
                     "Unexpected end of input on line {}: '{}'",
                     self.buffer.lines_loaded(),
                     &self.buffer.remaining_text()[..original_length] // Don't show the extra `\n0\n`
-                ));
+                ))
             }
             Err(e) => {
-                return decoding_error(format!(
+                decoding_error(format!(
                     "Parsing error occurred near line {}: '{}': '{}'",
                     self.buffer.lines_loaded(),
                     &self.buffer.remaining_text()[..original_length], // Don't show the extra `\n0\n`
                     e
-                ));
+                ))
             }
+        };
+
+        // If we didn't consume the sentinel value, remove the sentinel value from the buffer.
+        // Doing so makes this method idempotent.
+        if self.buffer.remaining_text().ends_with(SENTINEL_ION_TEXT) {
+            let length = self.buffer.remaining_text().len();
+            self.buffer
+                .inner()
+                .truncate(length - SENTINEL_ION_TEXT.len());
         }
+
+        item
     }
 }
 
@@ -179,15 +278,15 @@ mod reader_tests {
             2021-09-25T
             foo
             "hello"
-            {}
-            []
-            ()
+            {foo: bar}
+            ["foo", "bar"]
+            ('''foo''')
         "#;
         let mut reader = TextReader::new(ion_data);
         let mut next_is = |expected| {
             // In this test, none of the stream values are annotated.
             // Compare the stream item and ignore the annotations.
-            assert_eq!(reader.next().unwrap().1, expected);
+            assert_eq!(reader.next().unwrap().unwrap().1, expected);
         };
         next_is(TextStreamItem::Null(IonType::Null));
         next_is(TextStreamItem::Boolean(true));
@@ -199,13 +298,52 @@ mod reader_tests {
         ));
         next_is(TextStreamItem::Symbol(text_token("foo")));
         next_is(TextStreamItem::String("hello".to_string()));
+
+        // ===== CONTAINERS =====
+        // This part of the test is a bit clunky because the reader does not yet support
+        // step_in() and step_out(). We're calling functions like `next_struct_item()` that will
+        // eventually be private helper methods.
+        // TODO: Replace these calls with step_in(), step_out(), field_name(), and next().
         next_is(TextStreamItem::StructStart);
-        next_is(TextStreamItem::StructEnd);
-        next_is(TextStreamItem::ListStart);
-        next_is(TextStreamItem::ListEnd);
-        next_is(TextStreamItem::SExpressionStart);
-        next_is(TextStreamItem::SExpressionEnd);
-        next_is(TextStreamItem::EndOfStream);
+        assert_eq!(
+            reader.next_struct_field_name().unwrap().unwrap(),
+            text_token("foo")
+        );
+        assert_eq!(
+            reader.next_struct_item().unwrap().1,
+            TextStreamItem::Symbol(text_token("bar"))
+        );
+        // The struct only has one field, so asking for the next field name returns `None`.
+        assert_eq!(reader.next_struct_field_name(), Ok(None));
+
+        assert_eq!(reader.next().unwrap().unwrap().1, TextStreamItem::ListStart);
+        assert_eq!(
+            reader.next_list_item().unwrap().unwrap().1,
+            TextStreamItem::String(String::from("foo"))
+        );
+        assert_eq!(
+            reader.next_list_item().unwrap().unwrap().1,
+            TextStreamItem::String(String::from("bar"))
+        );
+        // There are only two values in the list, so asking for the next one returns `None`
+        assert_eq!(reader.next_list_item(), Ok(None));
+
+        assert_eq!(
+            reader.next().unwrap().unwrap().1,
+            TextStreamItem::SExpressionStart
+        );
+        assert_eq!(
+            reader.next_s_expression_item().unwrap().unwrap().1,
+            TextStreamItem::String(String::from("foo"))
+        );
+        // There's only one value in the list, so asking for the next one returns `None`
+        assert_eq!(reader.next_s_expression_item(), Ok(None));
+
+        // There are no more top level values.
+        assert_eq!(reader.next_top_level_item(), Ok(None));
+
+        // Asking for more still results in `None`
+        assert_eq!(reader.next_top_level_item(), Ok(None));
     }
 
     #[test]
@@ -223,7 +361,7 @@ mod reader_tests {
 
         let mut reader = TextReader::new(ion_data);
         let mut next_is = |expected_annotations, expected_item| {
-            let (annotations, item) = reader.next().unwrap();
+            let (annotations, item) = reader.next().unwrap().unwrap();
             assert_eq!(annotations, expected_annotations);
             assert_eq!(item, expected_item);
         };
@@ -250,13 +388,13 @@ mod reader_tests {
             $100::$200::$300::2021-09-25T
             'uranus'::foo
             neptune::"hello"
-            $55::{}
-            pluto::[]
-            haumea::makemake::eris::ceres::()
+            $55::{foo: bar}
+            pluto::[1, 2, 3]
+            haumea::makemake::eris::ceres::(++ -- &&&&&)
         "#;
         let mut reader = TextReader::new(ion_data);
         let mut next_is = |expected_annotations, expected_item| {
-            let (annotations, item) = reader.next().unwrap();
+            let (annotations, item) = reader.next().unwrap().unwrap();
             assert_eq!(annotations, expected_annotations);
             assert_eq!(item, expected_item);
         };
@@ -293,30 +431,84 @@ mod reader_tests {
             vec![text_token("neptune")],
             TextStreamItem::String("hello".to_string()),
         );
-        next_is(vec![local_sid_token(55)], TextStreamItem::StructStart);
-        next_is(vec![], TextStreamItem::StructEnd);
-        next_is(vec![text_token("pluto")], TextStreamItem::ListStart);
-        next_is(vec![], TextStreamItem::ListEnd);
-        next_is(
-            vec![
-                text_token("haumea"),
-                text_token("makemake"),
-                text_token("eris"),
-                text_token("ceres"),
-            ],
-            TextStreamItem::SExpressionStart,
+
+        // ===== CONTAINERS =====
+        // This part of the test is a bit clunky because the reader does not yet support
+        // step_in() and step_out(). We're calling functions like `next_struct_item()` that will
+        // eventually be private helper methods.
+        // TODO: Replace these calls with step_in(), step_out(), field_name(), and next().
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            (vec![local_sid_token(55)], TextStreamItem::StructStart)
         );
-        next_is(vec![], TextStreamItem::SExpressionEnd);
-        // No more values in the stream
-        next_is(vec![], TextStreamItem::EndOfStream);
-        // Continuing to ask for the next value continues to result in EndOfStream
-        next_is(vec![], TextStreamItem::EndOfStream);
-        next_is(vec![], TextStreamItem::EndOfStream);
+        assert_eq!(
+            reader.next_struct_field_name().unwrap().unwrap(),
+            text_token("foo")
+        );
+        assert_eq!(
+            reader.next_struct_item().unwrap().1,
+            TextStreamItem::Symbol(text_token("bar"))
+        );
+        // There's only one field in the struct, so asking for another field name returns `None`
+        assert_eq!(reader.next_struct_field_name(), Ok(None));
+
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            (vec![text_token("pluto")], TextStreamItem::ListStart)
+        );
+        assert_eq!(
+            reader.next_list_item().unwrap().unwrap().1,
+            TextStreamItem::Integer(1)
+        );
+        assert_eq!(
+            reader.next_list_item().unwrap().unwrap().1,
+            TextStreamItem::Integer(2)
+        );
+        assert_eq!(
+            reader.next_list_item().unwrap().unwrap().1,
+            TextStreamItem::Integer(3)
+        );
+        // There are only three values in the list, so asking for the next one returns `None`
+        assert_eq!(reader.next_list_item(), Ok(None));
+
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            (
+                vec![
+                    text_token("haumea"),
+                    text_token("makemake"),
+                    text_token("eris"),
+                    text_token("ceres"),
+                ],
+                TextStreamItem::SExpressionStart
+            )
+        );
+
+        assert_eq!(
+            reader.next_s_expression_item().unwrap().unwrap().1,
+            TextStreamItem::Symbol(text_token("++"))
+        );
+        assert_eq!(
+            reader.next_s_expression_item().unwrap().unwrap().1,
+            TextStreamItem::Symbol(text_token("--"))
+        );
+        assert_eq!(
+            reader.next_s_expression_item().unwrap().unwrap().1,
+            TextStreamItem::Symbol(text_token("&&&&&"))
+        );
+        // There's only three values in the s-expression, so asking for the next one returns `None`
+        assert_eq!(reader.next_s_expression_item(), Ok(None));
+
+        // There are no more top level values.
+        assert_eq!(reader.next_top_level_item(), Ok(None));
+
+        // Asking for more still results in `None`
+        assert_eq!(reader.next_top_level_item(), Ok(None));
     }
 
     fn top_level_value_test(ion_text: &str, expected: TextStreamItem) {
         let mut reader = TextReader::new(ion_text);
-        let item = reader.next().unwrap().1;
+        let item = reader.next().unwrap().unwrap().1;
         assert_eq!(item, expected);
     }
 


### PR DESCRIPTION
* Removes non-value variants from the `TextStreamItem` enum,
  including `ListEnd`, `SExpressionEnd`, `StructEnd`, `Comment`,
  and `EndOfStream`.
* Adds container item parsing rules that return a `None` if an
  end-of-container delimiter is found instead of a value.
* Adds methods to the reader for parsing container values. These
  methods will eventually be private helper methods called by
  `next()`. For the moment, users must call them manually.
* Makes the `parse_test_ok` and `parse_test_err` unit test helper
  methods generic, allowing them to be used in more places.

Fixes #328.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
