### PR TITLE
adds `scale` and `precision` methods to `Decimal` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ delegate = "0.5"
 thiserror = "1.0"
 nom = "6.1"
 num-bigint = "0.3"
+num-integer = "0.1.44"
 num-traits = "0.2"
 arrayvec = "0.7"
 

--- a/src/types/coefficient.rs
+++ b/src/types/coefficient.rs
@@ -39,7 +39,7 @@ impl Coefficient {
         &self.magnitude
     }
 
-    /// Returns the number of digits in the non-scaled integer representation of the coefficient.
+    /// Returns the number of digits in the base-10 representation of the coefficient
     pub(crate) fn number_of_decimal_digits(&self) -> u64 {
         self.magnitude.number_of_decimal_digits()
     }

--- a/src/types/coefficient.rs
+++ b/src/types/coefficient.rs
@@ -39,6 +39,10 @@ impl Coefficient {
         &self.magnitude
     }
 
+    pub(crate) fn digits(&self) -> u64 {
+        self.magnitude.digits()
+    }
+
     pub(crate) fn negative_zero() -> Self {
         Coefficient {
             sign: Sign::Negative,

--- a/src/types/coefficient.rs
+++ b/src/types/coefficient.rs
@@ -39,8 +39,9 @@ impl Coefficient {
         &self.magnitude
     }
 
-    pub(crate) fn digits(&self) -> u64 {
-        self.magnitude.digits()
+    /// Returns the number of digits in the non-scaled integer representation of the coefficient.
+    pub(crate) fn number_of_decimal_digits(&self) -> u64 {
+        self.magnitude.number_of_decimal_digits()
     }
 
     pub(crate) fn negative_zero() -> Self {

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -28,6 +28,23 @@ impl Decimal {
         }
     }
 
+    /// Returns scale of the Decimal value
+    /// A scale indicates the number of digits to the right of the decimal point.
+    pub fn scale(&self) -> i64 {
+        if self.exponent > 0 {
+            return 0;
+        }
+        self.exponent.abs()
+    }
+
+    /// Returns the number of digits in the non-scaled integer representation of the decimal.
+    pub fn digits(&self) -> u64 {
+        if self.exponent > 0 {
+            return self.coefficient.digits() + self.exponent as u64;
+        }
+        self.coefficient.digits()
+    }
+
     /// Constructs a Decimal with the value `-0d0`. This is provided as a convenience method
     /// because Rust will ignore a unary minus when it is applied to an zero literal (`-0`).
     pub fn negative_zero() -> Decimal {
@@ -286,6 +303,7 @@ mod decimal_tests {
     use crate::types::coefficient::{Coefficient, Sign};
     use crate::types::decimal::Decimal;
     use bigdecimal::BigDecimal;
+    use num_bigint::BigUint;
     use num_traits::{Float, ToPrimitive};
     use std::cmp::Ordering;
     use std::convert::TryInto;
@@ -413,5 +431,20 @@ mod decimal_tests {
         let actual: Decimal = big_decimal.into();
         let expected = Decimal::new(-24601, -3);
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_scale() {
+        let decimal_value = Decimal::new(-24601, -3);
+        assert_eq!(decimal_value.scale(), 3)
+    }
+
+    #[rstest]
+    #[case(Decimal::new(-24601, -3), 5)]
+    #[case(Decimal::new(u64::MAX, -3), 20)]
+    #[case(Decimal::new(BigUint::from(u64::MAX), 3), 23)]
+    #[case(Decimal::new(BigUint::from(u128::MAX), -2), 39)]
+    fn test_digits(#[case] value: Decimal, #[case] expected: u64) {
+        assert_eq!(value.digits(), expected);
     }
 }

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -8,6 +8,7 @@ use crate::types::coefficient::{Coefficient, Sign};
 use crate::types::magnitude::Magnitude;
 use std::convert::{TryFrom, TryInto};
 use std::fmt::{Display, Formatter};
+use std::ops::Neg;
 
 /// An arbitrary-precision Decimal type with a distinct representation of negative zero (`-0`).
 #[derive(Clone, Debug)]
@@ -29,20 +30,18 @@ impl Decimal {
     }
 
     /// Returns scale of the Decimal value
-    /// A scale indicates the number of digits to the right of the decimal point.
+    /// If zero or positive, a scale indicates the number of digits to the right of the decimal point.
+    /// If negative, the unscaled value of the number is multiplied by ten to the power of the negation of the scale. For example, a scale of -3 means the unscaled value is multiplied by 1000.
     pub fn scale(&self) -> i64 {
-        if self.exponent > 0 {
-            return 0;
-        }
-        self.exponent.abs()
+        self.exponent.neg()
     }
 
     /// Returns the number of digits in the non-scaled integer representation of the decimal.
-    pub fn digits(&self) -> u64 {
+    pub fn precision(&self) -> u64 {
         if self.exponent > 0 {
-            return self.coefficient.digits() + self.exponent as u64;
+            return self.coefficient.number_of_decimal_digits() + self.exponent as u64;
         }
-        self.coefficient.digits()
+        self.coefficient.number_of_decimal_digits()
     }
 
     /// Constructs a Decimal with the value `-0d0`. This is provided as a convenience method
@@ -433,18 +432,25 @@ mod decimal_tests {
         assert_eq!(actual, expected);
     }
 
-    #[test]
-    fn test_scale() {
-        let decimal_value = Decimal::new(-24601, -3);
-        assert_eq!(decimal_value.scale(), 3)
+    #[rstest]
+    #[case(Decimal::new(-24601, -3), 3)]
+    #[case(Decimal::new(u64::MAX, -5), 5)]
+    #[case(Decimal::new(u64::MAX, 0), 0)]
+    #[case(Decimal::new(4, 3), -3)]
+    fn test_scale(#[case] value: Decimal, #[case] expected: i64) {
+        assert_eq!(value.scale(), expected)
     }
 
     #[rstest]
     #[case(Decimal::new(-24601, -3), 5)]
-    #[case(Decimal::new(u64::MAX, -3), 20)]
+    #[case(Decimal::new(5, -3), 1)]
+    #[case(Decimal::new(24, -5), 2)]
+    #[case(Decimal::new(0, 0), 1)]
+    #[case(Decimal::new(234, 0), 3)]
+    #[case(Decimal::new(-234, 2), 5)]
     #[case(Decimal::new(BigUint::from(u64::MAX), 3), 23)]
     #[case(Decimal::new(BigUint::from(u128::MAX), -2), 39)]
-    fn test_digits(#[case] value: Decimal, #[case] expected: u64) {
-        assert_eq!(value.digits(), expected);
+    fn test_precision(#[case] value: Decimal, #[case] expected: u64) {
+        assert_eq!(value.precision(), expected);
     }
 }

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -31,7 +31,8 @@ impl Decimal {
 
     /// Returns scale of the Decimal value
     /// If zero or positive, a scale indicates the number of digits to the right of the decimal point.
-    /// If negative, the unscaled value of the number is multiplied by ten to the power of the negation of the scale. For example, a scale of -3 means the unscaled value is multiplied by 1000.
+    /// If negative, the unscaled value of the number is multiplied by ten to the power of the negation of the scale.
+    /// For example, a scale of -3 means the unscaled value is multiplied by 1000.
     pub fn scale(&self) -> i64 {
         self.exponent.neg()
     }

--- a/src/types/magnitude.rs
+++ b/src/types/magnitude.rs
@@ -71,7 +71,7 @@ impl Magnitude {
     }
 
     /// Returns the number of digits in the non-scaled integer representation of the magnitude.
-    pub(crate) fn digits(&self) -> u64 {
+    pub(crate) fn number_of_decimal_digits(&self) -> u64 {
         match self {
             Magnitude::U64(u64_value) => Magnitude::calculate_u64_digits(u64_value),
             Magnitude::BigUInt(big_uint_value) => {
@@ -80,36 +80,17 @@ impl Magnitude {
         }
     }
 
-    fn ten_to_the(pow: u64) -> BigUint {
-        if pow < 20 {
-            BigUint::from(10u64.pow(pow as u32))
-        } else {
-            let (half, rem) = pow.div_rem(&16);
-
-            let mut x = Magnitude::ten_to_the(half);
-
-            for _ in 0..4 {
-                x = &x * &x;
-            }
-
-            if rem == 0 {
-                x
-            } else {
-                x * Magnitude::ten_to_the(rem)
-            }
-        }
-    }
-
     fn calculate_big_uint_digits(int: &BigUint) -> u64 {
         if int.is_zero() {
             return 1;
         }
-        // guess number of digits based on number of bits in UInt
-        let mut digits = (int.bits() as f64 / std::f64::consts::LOG2_10) as u64;
-        let mut num = Magnitude::ten_to_the(digits);
-        while int >= &num {
-            num *= 10u8;
-            digits += 1;
+        let mut digits = 0;
+        let mut int_value = int.to_owned();
+        let ten: BigUint = BigUint::from(10 as u64);
+        while int_value > BigUint::zero() {
+            let (quotient, _) = int_value.div_rem(&ten);
+            int_value = quotient;
+            digits = digits + 1;
         }
         digits
     }

--- a/src/types/magnitude.rs
+++ b/src/types/magnitude.rs
@@ -105,7 +105,7 @@ impl Magnitude {
             return 1;
         }
         // guess number of digits based on number of bits in UInt
-        let mut digits = (int.bits() as f64 / 3.3219280949) as u64;
+        let mut digits = (int.bits() as f64 / std::f64::consts::LOG2_10) as u64;
         let mut num = Magnitude::ten_to_the(digits);
         while int >= &num {
             num *= 10u8;

--- a/src/types/magnitude.rs
+++ b/src/types/magnitude.rs
@@ -86,11 +86,11 @@ impl Magnitude {
         }
         let mut digits = 0;
         let mut int_value = int.to_owned();
-        let ten: BigUint = BigUint::from(10 as u64);
+        let ten: BigUint = BigUint::from(10u64);
         while int_value > BigUint::zero() {
             let (quotient, _) = int_value.div_rem(&ten);
             int_value = quotient;
-            digits = digits + 1;
+            digits += 1;
         }
         digits
     }

--- a/src/types/magnitude.rs
+++ b/src/types/magnitude.rs
@@ -2,6 +2,8 @@ use std::cmp::Ordering;
 
 use bigdecimal::ToPrimitive;
 use num_bigint::{BigUint, ToBigUint};
+use num_integer::Integer;
+use num_traits::Zero;
 
 /// An unsigned integer that can be combined with a [Sign](crate::types::coefficient::Sign)
 /// to act as the coefficient of a [Decimal](crate::types::decimal::Decimal).
@@ -66,6 +68,58 @@ impl Magnitude {
         }
         // Otherwise, the BigUint must be larger than the u64.
         Ordering::Less
+    }
+
+    /// Returns the number of digits in the non-scaled integer representation of the magnitude.
+    pub(crate) fn digits(&self) -> u64 {
+        match self {
+            Magnitude::U64(u64_value) => Magnitude::calculate_u64_digits(u64_value),
+            Magnitude::BigUInt(big_uint_value) => {
+                Magnitude::calculate_big_uint_digits(big_uint_value)
+            }
+        }
+    }
+
+    fn ten_to_the(pow: u64) -> BigUint {
+        if pow < 20 {
+            BigUint::from(10u64.pow(pow as u32))
+        } else {
+            let (half, rem) = pow.div_rem(&16);
+
+            let mut x = Magnitude::ten_to_the(half);
+
+            for _ in 0..4 {
+                x = &x * &x;
+            }
+
+            if rem == 0 {
+                x
+            } else {
+                x * Magnitude::ten_to_the(rem)
+            }
+        }
+    }
+
+    fn calculate_big_uint_digits(int: &BigUint) -> u64 {
+        if int.is_zero() {
+            return 1;
+        }
+        // guess number of digits based on number of bits in UInt
+        let mut digits = (int.bits() as f64 / 3.3219280949) as u64;
+        let mut num = Magnitude::ten_to_the(digits);
+        while int >= &num {
+            num *= 10u8;
+            digits += 1;
+        }
+        digits
+    }
+
+    fn calculate_u64_digits(value: &u64) -> u64 {
+        match value {
+            0 => 1,
+            1 => 1,
+            i => (*i as f64).log10().ceil() as u64,
+        }
     }
 }
 


### PR DESCRIPTION
*Issue #363*

*Description of changes:*
This PR works on adding `scale` and `precsion` methods to `Decimal` type.

*List of changes:*
* adds `number_of_decimal_digits()` to `Magnitude` and `Coefficient`.
* adds `precision()` to `Decimal` types
* adds `scale()` to `Decimal` type

*Tests:*
* adds unit tests in `Decimal` type.
