### PR TITLE
Null stream item

### DIFF
--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -25,15 +25,15 @@ fn main() -> IonResult<()> {
 // Prints the total number of values read upon completion.
 fn read_all_values<R: IonDataSource>(cursor: &mut RawBinaryReader<R>) -> IonResult<usize> {
     use IonType::*;
-    use RawStreamItem::{VersionMarker, Value, Null as NullValue, Nothing};
+    use RawStreamItem::{Nothing, Null as NullValue, Value, VersionMarker};
     let mut count: usize = 0;
     loop {
         match cursor.next()? {
             VersionMarker(_major, _minor) => {}
             NullValue(_ion_type) => {
                 count += 1;
-                continue
-            },
+                continue;
+            }
             Value(ion_type) => {
                 count += 1;
                 match ion_type {

--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -25,16 +25,17 @@ fn main() -> IonResult<()> {
 // Prints the total number of values read upon completion.
 fn read_all_values<R: IonDataSource>(cursor: &mut RawBinaryReader<R>) -> IonResult<usize> {
     use IonType::*;
-    use RawStreamItem::*;
+    use RawStreamItem::{VersionMarker, Value, Null as NullValue, Nothing};
     let mut count: usize = 0;
     loop {
         match cursor.next()? {
             VersionMarker(_major, _minor) => {}
-            Value(ion_type, is_null) => {
+            NullValue(_ion_type) => {
                 count += 1;
-                if is_null {
-                    continue;
-                }
+                continue
+            },
+            Value(ion_type) => {
+                count += 1;
                 match ion_type {
                     Struct | List | SExpression => cursor.step_in()?,
                     String => {

--- a/src/binary/binary_writer.rs
+++ b/src/binary/binary_writer.rs
@@ -209,9 +209,9 @@ mod tests {
         binary_writer.flush()?;
 
         let mut reader = Reader::new(RawBinaryReader::new(io::Cursor::new(buffer)));
-        assert_eq!(Value(IonType::Struct, false), reader.next()?);
+        assert_eq!(Value(IonType::Struct), reader.next()?);
         reader.step_in()?;
-        assert_eq!(Value(IonType::Symbol, false), reader.next()?);
+        assert_eq!(Value(IonType::Symbol), reader.next()?);
         assert_eq!("foo", reader.field_name()?);
         assert_eq!("bar", reader.read_symbol()?.as_ref());
 
@@ -228,7 +228,7 @@ mod tests {
         binary_writer.flush()?;
 
         let mut reader = Reader::new(RawBinaryReader::new(io::Cursor::new(buffer)));
-        assert_eq!(Value(IonType::Integer, false), reader.next()?);
+        assert_eq!(Value(IonType::Integer), reader.next()?);
         let mut annotations = reader.annotations();
         assert_eq!("foo", annotations.next().unwrap()?);
         assert_eq!("bar", annotations.next().unwrap()?);
@@ -247,11 +247,11 @@ mod tests {
         binary_writer.flush()?;
 
         let mut reader = Reader::new(RawBinaryReader::new(io::Cursor::new(buffer)));
-        assert_eq!(Value(IonType::Symbol, false), reader.next()?);
+        assert_eq!(Value(IonType::Symbol), reader.next()?);
         assert_eq!("foo", reader.read_symbol()?);
-        assert_eq!(Value(IonType::Symbol, false), reader.next()?);
+        assert_eq!(Value(IonType::Symbol), reader.next()?);
         assert_eq!("bar", reader.read_symbol()?);
-        assert_eq!(Value(IonType::Symbol, false), reader.next()?);
+        assert_eq!(Value(IonType::Symbol), reader.next()?);
         assert_eq!("baz", reader.read_symbol()?);
 
         Ok(())

--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -1582,28 +1582,19 @@ mod tests {
         assert_eq!(cursor.raw_header_bytes(), Some(&ion_data[2..=2]));
         assert_eq!(cursor.raw_value_bytes(), Some(&ion_data[3..9]));
         cursor.step_in()?;
-        assert_eq!(
-            RawStreamItem::Value(IonType::Integer),
-            cursor.next()?
-        );
+        assert_eq!(RawStreamItem::Value(IonType::Integer), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[3..=4]));
         assert_eq!(cursor.raw_field_id_bytes(), None);
         assert_eq!(cursor.raw_annotations_bytes(), None);
         assert_eq!(cursor.raw_header_bytes(), Some(&ion_data[3..=3]));
         assert_eq!(cursor.raw_value_bytes(), Some(&ion_data[4..=4]));
-        assert_eq!(
-            RawStreamItem::Value(IonType::Integer),
-            cursor.next()?
-        );
+        assert_eq!(RawStreamItem::Value(IonType::Integer), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[5..=6]));
         assert_eq!(cursor.raw_field_id_bytes(), None);
         assert_eq!(cursor.raw_annotations_bytes(), None);
         assert_eq!(cursor.raw_header_bytes(), Some(&ion_data[5..=5]));
         assert_eq!(cursor.raw_value_bytes(), Some(&ion_data[6..=6]));
-        assert_eq!(
-            RawStreamItem::Value(IonType::Integer),
-            cursor.next()?
-        );
+        assert_eq!(RawStreamItem::Value(IonType::Integer), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[7..=8]));
         assert_eq!(cursor.raw_field_id_bytes(), None);
         assert_eq!(cursor.raw_annotations_bytes(), None);
@@ -1612,10 +1603,7 @@ mod tests {
 
         cursor.step_out()?; // Step out of list
 
-        assert_eq!(
-            RawStreamItem::Value(IonType::Integer),
-            cursor.next()?
-        );
+        assert_eq!(RawStreamItem::Value(IonType::Integer), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[9..=11]));
         assert_eq!(cursor.raw_field_id_bytes(), Some(&ion_data[9..=9]));
         assert_eq!(cursor.raw_annotations_bytes(), None);
@@ -1625,10 +1613,7 @@ mod tests {
         cursor.step_out()?; // Step out of struct
 
         // Second top-level value
-        assert_eq!(
-            RawStreamItem::Value(IonType::Boolean),
-            cursor.next()?
-        );
+        assert_eq!(RawStreamItem::Value(IonType::Boolean), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[12..16]));
         assert_eq!(cursor.raw_field_id_bytes(), None);
         assert_eq!(cursor.raw_annotations_bytes(), Some(&ion_data[12..=14]));
@@ -1687,10 +1672,7 @@ mod tests {
         cursor.step_in()?;
 
         // foo: bar::baz::5
-        assert_eq!(
-            RawStreamItem::Value(IonType::Integer),
-            cursor.next()?
-        );
+        assert_eq!(RawStreamItem::Value(IonType::Integer), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[27..34]));
         assert_eq!(cursor.raw_field_id_bytes(), Some(&ion_data[27..=27]));
         assert_eq!(cursor.raw_annotations_bytes(), Some(&ion_data[28..32]));
@@ -1699,10 +1681,7 @@ mod tests {
         assert_eq!(cursor.read_i64()?, 5);
 
         // quux: 7
-        assert_eq!(
-            RawStreamItem::Value(IonType::Integer),
-            cursor.next()?
-        );
+        assert_eq!(RawStreamItem::Value(IonType::Integer), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[34..37]));
         assert_eq!(cursor.raw_field_id_bytes(), Some(&ion_data[34..=34]));
         assert_eq!(cursor.raw_annotations_bytes(), None);
@@ -1714,10 +1693,7 @@ mod tests {
         cursor.step_out()?;
 
         // false
-        assert_eq!(
-            RawStreamItem::Value(IonType::Boolean),
-            cursor.next()?
-        );
+        assert_eq!(RawStreamItem::Value(IonType::Boolean), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[37..=37]));
         assert_eq!(cursor.raw_field_id_bytes(), None);
         assert_eq!(cursor.raw_annotations_bytes(), None);

--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -371,10 +371,8 @@ impl<R: IonDataSource> StreamReader for RawBinaryReader<R> {
         self.cursor.index_at_depth += 1;
         self.cursor.value.index_at_depth = self.cursor.index_at_depth;
 
-        Ok(self.set_current_item(RawStreamItem::Value(
-            self.cursor.value.ion_type,
-            self.is_null(),
-        )))
+        let item = RawStreamItem::nullable_value(self.cursor.value.ion_type, self.is_null());
+        Ok(self.set_current_item(item))
     }
 
     fn current(&self) -> Self::Item {
@@ -1177,7 +1175,7 @@ mod tests {
     #[test]
     fn test_read_null_null() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x0F]);
-        assert_eq!(cursor.next()?, Value(IonType::Null, true));
+        assert_eq!(cursor.next()?, Null(IonType::Null));
         assert_eq!(cursor.read_null()?, IonType::Null);
         assert!(cursor.is_null());
         Ok(())
@@ -1186,7 +1184,7 @@ mod tests {
     #[test]
     fn test_read_null_string() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x8F]);
-        assert_eq!(cursor.next()?, Value(IonType::String, true));
+        assert_eq!(cursor.next()?, Null(IonType::String));
         assert_eq!(cursor.read_null()?, IonType::String);
         assert!(cursor.is_null());
         Ok(())
@@ -1195,7 +1193,7 @@ mod tests {
     #[test]
     fn test_read_bool_false() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x10]);
-        assert_eq!(cursor.next()?, Value(IonType::Boolean, false));
+        assert_eq!(cursor.next()?, Value(IonType::Boolean));
         assert_eq!(cursor.read_bool()?, false);
         Ok(())
     }
@@ -1203,7 +1201,7 @@ mod tests {
     #[test]
     fn test_read_bool_true() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x11]);
-        assert_eq!(cursor.next()?, Value(IonType::Boolean, false));
+        assert_eq!(cursor.next()?, Value(IonType::Boolean));
         assert_eq!(cursor.read_bool()?, true);
         Ok(())
     }
@@ -1211,7 +1209,7 @@ mod tests {
     #[test]
     fn test_read_i64_zero() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x20]);
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.read_i64()?, 0i64);
         Ok(())
     }
@@ -1219,7 +1217,7 @@ mod tests {
     #[test]
     fn test_read_i64_positive() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x21, 0x01]);
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.read_i64()?, 1i64);
         Ok(())
     }
@@ -1227,7 +1225,7 @@ mod tests {
     #[test]
     fn test_read_i64_negative() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x31, 0x01]);
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.read_i64()?, -1i64);
         Ok(())
     }
