### PR TITLE
Version bump to v0.9.0, update ion-hash dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [workspace]

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -16,11 +16,11 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 
 [dependencies]
-ion-rs = { path = "../", version = "0.8" }
+ion-rs = { path = "../", version = "0.9" }
 ion-c-sys = { path = "../ion-c-sys", version = "0.4" }
 num-bigint = "0.3"
 digest = "0.9"


### PR DESCRIPTION
*Issue #, if available:* #367

*Description of changes:*
* Bumps `ion-rs` to v0.9.0.
* Bumps `ion-hash` to v0.6.0 and sets its `ion-rs` dependency to v0.9.0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
