### PR TITLE
Adds user-level `TextWriter` and `BinaryWriter`

### DIFF
--- a/ion-c-sys/src/writer.rs
+++ b/ion-c-sys/src/writer.rs
@@ -476,6 +476,7 @@ impl<'a> IonCWriter<'a> for IonCWriterHandle<'a> {
 }
 
 impl IonCValueWriter for IonCWriterHandle<'_> {
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[inline]
     fn write_null(&mut self, tid: ION_TYPE) -> IonCResult<()> {
         ionc!(ion_writer_write_typed_null(self.writer, tid))
@@ -549,6 +550,7 @@ impl IonCValueWriter for IonCWriterHandle<'_> {
         ))
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[inline]
     fn start_container(&mut self, tid: ION_TYPE) -> IonCResult<()> {
         ionc!(ion_writer_start_container(self.writer, tid))

--- a/src/binary/binary_writer.rs
+++ b/src/binary/binary_writer.rs
@@ -94,6 +94,8 @@ impl<W: Write> BinaryWriter<W> {
 
 impl<W: Write> Writer for BinaryWriter<W> {
     fn supports_text_symbol_tokens(&self) -> bool {
+        // The BinaryWriter can always write text field names, annotations, and symbols
+        // after first adding the provided text to the symbol table.
         true
     }
 

--- a/src/binary/binary_writer.rs
+++ b/src/binary/binary_writer.rs
@@ -1,0 +1,253 @@
+use crate::binary::raw_binary_writer::RawBinaryWriter;
+use crate::constants::v1_0::system_symbol_ids;
+use crate::raw_symbol_token_ref::{AsRawSymbolTokenRef, RawSymbolTokenRef};
+use crate::result::{illegal_operation, IonResult};
+use crate::types::decimal::Decimal;
+use crate::types::timestamp::Timestamp;
+use crate::types::SymbolId;
+use crate::writer::Writer;
+use crate::IonType;
+use crate::SymbolTable;
+use delegate::delegate;
+use std::io::Write;
+
+/**
+ * An application-level binary Ion writer. This writer manages a symbol table and so can convert
+ * symbol IDs to their corresponding text.
+ */
+pub struct BinaryWriter<W: Write> {
+    raw_writer: RawBinaryWriter<W>,
+    symbol_table: SymbolTable,
+    // The number of symbols that have been added to the in-memory symbol table but
+    // whose definitions have not yet been written to the output stream.
+    num_pending_symbols: usize,
+    // The BinaryWriter uses the `symbol_table_writer` to encode local symbol tables to a buffer
+    // and then flush them to output before flushing the contents of the `raw_writer`. This guarantees
+    // that any symbols referenced in the `raw_writer`'s contents will be defined in the Ion stream
+    // before the reference appears.
+    symbol_table_writer: RawBinaryWriter<Vec<u8>>,
+}
+
+impl<W: Write> BinaryWriter<W> {
+    pub fn new(mut raw_writer: RawBinaryWriter<W>) -> Self {
+        // TODO: Track whether we've written an IVM and emit it at flush time instead
+        raw_writer
+            .write_ion_version_marker(1, 0)
+            .expect("Couldn't write IVM.");
+        BinaryWriter {
+            raw_writer,
+            symbol_table: SymbolTable::new(),
+            num_pending_symbols: 0,
+            symbol_table_writer: RawBinaryWriter::new(Vec::new()),
+        }
+    }
+
+    fn get_or_create_symbol_id(&mut self, text: &str) -> SymbolId {
+        if let Some(symbol_id) = self.symbol_table.sid_for(&text) {
+            // If the provided text is in the symbol table, use the associated symbol ID...
+            symbol_id
+        } else {
+            // ...otherwise, add it to the symbol table and return the new symbol ID.
+            self.num_pending_symbols += 1;
+            self.symbol_table.intern(text.to_owned())
+        }
+    }
+
+    fn write_symbol_table_for_pending_symbols(&mut self) -> IonResult<()> {
+        let pending_symbols_starting_index = self.symbol_table.len() - self.num_pending_symbols;
+        let pending_symbols = self
+            .symbol_table
+            .symbols_tail(pending_symbols_starting_index);
+
+        self.symbol_table_writer
+            .add_annotation(system_symbol_ids::ION_SYMBOL_TABLE);
+        self.symbol_table_writer.step_in(IonType::Struct)?;
+
+        self.symbol_table_writer
+            .set_field_name(system_symbol_ids::IMPORTS);
+        self.symbol_table_writer
+            .write_symbol(system_symbol_ids::ION_SYMBOL_TABLE)?;
+
+        self.symbol_table_writer
+            .set_field_name(system_symbol_ids::SYMBOLS);
+        self.symbol_table_writer.step_in(IonType::List)?;
+        for symbol in pending_symbols {
+            if let Some(text) = symbol {
+                self.symbol_table_writer.write_string(text)?;
+            } else {
+                self.symbol_table_writer.write_null(IonType::Null)?;
+            }
+        }
+        self.symbol_table_writer.step_out()?; // End symbols list
+
+        self.symbol_table_writer.step_out()?; // End $ion_symbol_table::{...}
+        self.symbol_table_writer.flush()?;
+
+        // Write the symbol_table_writer's encoded bytes to the raw_writer's output
+        let bytes = &self.symbol_table_writer.output()[..];
+        self.raw_writer.output_mut().write_all(bytes)?;
+        self.symbol_table_writer.output_mut().clear();
+
+        Ok(())
+    }
+}
+
+impl<W: Write> Writer for BinaryWriter<W> {
+    fn supports_text_symbol_tokens(&self) -> bool {
+        true
+    }
+
+    fn set_annotations<I, A>(&mut self, annotations: I)
+    where
+        A: AsRawSymbolTokenRef,
+        I: IntoIterator<Item = A>,
+    {
+        for annotation in annotations {
+            let symbol_id = match annotation.as_raw_symbol_token_ref() {
+                RawSymbolTokenRef::SymbolId(symbol_id) => {
+                    if self.symbol_table.sid_is_valid(symbol_id) {
+                        symbol_id
+                    } else {
+                        panic!(
+                            "Cannot set symbol ID ${} as annotation. It is undefined.",
+                            symbol_id
+                        );
+                    }
+                }
+                RawSymbolTokenRef::Text(text) => self.get_or_create_symbol_id(text),
+            };
+            self.raw_writer.add_annotation(symbol_id);
+        }
+    }
+
+    fn write_symbol<A: AsRawSymbolTokenRef>(&mut self, value: A) -> IonResult<()> {
+        let symbol_id = match value.as_raw_symbol_token_ref() {
+            RawSymbolTokenRef::SymbolId(symbol_id) => {
+                if self.symbol_table.sid_is_valid(symbol_id) {
+                    symbol_id
+                } else {
+                    return illegal_operation(format!(
+                        "Cannot set symbol ID ${} as annotation. It is undefined.",
+                        symbol_id
+                    ));
+                }
+            }
+            RawSymbolTokenRef::Text(text) => self.get_or_create_symbol_id(text),
+        };
+        self.raw_writer.write_symbol(symbol_id)
+    }
+
+    fn set_field_name<A: AsRawSymbolTokenRef>(&mut self, name: A) {
+        let text = match name.as_raw_symbol_token_ref() {
+            RawSymbolTokenRef::SymbolId(symbol_id) => {
+                if self.symbol_table.sid_is_valid(symbol_id) {
+                    symbol_id
+                } else {
+                    panic!(
+                        "Cannot set symbol ID ${} as field name. It is undefined.",
+                        symbol_id
+                    );
+                }
+            }
+            RawSymbolTokenRef::Text(text) => self.get_or_create_symbol_id(text),
+        };
+        self.raw_writer.set_field_name(text);
+    }
+
+    fn flush(&mut self) -> IonResult<()> {
+        // Check to see if there are any pending symbols.
+        if self.num_pending_symbols > 0 {
+            self.write_symbol_table_for_pending_symbols()?;
+            self.num_pending_symbols = 0;
+        }
+        self.raw_writer.flush()
+    }
+
+    delegate! {
+        to self.raw_writer {
+            fn ion_version(&self) -> (u8, u8);
+            fn write_ion_version_marker(&mut self, major: u8, minor: u8) -> IonResult<()>;
+            fn write_null(&mut self, ion_type: IonType) -> IonResult<()>;
+            fn write_bool(&mut self, value: bool) -> IonResult<()>;
+            fn write_i64(&mut self, value: i64) -> IonResult<()>;
+            fn write_f32(&mut self, value: f32) -> IonResult<()>;
+            fn write_f64(&mut self, value: f64) -> IonResult<()>;
+            fn write_decimal(&mut self, value: &Decimal) -> IonResult<()>;
+            fn write_timestamp(&mut self, value: &Timestamp) -> IonResult<()>;
+            fn write_string<A: AsRef<str>>(&mut self, value: A) -> IonResult<()>;
+            fn write_clob<A: AsRef<[u8]>>(&mut self, value: A) -> IonResult<()>;
+            fn write_blob<A: AsRef<[u8]>>(&mut self, value: A) -> IonResult<()>;
+            fn step_in(&mut self, container_type: IonType) -> IonResult<()>;
+            fn parent_type(&self) -> Option<IonType>;
+            fn depth(&self) -> usize;
+            fn step_out(&mut self) -> IonResult<()>;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RawBinaryReader, Reader};
+    use std::io;
+
+    #[test]
+    fn intern_field_names() -> IonResult<()> {
+        let mut buffer = Vec::new();
+        let raw_writer = RawBinaryWriter::new(&mut buffer);
+        let mut binary_writer = BinaryWriter::new(raw_writer);
+        binary_writer.step_in(IonType::Struct)?;
+        binary_writer.set_field_name("foo");
+        binary_writer.write_symbol("bar")?;
+        binary_writer.step_out()?;
+        binary_writer.flush()?;
+
+        let mut reader = Reader::new(RawBinaryReader::new(io::Cursor::new(buffer)));
+        assert_eq!(Some((IonType::Struct, false)), reader.next()?);
+        reader.step_in()?;
+        assert_eq!(Some((IonType::Symbol, false)), reader.next()?);
+        assert_eq!(Some("foo"), reader.field_name());
+        assert_eq!(Some("bar".to_owned()), reader.read_symbol()?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn intern_annotations() -> IonResult<()> {
+        let mut buffer = Vec::new();
+        let raw_writer = RawBinaryWriter::new(&mut buffer);
+        let mut binary_writer = BinaryWriter::new(raw_writer);
+        binary_writer.set_annotations(&["foo", "bar"]);
+        binary_writer.write_i64(5)?;
+        binary_writer.flush()?;
+
+        let mut reader = Reader::new(RawBinaryReader::new(io::Cursor::new(buffer)));
+        assert_eq!(Some((IonType::Integer, false)), reader.next()?);
+        let annotations: Vec<Option<&str>> = reader.annotations().collect();
+        assert_eq!(Some("foo"), annotations[0]);
+        assert_eq!(Some("bar"), annotations[1]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn intern_symbols() -> IonResult<()> {
+        let mut buffer = Vec::new();
+        let raw_writer = RawBinaryWriter::new(&mut buffer);
+        let mut binary_writer = BinaryWriter::new(raw_writer);
+        binary_writer.write_symbol("foo")?;
+        binary_writer.write_symbol("bar")?;
+        binary_writer.write_symbol("baz")?;
+        binary_writer.flush()?;
+
+        let mut reader = Reader::new(RawBinaryReader::new(io::Cursor::new(buffer)));
+        assert_eq!(Some((IonType::Symbol, false)), reader.next()?);
+        assert_eq!(Some("foo".to_owned()), reader.read_symbol()?);
+        assert_eq!(Some((IonType::Symbol, false)), reader.next()?);
+        assert_eq!(Some("bar".to_owned()), reader.read_symbol()?);
+        assert_eq!(Some((IonType::Symbol, false)), reader.next()?);
+        assert_eq!(Some("baz".to_owned()), reader.read_symbol()?);
+
+        Ok(())
+    }
+}

--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -6,7 +6,7 @@ use arrayvec::ArrayVec;
 use bigdecimal::Zero;
 
 use crate::{
-    binary::{int::Int, var_int::VarInt, var_uint::VarUInt, writer::MAX_INLINE_LENGTH},
+    binary::{int::Int, raw_binary_writer::MAX_INLINE_LENGTH, var_int::VarInt, var_uint::VarUInt},
     result::IonResult,
     types::{
         coefficient::{Coefficient, Sign},

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -3,17 +3,18 @@
 //! This module provides the necessary structures and logic to read values from a binary Ion
 //! data stream.
 
+pub mod binary_writer;
 pub(crate) mod constants;
 pub mod decimal;
 mod header;
 mod int;
 mod nibbles;
 pub(crate) mod raw_binary_reader;
+pub mod raw_binary_writer;
 pub mod timestamp;
 mod type_code;
 pub mod uint;
 mod var_int;
 mod var_uint;
-pub mod writer;
 
 pub use type_code::IonTypeCode;

--- a/src/binary/timestamp.rs
+++ b/src/binary/timestamp.rs
@@ -7,8 +7,8 @@ use chrono::{Datelike, Timelike};
 
 use crate::{
     binary::{
-        decimal::DecimalBinaryEncoder, var_int::VarInt, var_uint::VarUInt,
-        writer::MAX_INLINE_LENGTH,
+        decimal::DecimalBinaryEncoder, raw_binary_writer::MAX_INLINE_LENGTH, var_int::VarInt,
+        var_uint::VarUInt,
     },
     result::IonResult,
     types::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,10 @@ pub mod value;
 pub mod constants;
 mod raw_symbol_token;
 mod raw_symbol_token_ref;
-mod raw_writer;
 mod reader;
 mod symbol_table;
 mod system_reader;
+mod writer;
 
 pub use binary::raw_binary_reader::RawBinaryReader;
 pub use data_source::IonDataSource;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -168,7 +168,7 @@ impl<C: RawReader> Reader<C> {
     pub fn read_symbol(&mut self) -> IonResult<Option<String>> {
         // TODO: This currently allocates, which shouldn't be required.
         match self.raw_reader.read_symbol()? {
-            None => return Ok(None),
+            None => Ok(None),
             Some(RawSymbolToken::SymbolId(symbol_id)) => {
                 if let Some(text) = self.symbol_table.text_for(symbol_id) {
                     Ok(Some(text.to_owned()))

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -165,6 +165,24 @@ impl<C: RawReader> Reader<C> {
         &self.symbol_table
     }
 
+    pub fn read_symbol(&mut self) -> IonResult<Option<String>> {
+        // TODO: This currently allocates, which shouldn't be required.
+        match self.raw_reader.read_symbol()? {
+            None => return Ok(None),
+            Some(RawSymbolToken::SymbolId(symbol_id)) => {
+                if let Some(text) = self.symbol_table.text_for(symbol_id) {
+                    Ok(Some(text.to_owned()))
+                } else {
+                    return decoding_error(format!(
+                        "Found symbol ID ${}, which is not defined.",
+                        symbol_id
+                    ));
+                }
+            }
+            Some(RawSymbolToken::Text(text)) => Ok(Some(text)),
+        }
+    }
+
     // TODO: Offer other flavors of this method, including:
     //       * a version that returns a resolved token (OwnedSymbolToken?) that can provide both
     //         text and a SID if available

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,7 +1,8 @@
 mod parent_container;
 pub(in crate::text) mod parsers;
 pub mod raw_text_reader;
+pub mod raw_text_writer;
 mod text_buffer;
 mod text_data_source;
 mod text_value;
-pub mod writer;
+mod text_writer;

--- a/src/text/text_writer.rs
+++ b/src/text/text_writer.rs
@@ -1,0 +1,161 @@
+use crate::raw_symbol_token_ref::{AsRawSymbolTokenRef, RawSymbolTokenRef};
+use crate::result::{illegal_operation, IonResult};
+use crate::text::raw_text_writer::RawTextWriter;
+use crate::types::decimal::Decimal;
+use crate::types::timestamp::Timestamp;
+use crate::writer::Writer;
+use crate::IonType;
+use crate::SymbolTable;
+use delegate::delegate;
+use std::io::Write;
+
+/**
+ * An application-level text Ion writer. This writer manages a symbol table and so can convert
+ * symbol IDs to their corresponding text. However, unlike the BinaryWriter, it is capable of writing
+ * text to the output stream without first adding it to the symbol table.
+ */
+pub struct TextWriter<W: Write> {
+    raw_writer: RawTextWriter<W>,
+    symbol_table: SymbolTable,
+}
+
+impl<W: Write> TextWriter<W> {
+    pub fn new(raw_writer: RawTextWriter<W>) -> Self {
+        TextWriter {
+            raw_writer,
+            symbol_table: SymbolTable::new(),
+        }
+    }
+}
+
+impl<W: Write> Writer for TextWriter<W> {
+    fn supports_text_symbol_tokens(&self) -> bool {
+        true
+    }
+
+    fn set_annotations<I, A>(&mut self, annotations: I)
+    where
+        A: AsRawSymbolTokenRef,
+        I: IntoIterator<Item = A>,
+    {
+        for annotation in annotations {
+            let text = match annotation.as_raw_symbol_token_ref() {
+                RawSymbolTokenRef::SymbolId(symbol_id) => {
+                    // Get the text associated with this symbol ID
+                    if let Some(text) = self.symbol_table.text_for(symbol_id) {
+                        text
+                    } else {
+                        // TODO: TextWriter is intended to be an application-level interface, so
+                        //       dealing with undefined symbols is out of scope for it. Users
+                        //       wishing to write a symbol ID literal could use a RawTextWriter
+                        //       instead. However, we could consider allowing this via a config
+                        //       option.
+                        panic!(
+                            "Cannot use symbol ID ${} as an annotation; it is undefined.",
+                            symbol_id
+                        );
+                    }
+                }
+                RawSymbolTokenRef::Text(text) => text,
+            };
+            self.raw_writer.add_annotation(text);
+        }
+    }
+
+    fn write_symbol<A: AsRawSymbolTokenRef>(&mut self, value: A) -> IonResult<()> {
+        let text = match value.as_raw_symbol_token_ref() {
+            RawSymbolTokenRef::SymbolId(symbol_id) => {
+                // Get the text associated with this symbol ID
+                if let Some(text) = self.symbol_table.text_for(symbol_id) {
+                    text
+                } else {
+                    return illegal_operation(format!(
+                        "Cannot write symbol ID ${} as a symbol value; it is undefined.",
+                        symbol_id
+                    ));
+                }
+            }
+            RawSymbolTokenRef::Text(text) => text,
+        };
+        self.raw_writer.write_symbol(text)
+    }
+
+    fn set_field_name<A: AsRawSymbolTokenRef>(&mut self, name: A) {
+        let text = match name.as_raw_symbol_token_ref() {
+            RawSymbolTokenRef::SymbolId(symbol_id) => {
+                // Get the text associated with this symbol ID
+                if let Some(text) = self.symbol_table.text_for(symbol_id) {
+                    text
+                } else {
+                    panic!(
+                        "Cannot use symbol ID ${} as a field name; it is undefined.",
+                        symbol_id
+                    );
+                }
+            }
+            RawSymbolTokenRef::Text(text) => text,
+        };
+        self.raw_writer.set_field_name(text);
+    }
+
+    delegate! {
+        to self.raw_writer {
+            fn ion_version(&self) -> (u8, u8);
+            fn write_ion_version_marker(&mut self, major: u8, minor: u8) -> IonResult<()>;
+            fn write_null(&mut self, ion_type: IonType) -> IonResult<()>;
+            fn write_bool(&mut self, value: bool) -> IonResult<()>;
+            fn write_i64(&mut self, value: i64) -> IonResult<()>;
+            fn write_f32(&mut self, value: f32) -> IonResult<()>;
+            fn write_f64(&mut self, value: f64) -> IonResult<()>;
+            fn write_decimal(&mut self, value: &Decimal) -> IonResult<()>;
+            fn write_timestamp(&mut self, value: &Timestamp) -> IonResult<()>;
+            fn write_string<A: AsRef<str>>(&mut self, value: A) -> IonResult<()>;
+            fn write_clob<A: AsRef<[u8]>>(&mut self, value: A) -> IonResult<()>;
+            fn write_blob<A: AsRef<[u8]>>(&mut self, value: A) -> IonResult<()>;
+            fn step_in(&mut self, container_type: IonType) -> IonResult<()>;
+            fn parent_type(&self) -> Option<IonType>;
+            fn depth(&self) -> usize;
+            fn step_out(&mut self) -> IonResult<()>;
+            fn flush(&mut self) -> IonResult<()>;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::text::raw_text_reader::RawTextReader;
+    use crate::Reader;
+    use std::str::from_utf8;
+
+    #[test]
+    fn resolve_symbol_ids() -> IonResult<()> {
+        // Unlike the binary writer, the text writer won't add strings to the symbol table.
+        // However, if you ask it to write a symbol ID (e.g. $10) for which its initial symbol
+        // table has text, it will convert it to text before writing it.
+        let mut buffer = Vec::new();
+        let mut text_writer = TextWriter::new(RawTextWriter::new(&mut buffer));
+        // The following symbol IDs are in the system symbol table.
+        // https://amzn.github.io/ion-docs/docs/symbols.html#system-symbols
+        text_writer.step_in(IonType::Struct)?;
+        text_writer.set_field_name(4);
+        text_writer.set_annotations(&[1]);
+        text_writer.write_symbol(5)?;
+        text_writer.step_out()?;
+        text_writer.flush()?;
+        drop(text_writer);
+
+        let mut reader = Reader::new(RawTextReader::new(from_utf8(&buffer.as_slice()).unwrap()));
+        assert_eq!(Some((IonType::Struct, false)), reader.next()?);
+        reader.step_in()?;
+        assert_eq!(Some((IonType::Symbol, false)), reader.next()?);
+        let annotations: Vec<Option<&str>> = reader.annotations().collect();
+        assert_eq!(1, annotations.len());
+        // The reader returns text values for the symbol IDs it encountered in the stream
+        assert_eq!(Some("$ion"), annotations[0]);
+        assert_eq!(Some("name"), reader.field_name());
+        assert_eq!(Some("version".to_owned()), reader.read_symbol()?);
+
+        Ok(())
+    }
+}

--- a/src/text/text_writer.rs
+++ b/src/text/text_writer.rs
@@ -30,6 +30,7 @@ impl<W: Write> TextWriter<W> {
 
 impl<W: Write> Writer for TextWriter<W> {
     fn supports_text_symbol_tokens(&self) -> bool {
+        // The TextWriter can always write text field names, annotations, and symbols.
         true
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -7,16 +7,21 @@ use crate::types::IonType;
 /**
  * This trait captures the format-agnostic encoding functionality needed to write native Rust types
  * to a stream as Ion values.
- *
- * RawWriter implementations are not expected convert symbol text to symbol IDs or vice versa.
  */
-pub trait RawWriter {
+pub trait Writer {
     /// Returns the (major, minor) version of the Ion stream being written. If ion_version is called
     /// before an Ion Version Marker has been emitted, the version (1, 0) will be returned.
     fn ion_version(&self) -> (u8, u8);
 
     /// Writes an Ion version marker to the output stream.
     fn write_ion_version_marker(&mut self, major: u8, minor: u8) -> IonResult<()>;
+
+    /// Returns `true` if this RawWriter supports writing field names, annotations, and
+    /// symbol values directly as text; otherwise, returns `false`.
+    ///
+    /// If this method returns `false`, passing a [RawSymbolTokenRef::Text] to the
+    /// [set_annotations], [set_field_name], or [write_symbol] methods may result in a panic.
+    fn supports_text_symbol_tokens(&self) -> bool;
 
     /// Sets a list of annotations that will be applied to the next value that is written.
     fn set_annotations<I, A>(&mut self, annotations: I)


### PR DESCRIPTION
This PR introduces user-level wrappers for the `RawBinaryWriter`
and the `RawTextWriter`. These higher-level types manage a
symbol table and so can convert between text and symbol IDs,
adding new symbols when appropriate.

This PR also renames the `RawWriter` trait to `Writer`, as the
methods in its interface are applicable to both the raw and user
views of data.

While this PR adds basic unit test for the new wrapper types, it
stops short of providing exhaustive correctness checking. One or
more follow-on PRs will add full integration with ion-tests,
demonstrating spec conformance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