@@ -1235,7 +1233,7 @@ mod tests {
     #[test]
     fn test_read_f64_zero() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x40]);
-        assert_eq!(cursor.next()?, Value(IonType::Float, false));
+        assert_eq!(cursor.next()?, Value(IonType::Float));
         assert_eq!(cursor.read_f64()?, 0f64);
         Ok(())
     }
@@ -1243,7 +1241,7 @@ mod tests {
     #[test]
     fn test_read_decimal_zero() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x50]);
-        assert_eq!(cursor.next()?, Value(IonType::Decimal, false));
+        assert_eq!(cursor.next()?, Value(IonType::Decimal));
         assert_eq!(cursor.read_decimal()?, Decimal::new(0, 0));
         Ok(())
     }
@@ -1251,7 +1249,7 @@ mod tests {
     #[test]
     fn test_read_decimal_negative_zero() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x52, 0x80, 0x80]);
-        assert_eq!(cursor.next()?, Value(IonType::Decimal, false));
+        assert_eq!(cursor.next()?, Value(IonType::Decimal));
         assert_eq!(cursor.read_decimal()?, Decimal::negative_zero());
         Ok(())
     }
@@ -1259,7 +1257,7 @@ mod tests {
     #[test]
     fn test_read_decimal_positive_exponent() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x52, 0x81, 0x02]);
-        assert_eq!(cursor.next()?, Value(IonType::Decimal, false));
+        assert_eq!(cursor.next()?, Value(IonType::Decimal));
         assert_eq!(cursor.read_decimal()?, 20.into());
         Ok(())
     }
@@ -1267,7 +1265,7 @@ mod tests {
     #[test]
     fn test_read_decimal_negative_exponent() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x52, 0xC1, 0x02]);
-        assert_eq!(cursor.next()?, Value(IonType::Decimal, false));
+        assert_eq!(cursor.next()?, Value(IonType::Decimal));
         assert_eq!(cursor.read_decimal()?, Decimal::new(2, -1));
         Ok(())
     }
@@ -1275,7 +1273,7 @@ mod tests {
     #[test]
     fn test_read_timestamp() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x68, 0x80, 0x0F, 0xD0, 0x81, 0x81, 0x80, 0x80, 0x80]);
-        assert_eq!(cursor.next()?, Value(IonType::Timestamp, false));
+        assert_eq!(cursor.next()?, Value(IonType::Timestamp));
         let expected = Timestamp::with_ymd_hms(2000, 1, 1, 0, 0, 0).build_at_offset(0)?;
         assert_eq!(cursor.read_timestamp()?, expected);
         Ok(())
@@ -1284,7 +1282,7 @@ mod tests {
     #[test]
     fn test_read_timestamp_year() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x63, 0xC0, 0x0F, 0xC6]);
-        assert_eq!(cursor.next()?, Value(IonType::Timestamp, false));
+        assert_eq!(cursor.next()?, Value(IonType::Timestamp));
         let expected = Timestamp::with_year(1990).build()?;
         assert_eq!(cursor.read_timestamp()?, expected);
         Ok(())
