### PR TITLE
Edition 2021 and version bumps

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2021-08-30
+          toolchain: nightly-2022-01-10
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.7.0"
-edition = "2018"
+version = "0.8.0"
+edition = "2021"
 
 [workspace]
 members = [

--- a/ion-c-sys-macros/Cargo.toml
+++ b/ion-c-sys-macros/Cargo.toml
@@ -12,8 +12,8 @@ exclude = [
   "**/.git/**",
   "**/.github/**",
 ]
-version = "0.1.0"
-edition = "2018"
+version = "0.1.1"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -16,8 +16,8 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.4.12"
-edition = "2018"
+version = "0.4.13"
+edition = "2021"
 
 [dependencies]
 ion-c-sys-macros = { version = "0.1", path = "../ion-c-sys-macros" }

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -16,11 +16,11 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.0.4"
-edition = "2018"
+version = "0.0.5"
+edition = "2021"
 
 [dependencies]
-ion-rs = { path = "../", version = "0.7" }
+ion-rs = { path = "../", version = "0.8" }
 ion-c-sys = { path = "../ion-c-sys", version = "0.4" }
 num-bigint = "0.3"
 digest = "0.9"


### PR DESCRIPTION
This PR updates the Rust edition of:

* ion-rs
* ion-hash
* ion-c-sys-macros
* ion-c-sys

from `2018` to `2021`. No code changes were required. 

The GitHub Action that generates a code coverage report uses a pinned nightly version of `rustc` from August 2021, just before edition 2021 was stabilized. I've bumped it to the latest nightly so it can build the new edition.

This patch also bumps the version of each crate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
