### PR TITLE
Experimenting with a "packed" VarUInt header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ ion-c-sys = { path = "./ion-c-sys", version = "0.4" }
 
 [dev-dependencies]
 rstest = "0.9"
+criterion = "0.3"
+
+[[bench]]
+name = "var_uint_experiment"
+harness = false
 
 # Used by ion-tests integration
 walkdir = "2.3"

--- a/benches/var_uint_experiment.rs
+++ b/benches/var_uint_experiment.rs
@@ -1,0 +1,40 @@
+use std::io;
+use std::io::Write;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ion_rs::binary::var_uint::VarUInt;
+use ion_rs::result::IonResult;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let value: u64 = 202233312022;
+    let mut buffer1 = Vec::with_capacity(64);
+    c.bench_function("Classic write VarUInt",
+                     |b| b.iter(|| {
+                         buffer1.clear();
+                         let bytes_written = VarUInt::write_u64(&mut buffer1, value).unwrap();
+                         black_box(bytes_written);
+                     }));
+    let mut var_uint = Default::default();
+    c.bench_function("Classic read VarUInt",
+                     |b| b.iter(|| {
+                         var_uint = VarUInt::read(&mut io::Cursor::new(buffer1.as_slice())).unwrap();
+                     }));
+    println!("{buffer1:x?} => {value}");
+    assert_eq!(value, var_uint.value() as u64);
+
+    let mut buffer3 = Vec::with_capacity(64);
+    c.bench_function("New write VarUInt",
+                     |b| b.iter(|| {
+                         buffer3.clear();
+                         let bytes_written = VarUInt::write_new_var_uint(&mut buffer3, value).unwrap();
+                         black_box(bytes_written);
+                     }));
+    c.bench_function("New read VarUInt",
+                     |b| b.iter(|| {
+                         var_uint= VarUInt::read_new_var_uint(&mut io::Cursor::new(buffer3.as_slice())).unwrap();
+                     }));
+    println!("{buffer3:x?} => {value}");
+    assert_eq!(value, var_uint.value() as u64);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -13,7 +13,7 @@ pub mod timestamp;
 mod type_code;
 pub mod uint;
 mod var_int;
-mod var_uint;
+pub mod var_uint;
 pub mod writer;
 
 pub use type_code::IonTypeCode;

--- a/src/binary/var_uint.rs
+++ b/src/binary/var_uint.rs
@@ -1,6 +1,6 @@
 use crate::data_source::IonDataSource;
 use crate::result::{decoding_error, IonResult};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::mem;
 
 // ion_rust does not currently support reading variable length integers of truly arbitrary size.
@@ -20,7 +20,7 @@ const HIGHEST_BIT_VALUE: u8 = 0b1000_0000;
 /// Represents a variable-length unsigned integer. See the
 /// [VarUInt and VarInt Fields](amzn.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields)
 /// section of the binary Ion spec for more details.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct VarUInt {
     value: VarUIntStorage,
     size_in_bytes: VarUIntSizeStorage,