@@ -1293,7 +1291,7 @@ mod tests {
     #[test]
     fn test_read_timestamp_year_month() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x64, 0xC0, 0x0F, 0xE2, 0x86]);
-        assert_eq!(cursor.next()?, Value(IonType::Timestamp, false));
+        assert_eq!(cursor.next()?, Value(IonType::Timestamp));
         let expected = Timestamp::with_year(2018).with_month(6).build()?;
         assert_eq!(cursor.read_timestamp()?, expected);
         Ok(())
@@ -1302,7 +1300,7 @@ mod tests {
     #[test]
     fn test_read_timestamp_year_month_day() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x65, 0xC0, 0x0F, 0xE2, 0x86, 0x83]);
-        assert_eq!(cursor.next()?, Value(IonType::Timestamp, false));
+        assert_eq!(cursor.next()?, Value(IonType::Timestamp));
         let expected = Timestamp::with_ymd(2018, 6, 3).build()?;
         assert_eq!(cursor.read_timestamp()?, expected);
         Ok(())
@@ -1311,7 +1309,7 @@ mod tests {
     #[test]
     fn test_read_timestamp_year_month_day_hour_minute() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x67, 0x80, 0x0F, 0xE2, 0x86, 0x83, 0x8F, 0xA1]);
-        assert_eq!(cursor.next()?, Value(IonType::Timestamp, false));
+        assert_eq!(cursor.next()?, Value(IonType::Timestamp));
         let expected = Timestamp::with_ymd(2018, 6, 3)
             .with_hour_and_minute(15, 33)
             .build_at_offset(0)?;
@@ -1322,7 +1320,7 @@ mod tests {
     #[test]
     fn test_read_timestamp_year_month_day_hour_minute_second() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x68, 0x80, 0x0F, 0xE2, 0x86, 0x83, 0x8F, 0xA1, 0x8B]);
-        assert_eq!(cursor.next()?, Value(IonType::Timestamp, false));
+        assert_eq!(cursor.next()?, Value(IonType::Timestamp));
         let expected = Timestamp::with_ymd(2018, 6, 3)
             .with_hms(15, 33, 11)
             .build_at_offset(0)?;
@@ -1335,7 +1333,7 @@ mod tests {
         let mut cursor = ion_cursor_for(&[
             0x6B, 0x80, 0x0F, 0xE2, 0x86, 0x83, 0x8F, 0xA1, 0x8B, 0xC3, 0x02, 0x29,
         ]);
-        assert_eq!(cursor.next()?, Value(IonType::Timestamp, false));
+        assert_eq!(cursor.next()?, Value(IonType::Timestamp));
         let expected = Timestamp::with_ymd(2018, 6, 3)
             .with_hms(15, 33, 11)
             .with_milliseconds(553)
@@ -1347,7 +1345,7 @@ mod tests {
     #[test]
     fn test_read_symbol_10() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x71, 0x0A]);
-        assert_eq!(cursor.next()?, Value(IonType::Symbol, false));
+        assert_eq!(cursor.next()?, Value(IonType::Symbol));
         assert_eq!(cursor.read_symbol()?, local_sid_token(10));
         Ok(())
     }
@@ -1355,7 +1353,7 @@ mod tests {
     #[test]
     fn test_read_string_empty() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x80]);
-        assert_eq!(cursor.next()?, Value(IonType::String, false));
+        assert_eq!(cursor.next()?, Value(IonType::String));
         assert_eq!(cursor.read_string()?, String::from(""));
         Ok(())
     }
@@ -1363,7 +1361,7 @@ mod tests {
     #[test]
     fn test_read_string_foo() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x83, 0x66, 0x6f, 0x6f]);
-        assert_eq!(cursor.next()?, Value(IonType::String, false));
+        assert_eq!(cursor.next()?, Value(IonType::String));
         assert_eq!(cursor.read_string()?, String::from("foo"));
         Ok(())
     }
@@ -1371,7 +1369,7 @@ mod tests {
     #[test]
     fn test_read_string_foo_twice_fails() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x83, 0x66, 0x6f, 0x6f]);
-        assert_eq!(cursor.next()?, Value(IonType::String, false));
+        assert_eq!(cursor.next()?, Value(IonType::String));
         assert_eq!(cursor.read_string()?, String::from("foo"));
         // We've already consumed the string from the data source, so this should fail.
         assert!(cursor.read_string().is_err());
@@ -1381,7 +1379,7 @@ mod tests {
     #[test]
     fn test_read_clob_empty() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x90]);
-        assert_eq!(cursor.next()?, Value(IonType::Clob, false));
+        assert_eq!(cursor.next()?, Value(IonType::Clob));
         assert_eq!(cursor.read_clob()?, vec![]);
         Ok(())
     }
@@ -1389,7 +1387,7 @@ mod tests {
     #[test]
     fn test_read_clob_abc() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0x93, 0x61, 0x62, 0x63]);
-        assert_eq!(cursor.next()?, Value(IonType::Clob, false));
+        assert_eq!(cursor.next()?, Value(IonType::Clob));
         assert_eq!(cursor.read_clob()?.as_slice(), "abc".as_bytes());
         Ok(())
     }
@@ -1397,7 +1395,7 @@ mod tests {
     #[test]
     fn test_read_blob_empty() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0xA0]);
-        assert_eq!(cursor.next()?, Value(IonType::Blob, false));
+        assert_eq!(cursor.next()?, Value(IonType::Blob));
         assert_eq!(cursor.read_blob()?, vec![]);
         Ok(())
     }
@@ -1405,7 +1403,7 @@ mod tests {
     #[test]
     fn test_read_blob_123() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0xA3, 0x01, 0x02, 0x03]);
-        assert_eq!(cursor.next()?, Value(IonType::Blob, false));
+        assert_eq!(cursor.next()?, Value(IonType::Blob));
         assert_eq!(cursor.read_blob()?, vec![1u8, 2, 3]);
         Ok(())
     }
@@ -1413,7 +1411,7 @@ mod tests {
     #[test]
     fn test_read_list_empty() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0xB0]);
-        assert_eq!(cursor.next()?, Value(IonType::List, false));
+        assert_eq!(cursor.next()?, Value(IonType::List));
         cursor.step_in()?;
         assert_eq!(cursor.next()?, Nothing);
         cursor.step_out()?;
@@ -1423,10 +1421,10 @@ mod tests {
     #[test]
     fn test_read_list_123() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0xB6, 0x21, 0x01, 0x21, 0x02, 0x21, 0x03]);
-        assert_eq!(cursor.next()?, Value(IonType::List, false));
+        assert_eq!(cursor.next()?, Value(IonType::List));
         let mut list = vec![];
         cursor.step_in()?;
