### PR TITLE
reexport bigdecimal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,3 +35,7 @@ pub use reader::Reader;
 pub use symbol_table::SymbolTable;
 pub use system_event_handler::SystemEventHandler;
 pub use types::IonType;
+
+pub mod reexport {
+    pub use bigdecimal;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@ pub use symbol_table::SymbolTable;
 pub use system_event_handler::SystemEventHandler;
 pub use types::IonType;
 
-pub mod reexport {
+/// Re-exports of third party dependencies that are part of our public API.
+///
+/// See also: https://github.com/amzn/ion-rust/issues/302.
+pub mod external {
     pub use bigdecimal;
 }

--- a/tests/reexport.rs
+++ b/tests/reexport.rs
@@ -1,0 +1,17 @@
+use std::convert::TryInto;
+
+use ion_rs::reexport::bigdecimal::{BigDecimal, Zero};
+use ion_rs::types::decimal::Decimal;
+
+/// This test shows how the ion_rs integration with bigdecimal can be used
+/// through a reexport. This means that consumers of ion_rs can use this
+/// integration without having to specify the exact depdendency version.
+///
+/// See also: https://github.com/amzn/ion-rust/issues/302.
+#[test]
+fn bigdecimal_is_reexported() {
+    let ion_rs_type = Decimal::new(0, 0);
+    let integration_type: BigDecimal = ion_rs_type.try_into().expect("not negative zero");
+
+    assert_eq!((Zero::zero(), 0), integration_type.as_bigint_and_exponent())
+}

--- a/tests/reexport_external.rs
+++ b/tests/reexport_external.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-use ion_rs::reexport::bigdecimal::{BigDecimal, Zero};
+use ion_rs::external::bigdecimal::{BigDecimal, Zero};
 use ion_rs::types::decimal::Decimal;
 
 /// This test shows how the ion_rs integration with bigdecimal can be used


### PR DESCRIPTION
This commit pub-uses bigdecimal so that consumers can use the bigdecimal
type without have explicit exact-version dependency.

bigdecimal is a <1.0 library, and so cargo will pull in additional
copies of it by default, as semver says each release of a <1.0 crate is
backwards incompatible. So, if a consumer of ion-rust didn't have the
exact right version, then the `TryFrom<Decimal> for BigDecimal`
implementation wouldn't be accessible.

Fixes #302

-------

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.