### PR TITLE
Introduces the `RawWriter` trait

### DIFF
--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -779,7 +779,6 @@ impl<R: IonDataSource> RawReader for RawBinaryReader<R> {
     #[inline]
     fn step_out(&mut self) -> IonResult<()> {
         use std::mem;
-        let bytes_to_skip;
 
         // Clear annotations belonging to the current value before we step out.
         self.clear_annotations();
@@ -801,7 +800,7 @@ impl<R: IonDataSource> RawReader for RawBinaryReader<R> {
         // We're stepping out of the container, so we need to skip to the end of it.
         let value_end_excl = parent.value_end_exclusive();
         let bytes_read = self.cursor.bytes_read;
-        bytes_to_skip = value_end_excl - bytes_read;
+        let bytes_to_skip = value_end_excl - bytes_read;
 
         // Set the parent as the current value
         mem::swap(&mut self.cursor.value, parent);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod value;
 
 pub mod constants;
 mod raw_symbol_token;
+mod raw_symbol_token_ref;
+mod raw_writer;
 mod reader;
 mod symbol_table;
 mod system_reader;

--- a/src/raw_symbol_token.rs
+++ b/src/raw_symbol_token.rs
@@ -49,19 +49,28 @@ pub fn text_token<T: Into<String>>(text: T) -> RawSymbolToken {
 }
 
 impl From<SymbolId> for RawSymbolToken {
-    fn from(value: SymbolId) -> Self {
-        local_sid_token(value)
+    fn from(symbol_id: SymbolId) -> Self {
+        RawSymbolToken::SymbolId(symbol_id)
     }
 }
 
 impl From<String> for RawSymbolToken {
-    fn from(value: String) -> Self {
-        text_token(value)
+    fn from(text: String) -> Self {
+        RawSymbolToken::Text(text)
     }
 }
 
 impl From<&str> for RawSymbolToken {
-    fn from(value: &str) -> Self {
-        text_token(value.to_string())
+    fn from(text: &str) -> Self {
+        RawSymbolToken::Text(text.to_string())
+    }
+}
+
+impl<T> From<&T> for RawSymbolToken
+where
+    T: Clone + Into<RawSymbolToken>,
+{
+    fn from(value: &T) -> Self {
+        value.clone().into()
     }
 }

--- a/src/raw_symbol_token_ref.rs
+++ b/src/raw_symbol_token_ref.rs
@@ -1,0 +1,59 @@
+use crate::raw_symbol_token::RawSymbolToken;
+use crate::types::SymbolId;
+
+/// Like RawSymbolToken, but the Text variant holds a borrowed reference instead of a String.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RawSymbolTokenRef<'a> {
+    SymbolId(SymbolId),
+    Text(&'a str),
+}
+
+/// Implemented by types that can be viewed as a [RawSymbolTokenRef] without allocations.
+pub trait AsRawSymbolTokenRef {
+    fn as_raw_symbol_token_ref(&self) -> RawSymbolTokenRef;
+}
+
+impl<'a> AsRawSymbolTokenRef for RawSymbolTokenRef<'a> {
+    fn as_raw_symbol_token_ref(&self) -> RawSymbolTokenRef {
+        match self {
+            RawSymbolTokenRef::SymbolId(sid) => RawSymbolTokenRef::SymbolId(*sid),
+            RawSymbolTokenRef::Text(text) => RawSymbolTokenRef::Text(*text),
+        }
+    }
+}
+
+impl AsRawSymbolTokenRef for SymbolId {
+    fn as_raw_symbol_token_ref(&self) -> RawSymbolTokenRef {
+        RawSymbolTokenRef::SymbolId(*self)
+    }
+}
+
+impl AsRawSymbolTokenRef for String {
+    fn as_raw_symbol_token_ref(&self) -> RawSymbolTokenRef {
+        RawSymbolTokenRef::Text(self.as_str())
+    }
+}
+
+impl AsRawSymbolTokenRef for &str {
+    fn as_raw_symbol_token_ref(&self) -> RawSymbolTokenRef {
+        RawSymbolTokenRef::Text(self)
+    }
+}
+
+impl<T> AsRawSymbolTokenRef for &T
+where
+    T: AsRawSymbolTokenRef,
+{
+    fn as_raw_symbol_token_ref(&self) -> RawSymbolTokenRef {
+        (*self).as_raw_symbol_token_ref()
+    }
+}
+
+impl AsRawSymbolTokenRef for RawSymbolToken {
+    fn as_raw_symbol_token_ref(&self) -> RawSymbolTokenRef {
+        match self {
+            RawSymbolToken::SymbolId(sid) => RawSymbolTokenRef::SymbolId(*sid),
+            RawSymbolToken::Text(text) => RawSymbolTokenRef::Text(text.as_str()),
+        }
+    }
+}

--- a/src/raw_writer.rs
+++ b/src/raw_writer.rs
@@ -1,0 +1,89 @@
+use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+use crate::result::IonResult;
+use crate::types::decimal::Decimal;
+use crate::types::timestamp::Timestamp;
+use crate::types::IonType;
+
+/**
+ * This trait captures the format-agnostic encoding functionality needed to write native Rust types
+ * to a stream as Ion values.
+ *
+ * RawWriter implementations are not expected convert symbol text to symbol IDs or vice versa.
+ */
+pub trait RawWriter {
+    /// Returns the (major, minor) version of the Ion stream being written. If ion_version is called
+    /// before an Ion Version Marker has been emitted, the version (1, 0) will be returned.
+    fn ion_version(&self) -> (u8, u8);
+
+    /// Writes an Ion version marker to the output stream.
+    fn write_ion_version_marker(&mut self, major: u8, minor: u8) -> IonResult<()>;
+
+    /// Sets a list of annotations that will be applied to the next value that is written.
+    fn set_annotations<I, A>(&mut self, annotations: I)
+    where
+        A: AsRawSymbolTokenRef,
+        I: IntoIterator<Item = A>;
+
+    /// Writes an Ion `null` with the specified type to the output stream.
+    /// To write an untyped `null` (which is equivalent to `null.null`), pass [IonType::Null].
+    fn write_null(&mut self, ion_type: IonType) -> IonResult<()>;
+
+    /// Writes an Ion `boolean` with the specified value to the output stream.
+    fn write_bool(&mut self, value: bool) -> IonResult<()>;
+
+    /// Writes an Ion `integer` with the specified value to the output stream.
+    fn write_i64(&mut self, value: i64) -> IonResult<()>;
+
+    /// Writes an Ion `float` with the specified value to the output stream.
+    fn write_f32(&mut self, value: f32) -> IonResult<()>;
+
+    /// Writes an Ion `float` with the specified value to the output stream.
+    fn write_f64(&mut self, value: f64) -> IonResult<()>;
+
+    /// Writes an Ion `decimal` with the specified value to the output stream.
+    fn write_decimal(&mut self, value: &Decimal) -> IonResult<()>;
+
+    /// Writes an Ion `timestamp` with the specified value to the output stream.
+    fn write_timestamp(&mut self, value: &Timestamp) -> IonResult<()>;
+
+    /// Writes an Ion `symbol` with the specified value to the output stream.
+    fn write_symbol<A: AsRawSymbolTokenRef>(&mut self, value: A) -> IonResult<()>;
+
+    /// Writes an Ion `string` with the specified value to the output stream.
+    fn write_string<A: AsRef<str>>(&mut self, value: A) -> IonResult<()>;
+
+    /// Writes an Ion `clob` with the specified value to the output stream.
+    fn write_clob<A: AsRef<[u8]>>(&mut self, value: A) -> IonResult<()>;
+
+    /// Writes an Ion `blob` with the specified value to the output stream.
+    fn write_blob<A: AsRef<[u8]>>(&mut self, value: A) -> IonResult<()>;
+
+    /// Starts a new Ion container with the specified type.
+    /// The only valid IonType values are:
+    /// * [IonType::List]
+    /// * [IonType::SExpression]
+    /// * [IonType::Struct]
+    /// Passing any other IonType will result in an `Err`.
+    fn step_in(&mut self, container_type: IonType) -> IonResult<()>;
+
+    /// Sets the current field name to `name`. If the TextWriter is currently positioned inside
+    /// of a struct, the field name will be written before the next value. Otherwise, it will be
+    /// ignored.
+    fn set_field_name<A: AsRawSymbolTokenRef>(&mut self, name: A);
+
+    /// If the writer is positioned at the top level, returns `None`. Otherwise, returns
+    /// `Some(_)` with the parent container's [IonType].
+    fn parent_type(&self) -> Option<IonType>;
+
+    /// Returns the number of containers that the writer has stepped into without subsequently
+    /// stepping out.
+    fn depth(&self) -> usize;
+
+    /// Ends the current container. If the writer is not currently positioned within a container,
+    /// calling this method will result in an `Err`.
+    fn step_out(&mut self) -> IonResult<()>;
+
+    /// Causes any buffered data to be written to the underlying io::Write implementation.
+    /// This method can only be called when the writer is at the top level.
+    fn flush(&mut self) -> IonResult<()>;
+}

--- a/src/text/parsers/float.rs
+++ b/src/text/parsers/float.rs
@@ -39,7 +39,7 @@ fn float_numeric_value(input: &str) -> IResult<&str, TextValue> {
         ))),
         |text| {
             // TODO: Reusable buffer for sanitization
-            let mut sanitized = text.replace("_", "");
+            let mut sanitized = text.replace('_', "");
             if sanitized.ends_with('e') || sanitized.ends_with('E') {
                 sanitized.push('0');
             }

--- a/src/text/parsers/integer.rs
+++ b/src/text/parsers/integer.rs
@@ -96,7 +96,7 @@ fn base_10_integer(input: &str) -> IResult<&str, TextValue> {
 /// radix.
 fn parse_i64_with_radix(text: &str, radix: u32) -> Result<i64, ParseIntError> {
     if text.contains('_') {
-        let sanitized = text.replace("_", "");
+        let sanitized = text.replace('_', "");
         return i64::from_str_radix(&sanitized, radix);
     }
     i64::from_str_radix(text, radix)

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -588,7 +588,7 @@ impl<T: TextIonDataSource> RawReader for RawTextReader<T> {
     fn step_out(&mut self) -> IonResult<()> {
         if self.parents.is_empty() {
             return illegal_operation(
-                "Cannot call `step_out()` when the reader is at the top level.".to_string(),
+                "Cannot call `step_out()` when the reader is at the top level.",
             );
         }
 

--- a/src/types/coefficient.rs
+++ b/src/types/coefficient.rs
@@ -4,6 +4,7 @@ use num_traits::Zero;
 use crate::result::{illegal_operation, IonError};
 use crate::types::magnitude::Magnitude;
 use std::convert::TryFrom;
+use std::fmt::{Display, Formatter};
 use std::ops::{MulAssign, Neg};
 
 /// Indicates whether the Coefficient's magnitude is less than 0 (negative) or not (positive).
@@ -112,6 +113,19 @@ impl TryFrom<Coefficient> for BigInt {
             big_int.mul_assign(-1);
         }
         Ok(big_int)
+    }
+}
+
+impl Display for Coefficient {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.sign {
+            Sign::Positive => {}
+            Sign::Negative => write!(f, "-")?,
+        };
+        match &self.magnitude {
+            Magnitude::U64(m) => write!(f, "{}", *m),
+            Magnitude::BigUInt(m) => write!(f, "{}", m),
+        }
     }
 }
 

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -825,8 +825,7 @@ impl TryInto<ion_c_sys::timestamp::IonDateTime> for Timestamp {
             _ => {
                 // invariant violation
                 return illegal_operation(
-                    "Could not convert timestamp with fractional seconds and no mantissa"
-                        .to_string(),
+                    "Could not convert timestamp with fractional seconds and no mantissa",
                 );
             }
         };


### PR DESCRIPTION
This is a large diff, but is largely a reorganization of existing code. I've added my own review comments to highlight places where logic changes have been introduced.

A subsequent PR will create a user-level `Writer` that can wrap any implementation of `RawWriter`, abstracting over text and binary.

-----

This patch introduces a `RawWriter` trait that captures the
format-agnostic encoding functionality needed to write native Rust types
to a stream as Ion values. Unlike the higher-level `Writer` type,
`RawWriter` implementations are not required to manage a symbol table.

Summary of changes:
* Adds the `RawWriter` trait.
* Renames `BinarySystemWriter` to `RawBinaryWriter`.
* Renames `TextWriter` to `RawTextWriter`.
* Provides an impl of `RawWriter` for `RawBinaryWriter` and
  `RawTextWriter`.
* Adds the `RawSymbolToken` type, which represent a either symbol ID or
  text literal (e.g. $12 or 'foo') found in an Ion stream.
* Adds the `RawSymbolTokenRef` type, which is a borrowed version of
  `RawSymbolToken`.
* Modifies the `RawTextWriter` to be able to write symbol IDs ($12) and
  unquoted identifiers (foo) for symbol values, field names, and
  annotations.
* Incorporates several clippy suggestions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