-        while let Value(IonType::Integer, false) = cursor.next()? {
+        while let Value(IonType::Integer) = cursor.next()? {
             list.push(cursor.read_i64()?);
         }
         cursor.step_out()?;
@@ -1437,7 +1435,7 @@ mod tests {
     #[test]
     fn test_read_s_expression_empty() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0xC0]);
-        assert_eq!(cursor.next()?, Value(IonType::SExpression, false));
+        assert_eq!(cursor.next()?, Value(IonType::SExpression));
         cursor.step_in()?;
         assert_eq!(cursor.next()?, Nothing);
         cursor.step_out()?;
@@ -1447,10 +1445,10 @@ mod tests {
     #[test]
     fn test_read_s_expression_123() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0xC6, 0x21, 0x01, 0x21, 0x02, 0x21, 0x03]);
-        assert_eq!(cursor.next()?, Value(IonType::SExpression, false));
+        assert_eq!(cursor.next()?, Value(IonType::SExpression));
         let mut sexp = vec![];
         cursor.step_in()?;
-        while let Value(IonType::Integer, false) = cursor.next()? {
+        while let Value(IonType::Integer) = cursor.next()? {
             sexp.push(cursor.read_i64()?);
         }
         cursor.step_out()?;
@@ -1461,7 +1459,7 @@ mod tests {
     #[test]
     fn test_read_struct_empty() -> IonResult<()> {
         let mut cursor = ion_cursor_for(&[0xD0]);
-        assert_eq!(cursor.next()?, Value(IonType::Struct, false));
+        assert_eq!(cursor.next()?, Value(IonType::Struct));
         cursor.step_in()?;
         assert_eq!(cursor.next()?, Nothing);
         cursor.step_out()?;
@@ -1483,15 +1481,15 @@ mod tests {
             0x8C, // Field ID 12
             0x21, 0x03, // Integer 3
         ]);
-        assert_eq!(cursor.next()?, Value(IonType::Struct, false));
+        assert_eq!(cursor.next()?, Value(IonType::Struct));
         cursor.step_in()?;
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.field_name()?, local_sid_token(10));
         assert_eq!(cursor.read_i64()?, 1i64);
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.field_name()?, local_sid_token(11usize));
         assert_eq!(cursor.read_i64()?, 2i64);
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.field_name()?, local_sid_token(12usize));
         assert_eq!(cursor.read_i64()?, 3i64);
         cursor.step_out()?;
@@ -1515,26 +1513,26 @@ mod tests {
             0x21, 0x01, // Integer 1
         ]);
 
-        assert_eq!(cursor.next()?, Value(IonType::Struct, false));
+        assert_eq!(cursor.next()?, Value(IonType::Struct));
         cursor.step_in()?;
 
-        assert_eq!(cursor.next()?, Value(IonType::List, false));
+        assert_eq!(cursor.next()?, Value(IonType::List));
         assert_eq!(cursor.field_name()?, local_sid_token(11usize));
         cursor.step_in()?;
 
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.read_i64()?, 1i64);
 
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.read_i64()?, 2i64);
 
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.read_i64()?, 3i64);
 
         assert_eq!(cursor.next()?, Nothing); // End of the list's values
         cursor.step_out()?; // Step out of list
 
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
         assert_eq!(cursor.field_name()?, local_sid_token(10usize));
         assert_eq!(cursor.read_i64()?, 1i64);
 
@@ -1570,14 +1568,14 @@ mod tests {
             0x10, // Boolean false
         ];
         let mut cursor = ion_cursor_for(ion_data);
-        assert_eq!(RawStreamItem::Value(IonType::Struct, false), cursor.next()?);
+        assert_eq!(RawStreamItem::Value(IonType::Struct), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[0..12]));
         assert_eq!(cursor.raw_field_id_bytes(), None);
         assert_eq!(cursor.raw_annotations_bytes(), None);
         assert_eq!(cursor.raw_header_bytes(), Some(&ion_data[0..=0]));
         assert_eq!(cursor.raw_value_bytes(), Some(&ion_data[1..12]));
         cursor.step_in()?;
-        assert_eq!(RawStreamItem::Value(IonType::List, false), cursor.next()?);
+        assert_eq!(RawStreamItem::Value(IonType::List), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[1..9]));
         assert_eq!(cursor.raw_field_id_bytes(), Some(&ion_data[1..=1]));
         assert_eq!(cursor.raw_annotations_bytes(), None);
@@ -1585,7 +1583,7 @@ mod tests {
         assert_eq!(cursor.raw_value_bytes(), Some(&ion_data[3..9]));
         cursor.step_in()?;
         assert_eq!(
-            RawStreamItem::Value(IonType::Integer, false),
+            RawStreamItem::Value(IonType::Integer),
             cursor.next()?
         );
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[3..=4]));
@@ -1594,7 +1592,7 @@ mod tests {
         assert_eq!(cursor.raw_header_bytes(), Some(&ion_data[3..=3]));
         assert_eq!(cursor.raw_value_bytes(), Some(&ion_data[4..=4]));
         assert_eq!(
-            RawStreamItem::Value(IonType::Integer, false),
+            RawStreamItem::Value(IonType::Integer),
             cursor.next()?
         );
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[5..=6]));
@@ -1603,7 +1601,7 @@ mod tests {
         assert_eq!(cursor.raw_header_bytes(), Some(&ion_data[5..=5]));
         assert_eq!(cursor.raw_value_bytes(), Some(&ion_data[6..=6]));
         assert_eq!(
-            RawStreamItem::Value(IonType::Integer, false),
+            RawStreamItem::Value(IonType::Integer),
             cursor.next()?
         );
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[7..=8]));
@@ -1615,7 +1613,7 @@ mod tests {
         cursor.step_out()?; // Step out of list
 
         assert_eq!(
-            RawStreamItem::Value(IonType::Integer, false),
+            RawStreamItem::Value(IonType::Integer),
             cursor.next()?
         );
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[9..=11]));
@@ -1628,7 +1626,7 @@ mod tests {
 
         // Second top-level value
         assert_eq!(
-            RawStreamItem::Value(IonType::Boolean, false),
+            RawStreamItem::Value(IonType::Boolean),
             cursor.next()?
         );
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[12..16]));
@@ -1675,11 +1673,11 @@ mod tests {
         let mut cursor = ion_cursor_for(ion_data);
 
         // Local symbol table. We don't interpret any symbols for this test, so we can skip over it.
-        assert_eq!(RawStreamItem::Value(IonType::Struct, false), cursor.next()?);
+        assert_eq!(RawStreamItem::Value(IonType::Struct), cursor.next()?);
 
         // The first user-level value appears at byte offset 26
         // Top-level struct {
-        assert_eq!(RawStreamItem::Value(IonType::Struct, false), cursor.next()?);
+        assert_eq!(RawStreamItem::Value(IonType::Struct), cursor.next()?);
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[26..37]));
         assert_eq!(cursor.raw_field_id_bytes(), None);
         assert_eq!(cursor.raw_annotations_bytes(), None);
