### PR TITLE
Adds cargo_clippy GitHub Action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,12 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amzn/ion-rust'
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # In 2022-01-11, GitHub Actions changed the `windows-latest` virtual environment alias so
+        # that it stopped pointing to `windows-2019` and began pointing to `windows-2022` instead.
+        # The pipeline needs to be updated to support the new edition of Windows Server. In the
+        # meantime, the build only tests Windows Server 2019.
+        # See https://github.com/amzn/ion-rust/issues/353
+        os: [ubuntu-latest, windows-2019, macos-latest]
 
     steps:
       - name: Remove MSys64 MingW64 Binaries
@@ -46,4 +51,22 @@ jobs:
         with:
           command: fmt
           args: --verbose -- --check
+      # `clippy-check` will run `cargo clippy` on new pull requests. Due to a limitation in GitHub
+      # permissions, the behavior of the Action is different depending on the source of the PR. If the
+      # PR comes from the ion-rust project itself, any suggestions will be added to the PR as comments.
+      # If the PR comes from a fork, any suggestions will be added to the Action's STDOUT for review.
+      # For details, see: https://github.com/actions-rs/clippy-check/issues/2
+      - name: Install Clippy
+        # The clippy check depends on setup steps defined above, but we don't want it to run
+        # for every OS because it posts its comments to the PR. These `if` checks limit clippy to
+        # only running on the Linux test. (The choice of OS was arbitrary.)
+        if: matrix.os == 'ubuntu-latest'
+        run: rustup component add clippy
+      - name: Run Clippy
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/clippy-check@v1
+        with:
+          # Adding comments to the PR requires the GITHUB_TOKEN secret.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes #348.

*Description of changes:*

Adds a GitHub Action to run `cargo clippy` and post any suggestions to the body of the PR as comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