@@ -114,10 +114,115 @@ impl VarUInt {
     pub fn size_in_bytes(&self) -> VarUIntSizeStorage {
         self.size_in_bytes
     }
+
+    pub fn write_new_var_uint<W: Write>(sink: &mut W, value: u64) -> IonResult<usize> {
+        const BITS_PER_BYTE: u32 = 8;
+        // The header byte containing 'packed' continuation bits.
+        const HEADER_MASKS: &[u64] = &[
+            // A 1-byte value; the first bit is set to 1, indicating it is the last byte.
+            0b1000_0000,
+            // A 2-byte value; the second bit is set to 1, indicating the next byte is the last.
+            0b0100_0000 << (BITS_PER_BYTE * 1),
+            // A 3-byte value; the third bit is set to 1, indicating two more bytes follow.
+            0b0010_0000 << (BITS_PER_BYTE * 2),
+            // ... and so on.
+            0b0001_0000 << (BITS_PER_BYTE * 3),
+            0b0000_1000 << (BITS_PER_BYTE * 4),
+            0b0000_0100 << (BITS_PER_BYTE * 5),
+            0b0000_0010 << (BITS_PER_BYTE * 6),
+            0b0000_0001 << (BITS_PER_BYTE * 7),
+        ];
+        const SIZE_OF_U64_IN_BYTES: u32 = 8;
+
+        let leading_zeros = value.leading_zeros();
+        let empty_bits_in_leading_byte = leading_zeros % BITS_PER_BYTE;
+        let encoded_size_in_bytes = SIZE_OF_U64_IN_BYTES - (leading_zeros / BITS_PER_BYTE);
+
+        if encoded_size_in_bytes < empty_bits_in_leading_byte {
+            // The first byte of `value` has enough empty (zero) bits at the beginning to hold the
+            // header. Do a bitwise `or` with the appropriate header from the table above.
+            let encoded_value = value | HEADER_MASKS[encoded_size_in_bytes as usize - 1];
+            // Turn the value into a &[u8] containing big endian bytes.
+            let all_bytes = &encoded_value.to_be_bytes();
+            // Take a subslice of the array to ignore any leading zero bytes.
+            let occupied_bytes = &all_bytes[all_bytes.len() - (encoded_size_in_bytes as usize)..];
+            sink.write_all(occupied_bytes)?;
+            Ok(occupied_bytes.len())
+        } else if encoded_size_in_bytes == SIZE_OF_U64_IN_BYTES {
+            // The value is large enough that none of its leading bytes are zero.
+            if empty_bits_in_leading_byte >= 1 {
+                // The first bit is empty; write a 0-byte indicating 8 non-terminal bytes...
+                sink.write_all(&[0])?;
+                // ... then set the first bit of `value` to 1 to complete the header.
+                sink.write_all(&((1 << 63) | value).to_be_bytes())?;
+                Ok(9)
+            } else {
+                // The value is 8 bytes long AND the first bit is a 1. We can't squeeze any part of
+                // the header into the value's in-memory representation. Write the header...
+                sink.write_all(&[0, 0b1000_0000])?;
+                // ... and then write the value itself as big endian bytes.
+                sink.write_all(&value.to_be_bytes())?;
+                Ok(10)
+            }
+        } else {
+            // The value is shorter than 8 bytes, but there's no room for the header in the first
+            // encoded byte. We need to write a header byte and then the body.
+            let header_mask = HEADER_MASKS[encoded_size_in_bytes as usize];
+            let encoded_value = value | header_mask;
+            let all_bytes = &encoded_value.to_be_bytes();
+            let occupied_bytes = &all_bytes[all_bytes.len() - (encoded_size_in_bytes as usize + 1)..];
+            sink.write_all(occupied_bytes)?;
+            Ok(occupied_bytes.len())
+        }
+    }
+    pub fn read_new_var_uint<R: IonDataSource>(data_source: &mut R) -> IonResult<VarUInt> {
+        const BITS_PER_BYTE: u32 = 8;
+        const HEADER_MASKS: &[u8] = &[
+            0b0111_1111,
+            0b0011_1111,
+            0b0001_1111,
+            0b0000_1111,
+            0b0000_0111,
+            0b0000_0011,
+            0b0000_0001,
+        ];
+        const SIZE_OF_U64_IN_BYTES: u32 = 8;
+
+        // Read the first byte. (Technically the header could be multiple bytes, but not in this
+        // implementation.)
+        let header = data_source.next_byte()?.unwrap();
+        // The number of leading zeros in the header byte is the number of bytes that follow it in
+        // the input stream.
+        let leading_zeros = header.leading_zeros();
+
+        // This will hold our decoded value.
+        let mut buffer = [0u8; 8];
+
+        if leading_zeros >= 8 {
+            // This is important for correctness but not for this performance test.
+            todo!("Handle VarUInts with 8 or 9 bytes.");
+        }
+
+        // Place the header byte in the buffer using the number leading zeros we read to determine
+        // how large the decoded u64 will be.
+        let header_position = 8 - leading_zeros - 1;
+        buffer[header_position as usize] = header & HEADER_MASKS[leading_zeros as usize];
+
+        // Populate the rest of the buffer from the input stream.
+        let mut read_buffer = &mut buffer[(header_position+1) as usize..];
+        data_source.read_exact(read_buffer)?;
+        let bytes_read = 1 + read_buffer.len();
+
+        // Convert the buffer's contents into a u64
+        let magnitude: u64 = u64::from_be_bytes(buffer);
+
+        Ok(VarUInt { value: magnitude as usize, size_in_bytes: bytes_read})
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::io;
     use super::VarUInt;
     use crate::result::IonResult;
     use std::io::{BufReader, Cursor};
@@ -209,6 +314,21 @@ mod tests {
     fn test_write_var_uint_three_byte_values() -> IonResult<()> {
         var_uint_encoding_test(81_991, &[0b0000_0101, 0b0000_0000, 0b1100_0111])?;
         var_uint_encoding_test(400_600, &[0b0001_1000, 0b0011_1001, 0b1101_1000])?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_new_var_uint() -> IonResult<()> {
+        let value: u64 = 202233312022;
+
+        let mut buffer = Vec::with_capacity(64);
+        let bytes_written = VarUInt::write_new_var_uint(&mut buffer, 202233312022).unwrap();
+        println!("{buffer:x?}");
+        assert_eq!(6, bytes_written);
+
+        let read_buffer = &buffer[0..bytes_written];
+        let var_uint = VarUInt::read_new_var_uint(&mut io::Cursor::new(read_buffer)).unwrap();
+        assert_eq!(value, var_uint.value as u64);
         Ok(())
     }
 }


### PR DESCRIPTION
This is an encoding/performance experiment and should NOT be merged.

The `VarUInt` encoding primitive requires applications to perform bitwise operations on each byte of the value being read/written; it is inherently handled byte-at-a-time. @jobarr-amzn observed that they might be faster/easier to work with if all of the continuation bits were at the beginning of the value. This branch contains an implementation of that idea. 

The resulting data size is identical. However, read and write speeds were only modestly better than the original format.

![image](https://user-images.githubusercontent.com/611616/153489518-021de8e1-fab3-4bbf-89df-54ebc90634f4.png)

(Ignore the notes about 'regression' or 'no change'; what matters is the comparison between `Classic write VarUInt`/`New write VarUInt` and `Classic read VarUInt`/`New read VarUInt`.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