@@ -1690,7 +1688,7 @@ mod tests {
 
         // foo: bar::baz::5
         assert_eq!(
-            RawStreamItem::Value(IonType::Integer, false),
+            RawStreamItem::Value(IonType::Integer),
             cursor.next()?
         );
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[27..34]));
@@ -1702,7 +1700,7 @@ mod tests {
 
         // quux: 7
         assert_eq!(
-            RawStreamItem::Value(IonType::Integer, false),
+            RawStreamItem::Value(IonType::Integer),
             cursor.next()?
         );
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[34..37]));
@@ -1717,7 +1715,7 @@ mod tests {
 
         // false
         assert_eq!(
-            RawStreamItem::Value(IonType::Boolean, false),
+            RawStreamItem::Value(IonType::Boolean),
             cursor.next()?
         );
         assert_eq!(cursor.raw_bytes(), Some(&ion_data[37..=37]));
@@ -1745,7 +1743,7 @@ mod tests {
             0x00, // NOP code, 1 byte NOP. Also NOP at EOF :)
         ]);
 
-        assert_eq!(cursor.next()?, Value(IonType::Boolean, false));
+        assert_eq!(cursor.next()?, Value(IonType::Boolean));
         assert_eq!(cursor.next()?, Nothing);
 
         Ok(())
@@ -1761,7 +1759,7 @@ mod tests {
             0x11, // boolean true
         ]);
 
-        assert_eq!(cursor.next()?, Value(IonType::Boolean, false));
+        assert_eq!(cursor.next()?, Value(IonType::Boolean));
         assert_eq!(cursor.next()?, Nothing);
 
         Ok(())
@@ -1780,9 +1778,9 @@ mod tests {
             0x01, 0x02, // not interpreted, this is padding
         ]);
 
-        assert_eq!(cursor.next()?, Value(IonType::Struct, false));
+        assert_eq!(cursor.next()?, Value(IonType::Struct));
         cursor.step_in()?;
-        assert_eq!(cursor.next()?, Value(IonType::String, false));
+        assert_eq!(cursor.next()?, Value(IonType::String));
         assert_eq!(cursor.read_string()?, String::from("a"));
         assert_eq!(cursor.next()?, Nothing);
         cursor.step_out()?;
@@ -1803,9 +1801,9 @@ mod tests {
             0x61, // "a"
         ]);
 
-        assert_eq!(cursor.next()?, Value(IonType::Struct, false));
+        assert_eq!(cursor.next()?, Value(IonType::Struct));
         cursor.step_in()?;
-        assert_eq!(cursor.next()?, Value(IonType::String, false));
+        assert_eq!(cursor.next()?, Value(IonType::String));
         assert_eq!(cursor.read_string()?, String::from("a"));
         assert_eq!(cursor.next()?, Nothing);
         cursor.step_out()?;
@@ -1841,10 +1839,10 @@ mod tests {
             0x01, 0x02, // not interpreted, this is padding
         ]);
 
-        assert_eq!(cursor.next()?, Value(IonType::Struct, false));
+        assert_eq!(cursor.next()?, Value(IonType::Struct));
 
         cursor.step_in()?;
-        assert_eq!(cursor.next()?, Value(IonType::String, false));
+        assert_eq!(cursor.next()?, Value(IonType::String));
         assert_eq!(cursor.read_string()?, String::from("a"));
 
         assert!(matches!(cursor.next(), Err(IonError::DecodingError { .. })));
@@ -1864,10 +1862,10 @@ mod tests {
             0x01, // [6] "one" bytes of NOP padding follow, which would overrun the list
         ]); // [7] is out of the container
 
-        assert_eq!(cursor.next()?, Value(IonType::List, false));
+        assert_eq!(cursor.next()?, Value(IonType::List));
 
         cursor.step_in()?;
-        assert_eq!(cursor.next()?, Value(IonType::Integer, false));
+        assert_eq!(cursor.next()?, Value(IonType::Integer));
 
         assert!(matches!(cursor.next(), Err(IonError::DecodingError { .. })));
 

--- a/src/binary/raw_binary_writer.rs
+++ b/src/binary/raw_binary_writer.rs
@@ -895,7 +895,7 @@ mod writer_tests {
             },
             |reader| {
                 for value in values {
-                    assert_eq!(reader.next()?, StreamItem::Value(ion_type, false));
+                    assert_eq!(reader.next()?, StreamItem::Value(ion_type));
                     let reader_value = read_fn(reader)?;
                     assert_eq!(
                         reader_value, *value,
@@ -934,7 +934,7 @@ mod writer_tests {
             },
             |reader| {
                 for ion_type in ion_types {
-                    assert_eq!(reader.next()?, StreamItem::Value(*ion_type, true));
+                    assert_eq!(reader.next()?, StreamItem::Null(*ion_type));
                 }
                 Ok(())
             },
@@ -1069,7 +1069,7 @@ mod writer_tests {
                 expected_value
             )
         });
-        assert_eq!(next, StreamItem::Value(ion_type, false));
+        assert_eq!(next, StreamItem::Value(ion_type));
         let value = read_fn(reader)
             .unwrap_or_else(|_| panic!("Failed to read in expected value: {:?}", expected_value));
         assert_eq!(value, expected_value);
@@ -1103,14 +1103,14 @@ mod writer_tests {
     fn expect_null(reader: &mut TestReader) {
         assert_eq!(
             reader.next().expect("Failed to read null."),
-            StreamItem::Value(IonType::Null, true)
+            StreamItem::Null(IonType::Null)
         );
     }
 
     fn expect_container(reader: &mut TestReader, ion_type: IonType) {
         assert_eq!(
             reader.next().expect("Failed to read container."),
-            StreamItem::Value(ion_type, false)
+            StreamItem::Value(ion_type)
         );
     }
 

--- a/src/raw_reader.rs
+++ b/src/raw_reader.rs
@@ -21,11 +21,12 @@ pub enum RawStreamItem {
     /// An Ion Version Marker (IVM) indicating the Ion major and minor version that were used to
     /// encode the values that follow.
     VersionMarker(u8, u8),
-    /// An Ion value (e.g. an integer, timestamp, or struct).
-    /// Includes the value's IonType and whether it is null.
+    /// A non-null Ion value and its corresponding Ion data type.
     /// Stream values that represent system constructs (e.g. a struct marked with a
     /// $ion_symbol_table annotation) are still considered values at the raw level.
-    Value(IonType, bool),
+    Value(IonType),
+    /// A null Ion value and its corresponding Ion data type.
+    Null(IonType),
     /// Indicates that the reader is not positioned over anything. This can happen:
     /// * before the reader has begun processing the stream.
     /// * after the reader has stepped into a container, but before the reader has called next()
@@ -34,13 +35,25 @@ pub enum RawStreamItem {
     Nothing,
 }
 
+impl RawStreamItem {
+    /// If `is_null` is `true`, returns `RawStreamItem::Value(ion_type)`. Otherwise,
+    /// returns `RawStreamItem::Null(ion_type)`.
+    pub fn nullable_value(ion_type: IonType, is_null: bool) -> RawStreamItem {
+        if is_null {
+            RawStreamItem::Null(ion_type)
+        } else {
+            RawStreamItem::Value(ion_type)
+        }
+    }
+}
+
 impl Display for RawStreamItem {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use RawStreamItem::*;
         match self {
             VersionMarker(major, minor) => write!(f, "ion version marker (v{}.{})", major, minor),
-            Value(ion_type, true) => write!(f, "null.{}", ion_type),
-            Value(ion_type, false) => write!(f, "{}", ion_type),
+            Value(ion_type) => write!(f, "null.{}", ion_type),
+            Null(ion_type) => write!(f, "{}", ion_type),
             Nothing => write!(f, "nothing/end-of-sequence"),
         }
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -25,11 +25,10 @@ pub struct Reader<R: RawReader> {
 /// Stream components that an application-level [Reader] implementation may encounter.
 #[derive(Eq, PartialEq, Debug)]
 pub enum StreamItem {
-    /// An Ion value (e.g. an integer, timestamp, or struct).
-    /// Includes the value's IonType and whether it is null.
-    /// Stream values that represent system constructs (e.g. a struct marked with a
-    /// $ion_symbol_table annotation) are still considered values at the raw level.
-    Value(IonType, bool),
+    /// A non-null Ion value and its corresponding Ion data type.
+    Value(IonType),
+    /// A null Ion value and its corresponding Ion data type.
+    Null(IonType),
     /// Indicates that the reader is not positioned over anything. This can happen:
     /// * before the reader has begun processing the stream.
     /// * after the reader has stepped into a container, but before the reader has called next()
@@ -60,39 +59,60 @@ impl<R: RawReader> Reader<R> {
         let mut is_append = false;
         let mut new_symbols = vec![];
 
-        while let RawStreamItem::Value(ion_type, is_null) = self.raw_reader.next()? {
+        loop {
+            let ion_type = match self.raw_reader.next()? {
+                RawStreamItem::Value(ion_type) => ion_type,
+                RawStreamItem::Null(_) => continue,
+                RawStreamItem::Nothing => break,
+                RawStreamItem::VersionMarker(major, minor) => return decoding_error(
+                    format!(
+                        "encountered Ion version marker for v{}.{} in symbol table",
+                        major,
+                        minor
+                    )
+                )
+            };
+
             let field_id = self
                 .raw_reader
                 .field_name()
                 .expect("No field ID found inside $ion_symbol_table struct.");
-            match (field_id, ion_type, is_null) {
+            match (field_id, ion_type) {
                 // The field name is either SID 6 or the text 'imports' and the
                 // field value is a non-null symbol
-                (symbol, IonType::Symbol, false)
-                    if symbol.matches(system_symbol_ids::IMPORTS, "imports") =>
-                {
-                    // TODO: SST imports. This implementation only supports local symbol
-                    //       table imports and appends.
-                    let import_symbol = self.raw_reader.read_symbol()?;
-                    if !import_symbol.matches(3, "$ion_symbol_table") {
-                        unimplemented!("Can't handle non-$ion_symbol_table imports value.");
+                (symbol, IonType::Symbol)
+                if symbol.matches(system_symbol_ids::IMPORTS, "imports") =>
+                    {
+                        // TODO: SST imports. This implementation only supports local symbol
+                        //       table imports and appends.
+                        let import_symbol = self.raw_reader.read_symbol()?;
+                        if !import_symbol.matches(3, "$ion_symbol_table") {
+                            unimplemented!("Can't handle non-$ion_symbol_table imports value.");
+                        }
+                        is_append = true;
                     }
-                    is_append = true;
-                }
                 // The field name is either SID 7 or the text 'imports' and the
                 // field value is a non-null list
-                (symbol, IonType::List, false)
-                    if symbol.matches(system_symbol_ids::SYMBOLS, "symbols") =>
-                {
-                    self.raw_reader.step_in()?;
-                    while let RawStreamItem::Value(IonType::String, false) =
-                        self.raw_reader.next()?
+                (symbol, IonType::List)
+                if symbol.matches(system_symbol_ids::SYMBOLS, "symbols") =>
                     {
-                        let text = self.raw_reader.read_string()?;
-                        new_symbols.push(text);
+                        self.raw_reader.step_in()?;
+                        loop {
+                            use RawStreamItem::*;
+                            match self.raw_reader.next()? {
+                                Value(IonType::String) => {
+                                    new_symbols.push(Some(self.raw_reader.read_string()?));
+                                },
+                                Value(_) | Null(_) => {
+                                    // If we encounter a non-string or null, add a placeholder
+                                    new_symbols.push(None);
+                                }
+                                VersionMarker(_, _) => return decoding_error("Found IVM in symbol table."),
+                                Nothing => break
+                            }
+                        }
+                        self.raw_reader.step_out()?;
                     }
-                    self.raw_reader.step_out()?;
-                }
                 something_else => {
                     unimplemented!("No support for {:?}", something_else);
                 }
@@ -101,15 +121,15 @@ impl<R: RawReader> Reader<R> {
 
         if is_append {
             // We're adding new symbols to the end of the symbol table.
-            for new_symbol in new_symbols.drain(..) {
-                let _id = self.symbol_table.intern(new_symbol);
+            for maybe_text in new_symbols.drain(..) {
+                let _sid = self.symbol_table.intern_or_add_placeholder(maybe_text);
             }
         } else {
             // The symbol table has been set by defining new symbols without importing the current
             // symbol table.
             self.symbol_table.reset();
-            for new_symbol in new_symbols.drain(..) {
-                let _id = self.symbol_table.intern(new_symbol);
+            for maybe_text in new_symbols.drain(..) {
+                let _sid = self.symbol_table.intern_or_add_placeholder(maybe_text);
             }
         }
 
@@ -135,7 +155,11 @@ impl<R: RawReader> StreamReader for Reader<R> {
 
     fn current(&self) -> Self::Item {
         if let Some(ion_type) = self.ion_type() {
-            return StreamItem::Value(ion_type, self.is_null());
+            return if self.is_null() {
+                StreamItem::Null(ion_type)
+            } else {
+                StreamItem::Value(ion_type)
+            };
         }
         StreamItem::Nothing
     }
@@ -157,7 +181,7 @@ impl<R: RawReader> StreamReader for Reader<R> {
                         major, minor
                     ));
                 }
-                Value(IonType::Struct, false) => {
+                Value(IonType::Struct) => {
                     // Top-level structs whose _first_ annotation is $ion_symbol_table are
                     // interpreted as local symbol tables. Other trailing annotations (if any) are
                     // ignored. If the first annotation is something other than `$ion_symbol_table`,
@@ -185,9 +209,10 @@ impl<R: RawReader> StreamReader for Reader<R> {
                             continue;
                         }
                     }
-                    return Ok(StreamItem::Value(IonType::Struct, false));
+                    return Ok(StreamItem::Value(IonType::Struct));
                 }
-                Value(ion_type, is_null) => return Ok(StreamItem::Value(ion_type, is_null)),
+                Value(ion_type) => return Ok(StreamItem::Value(ion_type)),
+                Null(ion_type) => return Ok(StreamItem::Null(ion_type)),
                 Nothing => return Ok(StreamItem::Nothing),
             }
         }
@@ -371,16 +396,16 @@ mod tests {
     fn test_read_struct() -> IonResult<()> {
         let mut reader = ion_reader_for(EXAMPLE_STREAM);
 
-        assert_eq!(Value(IonType::Struct, false), reader.next()?);
+        assert_eq!(Value(IonType::Struct), reader.next()?);
         reader.step_in()?;
 
-        assert_eq!(reader.next()?, Value(IonType::Integer, false));
+        assert_eq!(reader.next()?, Value(IonType::Integer));
         assert_eq!(reader.field_name()?, "foo");
 
-        assert_eq!(reader.next()?, Value(IonType::Integer, false));
+        assert_eq!(reader.next()?, Value(IonType::Integer));
         assert_eq!(reader.field_name()?, "bar");
 
-        assert_eq!(reader.next()?, Value(IonType::Integer, false));
+        assert_eq!(reader.next()?, Value(IonType::Integer));
         assert_eq!(reader.field_name()?, "baz");
 
         Ok(())

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -177,7 +177,7 @@ impl SymbolTable {
     pub fn intern_or_add_placeholder<A: AsRef<str>>(&mut self, maybe_text: Option<A>) -> SymbolId {
         match maybe_text {
             Some(text) => self.intern(text),
-            None => self.add_placeholder()
+            None => self.add_placeholder(),
         }
     }
 

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -146,6 +146,8 @@ impl SymbolTable {
         self.initialize();
     }
 
+    /// If `text` is already in the symbol table, returns the corresponding [SymbolId].
+    /// Otherwise, adds `text` to the symbol table and returns the newly assigned [SymbolId].
     pub fn intern<A: AsRef<str>>(&mut self, text: A) -> SymbolId {
         let text = text.as_ref();
         // If the text is already in the symbol table, return the ID associated with it.
@@ -168,6 +170,15 @@ impl SymbolTable {
         let sid = self.symbols_by_id.len();
         self.symbols_by_id.push(None);
         sid
+    }
+
+    /// If `maybe_text` is `Some(text)`, this method is equivalent to `intern(text)`.
+    /// If `maybe_text` is `None`, this method is equivalent to `add_placeholder()`.
+    pub fn intern_or_add_placeholder<A: AsRef<str>>(&mut self, maybe_text: Option<A>) -> SymbolId {
+        match maybe_text {
+            Some(text) => self.intern(text),
+            None => self.add_placeholder()
+        }
     }
 
     /// If defined, returns the Symbol ID associated with the provided text.

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -502,9 +502,7 @@ impl<R: RawReader> StreamReader for SystemReader<R> {
                 // or part of a system value.
                 self.after_next(ion_type, false)?
             }
-            RawStreamItem::Null(ion_type) => {
-                self.after_next(ion_type, true)?
-            }
+            RawStreamItem::Null(ion_type) => self.after_next(ion_type, true)?,
             RawStreamItem::Nothing => SystemStreamItem::Nothing,
         };
         self.current_item = item;
@@ -781,20 +779,11 @@ mod tests {
         );
         // ...but expect all of the symbols we encounter after it to be in the symbol table,
         // indicating that the SystemReader processed the LST even though we skipped it with `next()`
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, "foo");
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, "bar");
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, "baz");
         Ok(())
     }
@@ -829,20 +818,11 @@ mod tests {
             );
         }
         // Confirm that the symbols defined in each append map to the expected text.
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, "foo");
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, "bar");
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, "baz");
         Ok(())
     }
@@ -877,10 +857,7 @@ mod tests {
         assert_eq!(reader.symbol_table.len(), 10);
 
         // Advance to the symbol $10, loading the LST as we pass it
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.symbol_table.len(), 11);
         assert_eq!(reader.read_symbol()?, "foo");
 
@@ -900,10 +877,7 @@ mod tests {
         );
 
         // Advance to the symbol $10 again, but this time it's 'baz'
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.symbol_table.len(), 11);
         assert_eq!(reader.read_symbol()?, "baz");
 
@@ -980,20 +954,11 @@ mod tests {
 
         // Read the user-level symbol values in the stream to confirm that the LST was processed
         // successfully by the SystemReader.
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, "foo");
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, "bar");
-        assert_eq!(
-            reader.next()?,
-            SystemStreamItem::Value(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SystemStreamItem::Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, "baz");
 
         Ok(())

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -759,8 +759,8 @@ impl<T: AsRef<[u8]>> SystemReader<RawBinaryReader<io::Cursor<T>>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::text::raw_text_reader::RawTextReader;
     use super::SystemStreamItem::*;
+    use crate::text::raw_text_reader::RawTextReader;
 
     use super::*;
 
@@ -783,10 +783,7 @@ mod tests {
           "#,
         );
         // We step over the LST...
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::Struct)
-        );
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::Struct));
         // ...but expect all of the symbols we encounter after it to be in the symbol table,
         // indicating that the SystemReader processed the LST even though we skipped it with `next()`
         assert_eq!(reader.next()?, Value(IonType::Symbol));
@@ -822,10 +819,7 @@ mod tests {
         );
         // Expect 3 symbol tables in a row, stepping over each one
         for _ in 0..3 {
-            assert_eq!(
-                reader.next()?,
-                SymbolTableValue(IonType::Struct)
-            );
+            assert_eq!(reader.next()?, SymbolTableValue(IonType::Struct));
         }
         // Confirm that the symbols defined in each append map to the expected text.
         assert_eq!(reader.next()?, Value(IonType::Symbol));
@@ -859,10 +853,7 @@ mod tests {
           "#,
         );
 
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::Struct)
-        );
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::Struct));
         // Only system symbols initially
         assert_eq!(reader.symbol_table.len(), 10);
 
@@ -877,14 +868,8 @@ mod tests {
         assert_eq!(reader.symbol_table.len(), 10);
 
         // Step over the two symbol tables that follow
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::Struct)
-        );
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::Struct)
-        );
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::Struct));
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::Struct));
 
         // Advance to the symbol $10 again, but this time it's 'baz'
         assert_eq!(reader.next()?, Value(IonType::Symbol));
@@ -913,10 +898,7 @@ mod tests {
         assert_eq!(reader.next()?, VersionMarker(1, 0));
 
         // Symbol table
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::Struct)
-        );
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::Struct));
 
         // Instead of stepping _over_ the LST as we've done in other tests, step into it.
         // We're going to visit/read every value inside the LST. Afterwards, we'll confirm
@@ -925,34 +907,19 @@ mod tests {
         reader.step_in()?;
 
         // Advance to `imports`, confirm its value is the system symbol "$ion_symbol_table"
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::Symbol)
-        );
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::Symbol));
         assert_eq!(reader.field_name()?, "imports");
         assert_eq!(reader.read_symbol()?, "$ion_symbol_table".to_string());
 
         // Advance to `symbols`, visit each string in the list
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::List)
-        );
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::List));
         assert_eq!(reader.field_name()?, "symbols");
         reader.step_in()?;
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::String)
-        );
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::String));
         assert_eq!(reader.read_string()?, "foo");
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::String)
-        );
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::String));
         assert_eq!(reader.read_string()?, "bar");
-        assert_eq!(
-            reader.next()?,
-            SymbolTableValue(IonType::String)
-        );
+        assert_eq!(reader.next()?, SymbolTableValue(IonType::String));
         assert_eq!(reader.read_string()?, "baz");
         // No more strings
         assert_eq!(reader.next()?, Nothing);

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -417,7 +417,10 @@ impl<T: TextIonDataSource> StreamReader for RawTextReader<T> {
 
         // If we're positioned on a value, return its IonType and whether it's null.
         if let Some(value) = self.current_value.as_ref() {
-            Ok(RawStreamItem::nullable_value(value.ion_type(), value.is_null()))
+            Ok(RawStreamItem::nullable_value(
+                value.ion_type(),
+                value.is_null(),
+            ))
         } else {
             Ok(RawStreamItem::Nothing)
         }

--- a/src/text/text_writer.rs
+++ b/src/text/text_writer.rs
@@ -149,9 +149,9 @@ mod tests {
         drop(text_writer);
 
         let mut reader = Reader::new(RawTextReader::new(from_utf8(&buffer.as_slice()).unwrap()));
-        assert_eq!(Value(IonType::Struct, false), reader.next()?);
+        assert_eq!(Value(IonType::Struct), reader.next()?);
         reader.step_in()?;
-        assert_eq!(Value(IonType::Symbol, false), reader.next()?);
+        assert_eq!(Value(IonType::Symbol), reader.next()?);
         assert_eq!(1, reader.number_of_annotations());
         // The reader returns text values for the symbol IDs it encountered in the stream
         assert_eq!("$ion", reader.annotations().next().unwrap()?);

--- a/tests/good_test_vectors.rs
+++ b/tests/good_test_vectors.rs
@@ -127,8 +127,8 @@ fn read_file(path: &Path) -> IonResult<()> {
 // Recursively reads all of the values in the provided Reader, surfacing any errors.
 fn read_all_values(reader: &mut Reader<RawBinaryReader<BufReader<File>>>) -> IonResult<()> {
     // StreamItem::Null conflicts with IonType::Null, so we give them aliases for clarity.
-    use ion_rs::StreamItem::{*, Null as NullValue};
-    use IonType::{*, Null as NullType};
+    use ion_rs::StreamItem::{Null as NullValue, *};
+    use IonType::{Null as NullType, *};
 
     while let Value(ion_type) | NullValue(ion_type) = reader.next()? {
         if reader.is_null() {

--- a/tests/good_test_vectors.rs
+++ b/tests/good_test_vectors.rs
@@ -126,11 +126,12 @@ fn read_file(path: &Path) -> IonResult<()> {
 
 // Recursively reads all of the values in the provided Reader, surfacing any errors.
 fn read_all_values(reader: &mut Reader<RawBinaryReader<BufReader<File>>>) -> IonResult<()> {
-    use ion_rs::StreamItem::*;
-    use IonType::*;
+    // StreamItem::Null conflicts with IonType::Null, so we give them aliases for clarity.
+    use ion_rs::StreamItem::{*, Null as NullValue};
+    use IonType::{*, Null as NullType};
 
-    while let Value(ion_type, is_null) = reader.next()? {
-        if is_null {
+    while let Value(ion_type) | NullValue(ion_type) = reader.next()? {
+        if reader.is_null() {
             continue;
         }
         match ion_type {
@@ -167,7 +168,7 @@ fn read_all_values(reader: &mut Reader<RawBinaryReader<BufReader<File>>>) -> Ion
             Clob => {
                 let _clob = reader.map_clob(|_c| ())?;
             }
-            Null => {
+            NullType => {
                 unreachable!("Value with IonType::Null returned is_null=false.");
             }
         }


### PR DESCRIPTION
*Issue #, if available:* Fixes #368.

*Description of changes:*

Each implementation of `StreamReader` has an associated type called
`Item` that represents the set of possible entities that the reader may
encounter in its stream:

| Reader       |      Item        |
|--------------|------------------|
| RawReader    | RawStreamItem    |
| SystemReader | SystemStreamItem |
| Reader       | StreamItem       |

While the entities enumerated by `Item` vary according to the reader's
level of abstraction, all of them include a `Value` variant that
indicates that the reader is currently positioned over an Ion value.

Prior to this PR, each `Value` enum variant was modeled as:

      Value(IonType, bool)

in which the `IonType` represented the value's corresponding Ion data
type and the `bool` indicated whether the value was a `null`. This
lead to user code that looked like:

```rust
     match reader.next()? {
        Value(IonType::String, true)  => /* ... */,
        Value(IonType::String, false) => /* ... */,
        _ => {}
     }
```

In such situations, the meaning of the `true` or `false` was not
obvious.

This PR splits `Value(IonType, bool)` out into two variants for
each enum:

```rust
enum $NAME {
     // ...
     Value(IonType),
     Null(IonType),
     // ...
}
````

This makes most interactions with the enum both more self-documenting
and more concise.

This PR also modifies `Reader` and `SymbolTable` to be able to handle
non-`string` values in a local symbol table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
