### PR TITLE
Adds `NativeElementReader`, lifts int size restriction

### DIFF
--- a/ion-hash/src/type_qualifier.rs
+++ b/ion-hash/src/type_qualifier.rs
@@ -5,10 +5,14 @@ use std::slice;
 ///! Implements "type qualifiers" (TQ) as per the [spec][spec].
 ///!
 ///! [spec]: https://amzn.github.io/ion-hash/docs/spec.html.
+use ion_rs::types::integer::Integer;
+///! Implements "type qualifiers" (TQ) as per the [spec][spec].
+///!
+///! [spec]: https://amzn.github.io/ion-hash/docs/spec.html.
 use ion_rs::{
     binary::IonTypeCode,
     types::{decimal::Decimal, timestamp::Timestamp},
-    value::{AnyInt, Element, Sequence, Struct, SymbolToken},
+    value::{Element, Sequence, Struct, SymbolToken},
     IonType,
 };
 use num_bigint::Sign;
@@ -45,7 +49,7 @@ impl TypeQualifier {
         match elem.ion_type() {
             IonType::Null => type_qualifier_null(),
             IonType::Boolean => type_qualifier_boolean(elem.as_bool()),
-            IonType::Integer => type_qualifier_integer(elem.as_any_int()),
+            IonType::Integer => type_qualifier_integer(elem.as_integer()),
             IonType::Float => type_qualifier_float(elem.as_f64()),
             IonType::Decimal => type_qualifier_decimal(elem.as_decimal()),
             IonType::Timestamp => type_qualifier_timestamp(elem.as_timestamp()),
@@ -65,12 +69,12 @@ impl TypeQualifier {
     }
 }
 
-fn is_anyint_positive(value: Option<&AnyInt>) -> bool {
+fn is_integer_positive(value: Option<&Integer>) -> bool {
     match value {
         None => true,
         Some(any) => match any {
-            AnyInt::I64(i) => *i >= 0,
-            AnyInt::BigInt(b) => !std::matches!(b.sign(), Sign::Minus),
+            Integer::I64(i) => *i >= 0,
+            Integer::BigInt(b) => !std::matches!(b.sign(), Sign::Minus),
         },
     }
 }
@@ -99,8 +103,8 @@ pub(crate) fn type_qualifier_boolean(value: Option<bool>) -> TypeQualifier {
     combine(IonTypeCode::Boolean, q)
 }
 
-pub(crate) fn type_qualifier_integer(any: Option<&AnyInt>) -> TypeQualifier {
-    let t = match is_anyint_positive(any) {
+pub(crate) fn type_qualifier_integer(any: Option<&Integer>) -> TypeQualifier {
+    let t = match is_integer_positive(any) {
         true => IonTypeCode::PositiveInteger,
         false => IonTypeCode::NegativeInteger,
     };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -10,6 +10,7 @@ use crate::result::{decoding_error, decoding_error_raw, IonResult};
 use crate::stream_reader::StreamReader;
 use crate::symbol_table::{Symbol, SymbolTable};
 use crate::types::decimal::Decimal;
+use crate::types::integer::Integer;
 use crate::types::timestamp::Timestamp;
 use crate::{IonType, RawBinaryReader};
 
@@ -274,6 +275,7 @@ impl<R: RawReader> StreamReader for Reader<R> {
             fn ion_type(&self) -> Option<IonType>;
             fn read_null(&mut self) -> IonResult<IonType>;
             fn read_bool(&mut self) -> IonResult<bool>;
+            fn read_integer(&mut self) -> IonResult<Integer>;
             fn read_i64(&mut self) -> IonResult<i64>;
             fn read_f32(&mut self) -> IonResult<f32>;
             fn read_f64(&mut self) -> IonResult<f64>;

--- a/src/stream_reader.rs
+++ b/src/stream_reader.rs
@@ -1,5 +1,6 @@
 use crate::result::IonResult;
 use crate::types::decimal::Decimal;
+use crate::types::integer::Integer;
 use crate::types::timestamp::Timestamp;
 use crate::types::IonType;
 
@@ -78,8 +79,13 @@ pub trait StreamReader {
     fn read_bool(&mut self) -> IonResult<bool>;
 
     /// Attempts to read the current item as an Ion integer and return it as an i64. If the current
-    /// item is not an integer or an IO error is encountered while reading, returns [IonError].
+    /// item is not an integer, the integer is too large to be represented as an `i64`, or an IO
+    /// error is encountered while reading, returns [IonError].
     fn read_i64(&mut self) -> IonResult<i64>;
+
+    /// Attempts to read the current item as an Ion integer and return it as an [Integer]. If the
+    /// current item is not an integer or an IO error is encountered while reading, returns [IonError].
+    fn read_integer(&mut self) -> IonResult<Integer>;
 
     /// Attempts to read the current item as an Ion float and return it as an f32. If the current
     /// item is not a float or an IO error is encountered while reading, returns [IonError].

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -10,6 +10,7 @@ use crate::result::{decoding_error, decoding_error_raw, illegal_operation, IonEr
 use crate::symbol_table::Symbol;
 use crate::system_reader::LstPosition::*;
 use crate::types::decimal::Decimal;
+use crate::types::integer::Integer;
 use crate::types::timestamp::Timestamp;
 use crate::{IonType, RawBinaryReader, StreamReader, SymbolTable};
 
@@ -712,6 +713,7 @@ impl<R: RawReader> StreamReader for SystemReader<R> {
             fn ion_type(&self) -> Option<IonType>;
             fn read_null(&mut self) -> IonResult<IonType>;
             fn read_bool(&mut self) -> IonResult<bool>;
+            fn read_integer(&mut self) -> IonResult<Integer>;
             fn read_i64(&mut self) -> IonResult<i64>;
             fn read_f32(&mut self) -> IonResult<f32>;
             fn read_f64(&mut self) -> IonResult<f64>;

--- a/src/text/parsers/containers.rs
+++ b/src/text/parsers/containers.rs
@@ -218,6 +218,7 @@ mod container_parsing_tests {
     use crate::text::parsers::unit_test_support::{parse_test_err, parse_test_ok};
     use crate::text::text_value::TextValue;
     use crate::types::decimal::Decimal;
+    use crate::types::integer::Integer;
 
     use super::*;
 
@@ -241,8 +242,8 @@ mod container_parsing_tests {
     }
 
     #[rstest]
-    #[case("5,", TextValue::Integer(5).without_annotations())]
-    #[case("foo::bar::5,", TextValue::Integer(5).with_annotations(&["foo", "bar"]))]
+    #[case("5,", TextValue::Integer(Integer::I64(5)).without_annotations())]
+    #[case("foo::bar::5,", TextValue::Integer(Integer::I64(5)).with_annotations(&["foo", "bar"]))]
     #[case("foo::bar,", TextValue::Symbol(text_token("bar")).with_annotations("foo"))]
     #[case("bar]", TextValue::Symbol(text_token("bar")).without_annotations())]
     #[case("7.]", TextValue::Decimal(Decimal::new(7, 0)).without_annotations())]
@@ -259,8 +260,8 @@ mod container_parsing_tests {
     #[rstest]
     #[case("'++',", Some(TextValue::Symbol(text_token("++")).without_annotations()))]
     #[case("foo::'++',", Some(TextValue::Symbol(text_token("++")).with_annotations("foo")))]
-    #[case("5    ,", Some(TextValue::Integer(5).without_annotations()))]
-    #[case("5]", Some(TextValue::Integer(5).without_annotations()))]
+    #[case("5    ,", Some(TextValue::Integer(Integer::I64(5)).without_annotations()))]
+    #[case("5]", Some(TextValue::Integer(Integer::I64(5)).without_annotations()))]
     #[case("]", None)]
     #[case("  ]", None)]
     #[case(" /*comment*/  ]", None)]
@@ -274,9 +275,9 @@ mod container_parsing_tests {
     #[rstest]
     #[case("++ ", TextValue::Symbol(text_token("++")).without_annotations())]
     #[case("foo::++ ", TextValue::Symbol(text_token("++")).with_annotations("foo"))]
-    #[case("5 ", TextValue::Integer(5).without_annotations())]
-    #[case("5)", TextValue::Integer(5).without_annotations())]
-    #[case("foo::bar::5 ", TextValue::Integer(5).with_annotations(&["foo", "bar"]))]
+    #[case("5 ", TextValue::Integer(Integer::I64(5)).without_annotations())]
+    #[case("5)", TextValue::Integer(Integer::I64(5)).without_annotations())]
+    #[case("foo::bar::5 ", TextValue::Integer(Integer::I64(5)).with_annotations(&["foo", "bar"]))]
     //               v--- This zero allows the parser to tell that the previous value is complete.
     #[case("foo::bar 0", TextValue::Symbol(text_token("bar")).with_annotations("foo"))]
     #[case("bar)", TextValue::Symbol(text_token("bar")).without_annotations())]
@@ -294,7 +295,7 @@ mod container_parsing_tests {
     #[rstest]
     #[case("++ ", Some(TextValue::Symbol(text_token("++")).without_annotations()))]
     #[case("foo::++ ", Some(TextValue::Symbol(text_token("++")).with_annotations("foo")))]
-    #[case("5 ", Some(TextValue::Integer(5).without_annotations()))]
+    #[case("5 ", Some(TextValue::Integer(Integer::I64(5)).without_annotations()))]
     #[case(")", None)]
     #[case("  )", None)]
     #[case(" /*comment*/  )", None)]
@@ -306,9 +307,9 @@ mod container_parsing_tests {
     }
 
     #[rstest]
-    #[case("5,", TextValue::Integer(5).without_annotations())]
-    #[case("5  ,", TextValue::Integer(5).without_annotations())]
-    #[case("foo::bar::5,", TextValue::Integer(5).with_annotations(&["foo", "bar"]))]
+    #[case("5,", TextValue::Integer(Integer::I64(5)).without_annotations())]
+    #[case("5  ,", TextValue::Integer(Integer::I64(5)).without_annotations())]
+    #[case("foo::bar::5,", TextValue::Integer(Integer::I64(5)).with_annotations(&["foo", "bar"]))]
     #[case("foo::bar,", TextValue::Symbol(text_token("bar")).with_annotations("foo"))]
     #[case("bar}", TextValue::Symbol(text_token("bar")).without_annotations())]
     #[case("7.}", TextValue::Decimal(Decimal::new(7, 0)).without_annotations())]

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -38,6 +38,7 @@ mod parse_top_level_values_tests {
     use crate::text::parsers::unit_test_support::{parse_test_ok, parse_unwrap};
     use crate::text::parsers::value::value;
     use crate::text::text_value::TextValue;
+    use crate::types::integer::Integer;
     use crate::IonType;
 
     use super::*;
@@ -92,7 +93,7 @@ mod parse_top_level_values_tests {
     // Here, 'END' is simply an unrelated symbol value that the parser knows to ignore.
     #[case("foo::bar::baz END", &["foo", "bar"], TextValue::Symbol(text_token("baz")))]
     #[case("foo::bar::baz END", &["foo", "bar"], TextValue::Symbol(text_token("baz")))]
-    #[case("foo::'bar'::7 END", &["foo", "bar"], TextValue::Integer(7))]
+    #[case("foo::'bar'::7 END", &["foo", "bar"], TextValue::Integer(Integer::I64(7)))]
     #[case("'foo'::'bar'::{ END", &["foo", "bar"], TextValue::StructStart)]
     #[case("'foo bar'::false END", &["foo bar"], TextValue::Boolean(false))]
     fn test_parse_annotated_value(

--- a/src/text/text_data_source.rs
+++ b/src/text/text_data_source.rs
@@ -25,7 +25,7 @@ impl<'a> TextIonDataSource for &'a str {
     }
 }
 
-impl<'a> TextIonDataSource for &'a &[u8] {
+impl<'a> TextIonDataSource for &'a [u8] {
     type TextSource = io::Cursor<Self>;
 
     fn to_text_ion_data_source(self) -> Self::TextSource {

--- a/src/text/text_value.rs
+++ b/src/text/text_value.rs
@@ -1,5 +1,6 @@
 use crate::raw_symbol_token::RawSymbolToken;
 use crate::types::decimal::Decimal;
+use crate::types::integer::Integer;
 use crate::types::timestamp::Timestamp;
 use crate::IonType;
 
@@ -46,7 +47,7 @@ impl PartialEq<TextValue> for AnnotatedTextValue {
 pub(crate) enum TextValue {
     Null(IonType),
     Boolean(bool),
-    Integer(i64),
+    Integer(Integer),
     Float(f64),
     Decimal(Decimal),
     Timestamp(Timestamp),

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -1,0 +1,201 @@
+use crate::result::{decoding_error, IonError};
+use crate::value::Element;
+use num_bigint::{BigInt, BigUint};
+use num_traits::ToPrimitive;
+use std::ops::Neg;
+
+/// Provides convenient integer accessors for integer values that are like [`Integer`]
+pub trait IntAccess {
+    /// Returns the value as an `i64` if it can be represented as such.
+    ///
+    /// ## Usage
+    /// ```
+    /// # use ion_rs::value::*;
+    /// # use ion_rs::value::owned::*;
+    /// # use ion_rs::value::borrowed::*;
+    /// # use ion_rs::types::integer::*;
+    /// # use num_bigint::*;
+    /// let big_int = Integer::BigInt(BigInt::from(100));
+    /// let i64_int = Integer::I64(100);
+    /// assert_eq!(big_int.as_i64(), i64_int.as_i64());
+    ///
+    /// // works on element too
+    /// let big_elem: OwnedElement = OwnedValue::Integer(big_int).into();
+    /// let i64_elem: BorrowedElement = BorrowedValue::Integer(i64_int).into();
+    ///
+    /// assert_eq!(big_elem.as_i64(), i64_elem.as_i64());
+    /// ```
+    fn as_i64(&self) -> Option<i64>;
+
+    /// Returns a reference as a [`BigInt`] if it is represented as such.  Note that this
+    /// method may return `None` if the underlying representation *is not* stored in a [`BigInt`]
+    /// such as if it is represented as an `i64` so it is somewhat asymmetric with respect
+    /// to [`IntAccess::as_i64`].
+    ///
+    /// ## Usage
+    /// ```
+    /// # use ion_rs::value::*;
+    /// # use ion_rs::value::owned::*;
+    /// # use ion_rs::value::borrowed::*;
+    /// # use ion_rs::types::integer::*;
+    /// # use num_bigint::*;
+    /// # use std::str::FromStr;
+    /// let big_int = Integer::BigInt(BigInt::from(100));
+    /// assert_eq!(BigInt::from_str("100").unwrap(), *big_int.as_big_int().unwrap());
+    /// let i64_int = Integer::I64(100);
+    /// assert_eq!(None, i64_int.as_big_int());
+    ///
+    /// // works on element too
+    /// let big_elem: BorrowedElement = BorrowedValue::Integer(big_int).into();
+    /// assert_eq!(BigInt::from_str("100").unwrap(), *big_elem.as_big_int().unwrap());
+    /// let i64_elem: OwnedElement = OwnedValue::Integer(i64_int).into();
+    /// assert_eq!(None, i64_elem.as_big_int());
+    /// ```
+    fn as_big_int(&self) -> Option<&BigInt>;
+}
+
+/// Represents a UInt of any size. Used for reading binary integers and symbol IDs.
+///
+/// Equality tests do NOT compare across storage types; U64(1) is not the same as BigUInt(1).
+#[derive(Debug, Clone, PartialEq)]
+pub enum UInteger {
+    U64(u64),
+    BigUInt(BigUint),
+}
+
+impl From<UInteger> for Integer {
+    fn from(value: UInteger) -> Self {
+        match value {
+            UInteger::U64(uint) => {
+                if let Ok(signed) = i64::try_from(uint) {
+                    // The u64 was successfully converted to an i64
+                    Integer::I64(signed)
+                } else {
+                    // The u64 was slightly too big to be represented as an i64; it required the
+                    // 64th bit to store the magnitude. Up-convert it to a BigInt.
+                    Integer::BigInt(BigInt::from(uint))
+                }
+            }
+            UInteger::BigUInt(big_uint) => Integer::BigInt(BigInt::from(big_uint)),
+        }
+    }
+}
+
+impl TryFrom<&UInteger> for i64 {
+    type Error = IonError;
+
+    fn try_from(value: &UInteger) -> Result<Self, Self::Error> {
+        match value {
+            UInteger::U64(uint) => i64::try_from(*uint).or_else(|_| {
+                decoding_error(format!(
+                    "Unsigned integer {:?} was too large to be represented as an i64.",
+                    uint
+                ))
+            }),
+            UInteger::BigUInt(big_uint) => i64::try_from(big_uint).or_else(|_| {
+                decoding_error(format!(
+                    "Unsigned integer {:?} was too large to be represented as an i64.",
+                    big_uint
+                ))
+            }),
+        }
+    }
+}
+
+impl TryFrom<&UInteger> for usize {
+    type Error = IonError;
+
+    fn try_from(value: &UInteger) -> Result<Self, Self::Error> {
+        match value {
+            UInteger::U64(uint) => usize::try_from(*uint).or_else(|_| {
+                decoding_error(format!(
+                    "Unsigned integer {:?} was too large to be represented as an usize.",
+                    uint
+                ))
+            }),
+            UInteger::BigUInt(big_uint) => usize::try_from(big_uint).or_else(|_| {
+                decoding_error(format!(
+                    "Unsigned integer {:?} was too large to be represented as an usize.",
+                    big_uint
+                ))
+            }),
+        }
+    }
+}
+
+/// Container for either an integer that can fit in a 64-bit word or an arbitrarily sized
+/// [`BigInt`].
+///
+/// See [`IntAccess`] for common operations.
+#[derive(Debug, Clone)]
+pub enum Integer {
+    I64(i64),
+    BigInt(BigInt),
+}
+
+impl IntAccess for Integer {
+    #[inline]
+    fn as_i64(&self) -> Option<i64> {
+        match &self {
+            Integer::I64(i) => Some(*i),
+            Integer::BigInt(big) => big.to_i64(),
+        }
+    }
+
+    #[inline]
+    fn as_big_int(&self) -> Option<&BigInt> {
+        match &self {
+            Integer::I64(_) => None,
+            Integer::BigInt(big) => Some(big),
+        }
+    }
+}
+
+impl PartialEq for Integer {
+    fn eq(&self, other: &Self) -> bool {
+        use Integer::*;
+        match self {
+            I64(my_i64) => match other {
+                I64(other_i64) => my_i64 == other_i64,
+                BigInt(other_bi) => Some(*my_i64) == other_bi.to_i64(),
+            },
+            BigInt(my_bi) => match other {
+                I64(other_i64) => my_bi.to_i64() == Some(*other_i64),
+                BigInt(other_bi) => my_bi == other_bi,
+            },
+        }
+    }
+}
+
+impl Eq for Integer {}
+
+impl Neg for Integer {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        use Integer::*;
+        match self {
+            I64(value) => I64(-value),
+            BigInt(value) => BigInt(-value),
+        }
+    }
+}
+
+impl<T> IntAccess for T
+where
+    T: Element,
+{
+    fn as_i64(&self) -> Option<i64> {
+        match self.as_integer() {
+            Some(any) => any.as_i64(),
+            _ => None,
+        }
+    }
+
+    fn as_big_int(&self) -> Option<&BigInt> {
+        match self.as_integer() {
+            Some(any) => any.as_big_int(),
+            _ => None,
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -6,6 +6,7 @@ pub type SymbolId = usize;
 
 pub mod coefficient;
 pub mod decimal;
+pub mod integer;
 pub mod magnitude;
 pub mod timestamp;
 

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -354,6 +354,12 @@ impl TimestampBuilder {
     where
         D: Datelike + Timelike + Debug,
     {
+        if self.year <= 0 || self.year > 9999 {
+            return illegal_operation(format!(
+                "Timestamp year '{}' out of range (1-9999)",
+                self.year
+            ));
+        }
         datetime = datetime.with_year(self.year as i32).ok_or_else(|| {
             illegal_operation_raw(format!("specified year ('{}') is invalid", self.year))
         })?;

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -9,9 +9,10 @@
 
 use super::{Element, ImportSource, Sequence, Struct, SymbolToken};
 use crate::types::decimal::Decimal;
+use crate::types::integer::Integer;
 use crate::types::timestamp::Timestamp;
 use crate::types::SymbolId;
-use crate::value::{AnyInt, Builder};
+use crate::value::Builder;
 use crate::IonType;
 use num_bigint::BigInt;
 use std::collections::HashMap;
@@ -169,11 +170,11 @@ impl<'val> Builder for BorrowedElement<'val> {
     }
 
     fn new_i64(int: i64) -> Self::Element {
-        BorrowedValue::Integer(AnyInt::I64(int)).into()
+        BorrowedValue::Integer(Integer::I64(int)).into()
     }
 
     fn new_big_int(big_int: BigInt) -> Self::Element {
-        BorrowedValue::Integer(AnyInt::BigInt(big_int)).into()
+        BorrowedValue::Integer(Integer::BigInt(big_int)).into()
     }
 
     fn new_decimal(decimal: Decimal) -> Self::Element {
@@ -390,7 +391,7 @@ impl<'val> Eq for BorrowedStruct<'val> {}
 #[derive(Debug, Clone, PartialEq)]
 pub enum BorrowedValue<'val> {
     Null(IonType),
-    Integer(AnyInt),
+    Integer(Integer),
     Float(f64),
     Decimal(Decimal),
     Timestamp(Timestamp),
@@ -441,13 +442,13 @@ impl<'val> From<IonType> for BorrowedElement<'val> {
 
 impl<'val> From<i64> for BorrowedElement<'val> {
     fn from(i64_val: i64) -> Self {
-        BorrowedValue::Integer(AnyInt::I64(i64_val)).into()
+        BorrowedValue::Integer(Integer::I64(i64_val)).into()
     }
 }
 
 impl<'val> From<BigInt> for BorrowedElement<'val> {
     fn from(big_int_val: BigInt) -> Self {
-        BorrowedValue::Integer(AnyInt::BigInt(big_int_val)).into()
+        BorrowedValue::Integer(Integer::BigInt(big_int_val)).into()
     }
 }
 
@@ -530,7 +531,7 @@ impl<'val> Element for BorrowedElement<'val> {
         matches!(&self.value, BorrowedValue::Null(_))
     }
 
-    fn as_any_int(&self) -> Option<&AnyInt> {
+    fn as_integer(&self) -> Option<&Integer> {
         match &self.value {
             BorrowedValue::Integer(i) => Some(i),
             _ => None,

--- a/src/value/ion_c_reader.rs
+++ b/src/value/ion_c_reader.rs
@@ -1,0 +1,220 @@
+use crate::result::IonResult;
+use crate::value::owned::{text_token, OwnedElement, OwnedSequence, OwnedStruct};
+use crate::value::reader::ElementReader;
+use crate::IonType;
+use ion_c_sys::reader::{IonCReader, IonCReaderHandle};
+use ion_c_sys::ION_TYPE;
+
+struct IonCReaderIterator<'a> {
+    reader: IonCReaderHandle<'a>,
+    done: bool,
+}
+
+impl<'a> IonCReaderIterator<'a> {
+    /// Moves the reader forward converting to `IonResult`.
+    #[inline]
+    fn read_next(&mut self) -> IonResult<ION_TYPE> {
+        Ok(self.reader.next()?)
+    }
+
+    /// Materializes a value with an [`IonType`]
+    fn materialize(&mut self, ion_type: IonType) -> IonResult<OwnedElement> {
+        use crate::types::integer::Integer;
+        use crate::value::owned::OwnedValue::*;
+        use crate::value::owned::{OwnedSymbolToken, OwnedValue};
+        // TODO when doing BorrowedElement, we can compare against the input buffer if
+        //      there is one and be smart about when to materialize strings...
+
+        // TODO deal with local SIDs/sources, this requires deeper integration with Ion C
+        //      than we're willing to do right now...
+
+        let annotations: Vec<OwnedSymbolToken> = self
+            .reader
+            .get_annotations()?
+            .iter()
+            .map(|s| (*s).into())
+            .collect();
+
+        let value: OwnedValue = if self.reader.is_null()? {
+            Null(ion_type)
+        } else {
+            match ion_type {
+                // technically unreachable...
+                IonType::Null => Null(ion_type),
+                IonType::Boolean => Boolean(self.reader.read_bool()?),
+                // TODO deal with the big integer case
+                IonType::Integer => Integer(if let Ok(ival) = self.reader.read_i64() {
+                    Integer::I64(ival)
+                } else {
+                    Integer::BigInt(self.reader.read_bigint()?)
+                }),
+                IonType::Float => Float(self.reader.read_f64()?),
+                IonType::Decimal => Decimal(self.reader.read_bigdecimal()?.into()),
+                IonType::Timestamp => Timestamp(self.reader.read_datetime()?.into()),
+                // TODO get the `ION_SYMBOL` value and extract the complete symbolic information.
+                IonType::Symbol => Symbol(self.reader.read_string()?.as_str().into()),
+                IonType::String => String(self.reader.read_string()?.as_str().into()),
+                IonType::Clob => Clob(self.reader.read_bytes()?),
+                IonType::Blob => Blob(self.reader.read_bytes()?),
+                IonType::List => List(self.materialize_sequence()?),
+                IonType::SExpression => SExpression(self.materialize_sequence()?),
+                IonType::Struct => Struct(self.materialize_struct()?),
+            }
+        };
+
+        Ok(OwnedElement::new(annotations, value))
+    }
+
+    /// Materializes a top-level value with a known Ion C type.
+    #[inline]
+    fn materialize_top_level(&mut self, ionc_type: ION_TYPE) -> IonResult<OwnedElement> {
+        self.materialize(ionc_type.try_into()?)
+    }
+
+    fn materialize_sequence(&mut self) -> IonResult<OwnedSequence> {
+        let mut children = Vec::new();
+        self.reader.step_in()?;
+        loop {
+            let ionc_type = self.read_next()?;
+            if let ion_c_sys::ION_TYPE_EOF = ionc_type {
+                break;
+            }
+
+            children.push(self.materialize_top_level(ionc_type)?);
+        }
+        self.reader.step_out()?;
+        Ok(children.into_iter().collect())
+    }
+
+    fn materialize_struct(&mut self) -> IonResult<OwnedStruct> {
+        let mut fields = vec![];
+        self.reader.step_in()?;
+        loop {
+            let ionc_type = self.read_next()?;
+            if let ion_c_sys::ION_TYPE_EOF = ionc_type {
+                break;
+            }
+
+            // TODO get the `ION_SYMBOL` value and extract the complete symbolic information.
+            let token = text_token(self.reader.get_field_name()?.as_str());
+            let elem = self.materialize_top_level(ionc_type)?;
+            fields.push((token, elem));
+        }
+        self.reader.step_out()?;
+        Ok(fields.into_iter().collect())
+    }
+}
+
+impl<'a> Iterator for IonCReaderIterator<'a> {
+    type Item = IonResult<OwnedElement>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // if we previously returned an error, we're done
+        if self.done {
+            return None;
+        }
+        // perform scaffolding over the Some/None part of the API
+        match self.read_next() {
+            Ok(ionc_type) => {
+                if let ion_c_sys::ION_TYPE_EOF = ionc_type {
+                    // reader says nothing, we're done!
+                    self.done = true;
+                    None
+                } else {
+                    // we've got something
+                    let result = self.materialize_top_level(ionc_type);
+                    if result.is_err() {
+                        // a failure means the iterator is done
+                        self.done = true;
+                    }
+                    Some(result)
+                }
+            }
+            // next failed...
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+pub struct IonCElementReader;
+
+impl ElementReader for IonCElementReader {
+    fn iterate_over<'a, 'b>(
+        &'a self,
+        data: &'b [u8],
+    ) -> IonResult<Box<dyn Iterator<Item = IonResult<OwnedElement>> + 'b>> {
+        let reader = IonCReaderHandle::try_from(data)?;
+
+        Ok(Box::new(IonCReaderIterator {
+            reader,
+            done: false,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod ion_c_reader_tests {
+    use super::*;
+    use crate::value::reader::ion_c_element_reader;
+    use ion_c_sys::result::{IonCError, Position};
+    use ion_c_sys::{
+        ion_error_code_IERR_INVALID_BINARY, ion_error_code_IERR_INVALID_STATE,
+        ion_error_code_IERR_NULL_VALUE,
+    };
+    use rstest::*;
+
+    #[rstest]
+    #[case::unknown_local_symbol(
+    br#"
+            $ion_1_0
+            $ion_symbol_table::{
+                symbols:[null]
+            }
+            $10
+        "#,
+    vec![
+    Err(IonCError::from(ion_error_code_IERR_NULL_VALUE)
+    .with_position(Position::text(124, 4, 8))
+    .into())
+    ]
+    )]
+    #[case::unknown_shared_symbol_field_name(
+    br#"
+            $ion_1_0
+            $ion_symbol_table::{
+                imports:[{name: "my_table", version: 1, max_id: 100}]
+            }
+            {$10:5}
+        "#,
+    vec![
+    Err(IonCError::from(ion_error_code_IERR_NULL_VALUE)
+    .with_position(Position::text(157, 1, 5))
+    .into())
+    ]
+    )]
+    #[case::illegal_negative_zero_int(
+    &[0xE0, 0x01, 0x00, 0xEA, 0x30],
+    vec![
+    Err(IonCError::from(ion_error_code_IERR_INVALID_BINARY)
+    .with_position(Position::binary(5))
+    .into())
+    ]
+    )]
+    #[case::illegal_fcode(
+    &[0xE0, 0x01, 0x00, 0xEA, 0xF0],
+    vec![
+    Err(IonCError::from(ion_error_code_IERR_INVALID_STATE)
+    .with_position(Position::binary(5))
+    .into())
+    ]
+    )]
+    /// Like read_and_compare, but against results (which makes it easier to test for errors).
+    fn read_and_expect(
+        #[case] input: &[u8],
+        #[case] expected: Vec<IonResult<OwnedElement>>,
+    ) -> IonResult<()> {
+        let actual: Vec<_> = ion_c_element_reader().iterate_over(input)?.collect();
+        assert_eq!(expected, actual);
+        Ok(())
+    }
+}

--- a/src/value/native_reader.rs
+++ b/src/value/native_reader.rs
@@ -1,0 +1,126 @@
+use crate::raw_reader::RawReader;
+use crate::result::IonResult;
+use crate::text::raw_text_reader::RawTextReader;
+use crate::value::owned;
+use crate::value::owned::{OwnedElement, OwnedSequence, OwnedStruct, OwnedValue};
+use crate::value::reader::ElementReader;
+use crate::{IonType, RawBinaryReader, Reader, StreamItem, StreamReader};
+
+/// Provides an implementation of [ElementReader] that is backed by a native Rust [Reader].
+pub struct NativeElementReader;
+
+struct NativeElementIterator<R: RawReader> {
+    reader: Reader<R>,
+}
+
+impl<R: RawReader> Iterator for NativeElementIterator<R> {
+    type Item = IonResult<OwnedElement>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.materialize_next().transpose()
+    }
+}
+
+impl ElementReader for NativeElementReader {
+    fn iterate_over<'a, 'b>(
+        &'a self,
+        data: &'b [u8],
+    ) -> IonResult<Box<dyn Iterator<Item = IonResult<OwnedElement>> + 'b>> {
+        // Match against the slice to see if it starts with the binary IVM
+        match data {
+            &[0xe0, 0x01, 0x00, 0xea, ..] => {
+                // It's binary! Construct a binary Reader.
+                let raw_reader = RawBinaryReader::new(data);
+                let reader = Reader::new(raw_reader);
+                let iterator = NativeElementIterator { reader };
+                Ok(Box::new(iterator))
+            }
+            _ => {
+                // It's not binary! Construct a text Reader.
+                let raw_reader = RawTextReader::new(data);
+                let reader = Reader::new(raw_reader);
+                let iterator = NativeElementIterator { reader };
+                Ok(Box::new(iterator))
+            }
+        }
+    }
+}
+
+
+impl<R: RawReader> NativeElementIterator<R> {
+    /// Recursively materialize the next Ion value in the stream and return it as `Ok(Some(element))`.
+    /// If there are no more values at this level, returns `Ok(None)`.
+    /// If an error occurs while materializing the value, returns an `Err`.
+    fn materialize_next(&mut self) -> IonResult<Option<OwnedElement>> {
+        // Advance the reader to the next value
+        let current_item = self.reader.next()?;
+
+        // Collect this item's annotations into a Vec. We have to do this before materializing the
+        // value itself because materializing a collection requires advancing the reader further.
+        let mut annotations = Vec::new();
+        for annotation in self.reader.annotations() {
+            // If the annotation couldn't be resolved to text, early return the error.
+            let annotation = annotation?;
+            let symbol = owned::text_token(annotation.as_ref());
+            annotations.push(symbol);
+        }
+
+        let value = match current_item {
+            // No more values at this level of the stream
+            StreamItem::Nothing => return Ok(None),
+            // This is a typed null
+            StreamItem::Null(ion_type) => OwnedValue::Null(ion_type),
+            // This is a non-null value
+            StreamItem::Value(ion_type) => {
+                use IonType::*;
+                match ion_type {
+                    Null => unreachable!("non-null value had IonType::Null"),
+                    Boolean => OwnedValue::Boolean(self.reader.read_bool()?),
+                    Integer => OwnedValue::Integer(self.reader.read_integer()?),
+                    Float => OwnedValue::Float(self.reader.read_f64()?),
+                    Decimal => OwnedValue::Decimal(self.reader.read_decimal()?),
+                    Timestamp => OwnedValue::Timestamp(self.reader.read_timestamp()?),
+                    Symbol => {
+                        OwnedValue::Symbol(owned::text_token(self.reader.read_symbol()?.as_ref()))
+                    }
+                    String => OwnedValue::String(self.reader.read_string()?),
+                    Clob => OwnedValue::Clob(self.reader.read_clob()?),
+                    Blob => OwnedValue::Blob(self.reader.read_blob()?),
+                    // It's a collection; recursively materialize all of this value's children
+                    List => OwnedValue::List(self.materialize_sequence()?),
+                    SExpression => OwnedValue::SExpression(self.materialize_sequence()?),
+                    Struct => OwnedValue::Struct(self.materialize_struct()?),
+                }
+            }
+        };
+
+        Ok(Some(OwnedElement::new(annotations, value)))
+    }
+
+    /// Steps into the current sequence and materializes each of its children to construct
+    /// an [OwnedSequence]. When all of the the children have been materialized, steps out.
+    /// The reader MUST be positioned over a list or s-expression when this is called.
+    fn materialize_sequence(&mut self) -> IonResult<OwnedSequence> {
+        let mut child_elements = Vec::new();
+        self.reader.step_in()?;
+        while let Some(element) = self.materialize_next()? {
+            child_elements.push(element);
+        }
+        self.reader.step_out()?;
+        Ok(OwnedSequence::new(child_elements))
+    }
+
+    /// Steps into the current struct and materializes each of its fields to construct
+    /// an [OwnedStruct]. When all of the the fields have been materialized, steps out.
+    /// The reader MUST be positioned over a struct when this is called.
+    fn materialize_struct(&mut self) -> IonResult<OwnedStruct> {
+        let mut child_elements = Vec::new();
+        self.reader.step_in()?;
+        while let Some(element) = self.materialize_next()? {
+            let field = self.reader.field_name()?;
+            child_elements.push((owned::text_token(field.as_ref()), element));
+        }
+        self.reader.step_out()?;
+        Ok(OwnedStruct::from_iter(child_elements.into_iter()))
+    }
+}

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -5,8 +5,9 @@
 //! This API is simpler to manage with respect to borrowing lifetimes, but requires full
 //! ownership of data to do so.
 
-use super::{AnyInt, Element, ImportSource, Sequence, Struct, SymbolToken};
+use super::{Element, ImportSource, Sequence, Struct, SymbolToken};
 use crate::types::decimal::Decimal;
+use crate::types::integer::Integer;
 use crate::types::timestamp::Timestamp;
 use crate::types::SymbolId;
 use crate::value::Builder;
@@ -172,11 +173,11 @@ impl Builder for OwnedElement {
     }
 
     fn new_i64(int: i64) -> Self::Element {
-        OwnedValue::Integer(AnyInt::I64(int)).into()
+        OwnedValue::Integer(Integer::I64(int)).into()
     }
 
     fn new_big_int(big_int: BigInt) -> Self::Element {
-        OwnedValue::Integer(AnyInt::BigInt(big_int)).into()
+        OwnedValue::Integer(Integer::BigInt(big_int)).into()
     }
 
     fn new_decimal(decimal: Decimal) -> Self::Element {
@@ -392,7 +393,7 @@ impl Eq for OwnedStruct {}
 #[derive(Debug, Clone, PartialEq)]
 pub enum OwnedValue {
     Null(IonType),
-    Integer(AnyInt),
+    Integer(Integer),
     Float(f64),
     Decimal(Decimal),
     Timestamp(Timestamp),
@@ -442,13 +443,13 @@ impl From<IonType> for OwnedElement {
 
 impl From<i64> for OwnedElement {
     fn from(i64_val: i64) -> Self {
-        OwnedValue::Integer(AnyInt::I64(i64_val)).into()
+        OwnedValue::Integer(Integer::I64(i64_val)).into()
     }
 }
 
 impl From<BigInt> for OwnedElement {
     fn from(big_int_val: BigInt) -> Self {
-        OwnedValue::Integer(AnyInt::BigInt(big_int_val)).into()
+        OwnedValue::Integer(Integer::BigInt(big_int_val)).into()
     }
 }
 
@@ -532,7 +533,7 @@ impl Element for OwnedElement {
         matches!(&self.value, OwnedValue::Null(_))
     }
 
-    fn as_any_int(&self) -> Option<&AnyInt> {
+    fn as_integer(&self) -> Option<&Integer> {
         match &self.value {
             OwnedValue::Integer(i) => Some(i),
             _ => None,

--- a/src/value/reader.rs
+++ b/src/value/reader.rs
@@ -4,14 +4,9 @@
 //! as slices or files.
 
 use crate::result::{decoding_error, IonResult};
-use crate::value::owned::{OwnedElement, OwnedSequence, OwnedStruct, OwnedSymbolToken, OwnedValue};
-use crate::value::AnyInt;
-use crate::IonType;
-use ion_c_sys::reader::{IonCReader, IonCReaderHandle};
-use ion_c_sys::ION_TYPE;
-use std::convert::{TryFrom, TryInto};
-
-use super::owned::text_token;
+use crate::value::ion_c_reader::IonCElementReader;
+use crate::value::native_reader::NativeElementReader;
+use crate::value::owned::OwnedElement;
 
 // TODO add/refactor trait/implementation for borrowing over some context
 //      we could make it generic with generic associated types or just have a lifetime
@@ -71,170 +66,29 @@ pub trait ElementReader {
     }
 }
 
-struct IonCReaderIterator<'a> {
-    reader: IonCReaderHandle<'a>,
-    done: bool,
-}
-
-impl<'a> IonCReaderIterator<'a> {
-    /// Moves the reader forward converting to `IonResult`.
-    #[inline]
-    fn read_next(&mut self) -> IonResult<ION_TYPE> {
-        Ok(self.reader.next()?)
-    }
-
-    /// Materializes a value with an [`IonType`]
-    fn materialize(&mut self, ion_type: IonType) -> IonResult<OwnedElement> {
-        use OwnedValue::*;
-        // TODO when doing BorrowedElement, we can compare against the input buffer if
-        //      there is one and be smart about when to materialize strings...
-
-        // TODO deal with local SIDs/sources, this requires deeper integration with Ion C
-        //      than we're willing to do right now...
-
-        let annotations: Vec<OwnedSymbolToken> = self
-            .reader
-            .get_annotations()?
-            .iter()
-            .map(|s| (*s).into())
-            .collect();
-
-        let value: OwnedValue = if self.reader.is_null()? {
-            Null(ion_type)
-        } else {
-            match ion_type {
-                // technically unreachable...
-                IonType::Null => Null(ion_type),
-                IonType::Boolean => Boolean(self.reader.read_bool()?),
-                // TODO deal with the big integer case
-                IonType::Integer => Integer(if let Ok(ival) = self.reader.read_i64() {
-                    AnyInt::I64(ival)
-                } else {
-                    AnyInt::BigInt(self.reader.read_bigint()?)
-                }),
-                IonType::Float => Float(self.reader.read_f64()?),
-                IonType::Decimal => Decimal(self.reader.read_bigdecimal()?.into()),
-                IonType::Timestamp => Timestamp(self.reader.read_datetime()?.into()),
-                // TODO get the `ION_SYMBOL` value and extract the complete symbolic information.
-                IonType::Symbol => Symbol(self.reader.read_string()?.as_str().into()),
-                IonType::String => String(self.reader.read_string()?.as_str().into()),
-                IonType::Clob => Clob(self.reader.read_bytes()?),
-                IonType::Blob => Blob(self.reader.read_bytes()?),
-                IonType::List => List(self.materialize_sequence()?),
-                IonType::SExpression => SExpression(self.materialize_sequence()?),
-                IonType::Struct => Struct(self.materialize_struct()?),
-            }
-        };
-
-        Ok(OwnedElement::new(annotations, value))
-    }
-
-    /// Materializes a top-level value with a known Ion C type.
-    #[inline]
-    fn materialize_top_level(&mut self, ionc_type: ION_TYPE) -> IonResult<OwnedElement> {
-        self.materialize(ionc_type.try_into()?)
-    }
-
-    fn materialize_sequence(&mut self) -> IonResult<OwnedSequence> {
-        let mut children = Vec::new();
-        self.reader.step_in()?;
-        loop {
-            let ionc_type = self.read_next()?;
-            if let ion_c_sys::ION_TYPE_EOF = ionc_type {
-                break;
-            }
-
-            children.push(self.materialize_top_level(ionc_type)?);
-        }
-        self.reader.step_out()?;
-        Ok(children.into_iter().collect())
-    }
-
-    fn materialize_struct(&mut self) -> IonResult<OwnedStruct> {
-        let mut fields = vec![];
-        self.reader.step_in()?;
-        loop {
-            let ionc_type = self.read_next()?;
-            if let ion_c_sys::ION_TYPE_EOF = ionc_type {
-                break;
-            }
-
-            // TODO get the `ION_SYMBOL` value and extract the complete symbolic information.
-            let token = text_token(self.reader.get_field_name()?.as_str());
-            let elem = self.materialize_top_level(ionc_type)?;
-            fields.push((token, elem));
-        }
-        self.reader.step_out()?;
-        Ok(fields.into_iter().collect())
-    }
-}
-
-impl<'a> Iterator for IonCReaderIterator<'a> {
-    type Item = IonResult<OwnedElement>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // if we previously returned an error, we're done
-        if self.done {
-            return None;
-        }
-        // perform scaffolding over the Some/None part of the API
-        match self.read_next() {
-            Ok(ionc_type) => {
-                if let ion_c_sys::ION_TYPE_EOF = ionc_type {
-                    // reader says nothing, we're done!
-                    self.done = true;
-                    None
-                } else {
-                    // we've got something
-                    let result = self.materialize_top_level(ionc_type);
-                    if result.is_err() {
-                        // a failure means the iterator is done
-                        self.done = true;
-                    }
-                    Some(result)
-                }
-            }
-            // next failed...
-            Err(e) => Some(Err(e)),
-        }
-    }
-}
-
-struct IonCElementReader;
-
-impl ElementReader for IonCElementReader {
-    fn iterate_over<'a, 'b>(
-        &'a self,
-        data: &'b [u8],
-    ) -> IonResult<Box<dyn Iterator<Item = IonResult<OwnedElement>> + 'b>> {
-        let reader = IonCReaderHandle::try_from(data)?;
-
-        Ok(Box::new(IonCReaderIterator {
-            reader,
-            done: false,
-        }))
-    }
-}
-
 /// Returns an implementation defined [`ElementReader`] instance.
 pub fn element_reader() -> impl ElementReader {
+    ion_c_element_reader()
+}
+
+pub fn native_element_reader() -> NativeElementReader {
+    NativeElementReader {}
+}
+
+pub fn ion_c_element_reader() -> IonCElementReader {
     IonCElementReader {}
 }
 
 #[cfg(test)]
 mod reader_tests {
     use super::*;
+    use crate::types::integer::Integer;
     use crate::types::timestamp::Timestamp as TS;
     use crate::value::owned::OwnedValue::*;
     use crate::value::owned::*;
-    use crate::value::{AnyInt, Element};
+    use crate::value::Element;
     use crate::IonType;
     use bigdecimal::BigDecimal;
-    use ion_c_sys::result::{IonCError, Position};
-    use ion_c_sys::{
-        ion_error_code_IERR_INVALID_BINARY, ion_error_code_IERR_INVALID_STATE,
-        ion_error_code_IERR_NULL_VALUE,
-    };
     use num_bigint::BigInt;
     use rstest::*;
     use std::str::FromStr;
@@ -286,12 +140,12 @@ mod reader_tests {
             -65536, 65535,
             -4294967296, 4294967295,
             -9007199254740992, 9007199254740991,
-        ].into_iter().map(AnyInt::I64).chain(
+        ].into_iter().map(Integer::I64).chain(
             vec![
                 "-18446744073709551616", "18446744073709551615",
                 "-79228162514264337593543950336", "79228162514264337593543950335",
             ].into_iter()
-            .map(|v| AnyInt::BigInt(BigInt::parse_bytes(v.as_bytes(), 10).unwrap()))
+            .map(|v| Integer::BigInt(BigInt::parse_bytes(v.as_bytes(), 10).unwrap()))
         ).map(|ai| Integer(ai).into()).collect(),
     )]
     #[case::int64_threshold_as_big_int(
@@ -299,14 +153,14 @@ mod reader_tests {
         vec![
             "18446744073709551615",
         ].into_iter()
-        .map(|v| AnyInt::BigInt(BigInt::parse_bytes(v.as_bytes(), 10).unwrap())).map(|ai| Integer(ai).into()).collect(),
+        .map(|v| Integer::BigInt(BigInt::parse_bytes(v.as_bytes(), 10).unwrap())).map(|ai| Integer(ai).into()).collect(),
     )]
     #[case::int64_threshold_as_int64(
         &[0xE0, 0x01, 0x00, 0xEA, 0x38, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
         vec![
             "-9223372036854775808",
         ].into_iter()
-        .map(|v| AnyInt::BigInt(BigInt::parse_bytes(v.as_bytes(), 10).unwrap())).map(|ai| Integer(ai).into()).collect(),
+        .map(|v| Integer::BigInt(BigInt::parse_bytes(v.as_bytes(), 10).unwrap())).map(|ai| Integer(ai).into()).collect(),
     )]
     #[case::floats(
         // TODO NaN is Ion Data Model equivalent to itself but not PartialEq
@@ -443,61 +297,6 @@ mod reader_tests {
     fn read_nan() -> IonResult<()> {
         let actual = element_reader().read_one(b"nan")?;
         assert!(actual.as_f64().unwrap().is_nan());
-        Ok(())
-    }
-
-    #[rstest]
-    #[case::unknown_local_symbol(
-        br#"
-            $ion_1_0
-            $ion_symbol_table::{
-                symbols:[null]
-            }
-            $10
-        "#,
-        vec![
-            Err(IonCError::from(ion_error_code_IERR_NULL_VALUE)
-                .with_position(Position::text(124, 4, 8))
-                .into())
-        ]
-    )]
-    #[case::unknown_shared_symbol_field_name(
-        br#"
-            $ion_1_0
-            $ion_symbol_table::{
-                imports:[{name: "my_table", version: 1, max_id: 100}]
-            }
-            {$10:5}
-        "#,
-        vec![
-            Err(IonCError::from(ion_error_code_IERR_NULL_VALUE)
-                .with_position(Position::text(157, 1, 5))
-                .into())
-        ]
-    )]
-    #[case::illegal_negative_zero_int(
-        &[0xE0, 0x01, 0x00, 0xEA, 0x30],
-        vec![
-            Err(IonCError::from(ion_error_code_IERR_INVALID_BINARY)
-                .with_position(Position::binary(5))
-                .into())
-        ]
-    )]
-    #[case::illegal_fcode(
-        &[0xE0, 0x01, 0x00, 0xEA, 0xF0],
-        vec![
-            Err(IonCError::from(ion_error_code_IERR_INVALID_STATE)
-                .with_position(Position::binary(5))
-                .into())
-        ]
-    )]
-    /// Like read_and_compare, but against results (which makes it easier to test for errors).
-    fn read_and_expect(
-        #[case] input: &[u8],
-        #[case] expected: Vec<IonResult<OwnedElement>>,
-    ) -> IonResult<()> {
-        let actual: Vec<_> = element_reader().iterate_over(input)?.collect();
-        assert_eq!(expected, actual);
         Ok(())
     }
 }

--- a/src/value/writer.rs
+++ b/src/value/writer.rs
@@ -3,13 +3,14 @@
 //! Provides utility to serialize Ion data from [`Element`](super::Element) into common targets
 //! such as byte buffers or files.
 
-use super::{AnyInt, Element, Sequence, Struct, SymbolToken};
+use super::{Element, Sequence, Struct, SymbolToken};
 use crate::result::{illegal_operation, IonError, IonResult};
 use crate::IonType;
 use ion_c_sys::writer::{IonCValueWriter, IonCWriter, IonCWriterHandle};
 use ion_c_sys::ION_WRITER_OPTIONS;
 use std::convert::TryInto;
 
+use crate::types::integer::Integer;
 pub use Format::*;
 pub use TextKind::*;
 
@@ -116,12 +117,12 @@ impl<'a> IonCSliceElementWriter<'a> {
                         af_writer.write_bool(try_to!(element.as_bool()))?;
                     }
                     IonType::Integer => {
-                        let any_int = try_to!(element.as_any_int());
+                        let any_int = try_to!(element.as_integer());
                         match any_int {
-                            AnyInt::I64(i64_val) => {
+                            Integer::I64(i64_val) => {
                                 af_writer.write_i64(*i64_val)?;
                             }
-                            AnyInt::BigInt(big_val) => {
+                            Integer::BigInt(big_val) => {
                                 af_writer.write_bigint(big_val)?;
                             }
                         }

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -13,56 +13,6 @@ use test_generator::test_resources;
 /// Buffer size for our writing tests around round-tripping
 const WRITE_BUF_LENGTH: usize = 16 * 1024 * 1024;
 
-/// Files that should always be skipped for some reason.
-const ALL_SKIP_LIST: &[&str] = &[
-    // ion-c does not currently support these
-    // see: https://github.com/amzn/ion-c/blob/master/test/gather_vectors.cpp
-    "ion-tests/iontestdata/good/utf16.ion",
-    "ion-tests/iontestdata/good/utf32.ion",
-    "ion-tests/iontestdata/good/subfieldVarUInt32bit.ion",
-    "ion-tests/iontestdata/good/typecodes/T6-large.10n",
-    "ion-tests/iontestdata/good/typecodes/T7-large.10n",
-    "ion-tests/iontestdata/good/typecodes/type_6_length_0.10n",
-    // these appear to have a problem specific to how we're calling ion-c (amzn/ion-rust#218)
-    "ion-tests/iontestdata/good/item1.10n",
-    "ion-tests/iontestdata/good/subfieldVarInt.ion",
-    // these are symbols with unknown text (amzn/ion-rust#219)
-    "ion-tests/iontestdata/good/symbolExplicitZero.10n",
-    "ion-tests/iontestdata/good/symbolImplicitZero.10n",
-    "ion-tests/iontestdata/good/symbolZero.ion",
-    "ion-tests/iontestdata/good/typecodes/T7-small.10n",
-];
-
-/// Files that should not be tested for equivalence with read_one against read_all
-const READ_ONE_EQUIVS_SKIP_LIST: &[&str] = &[
-    // we need a structural equality (IonEq) for these (amzn/ion-rust#220)
-    "ion-tests/iontestdata/good/floatSpecials.ion",
-];
-
-/// Files that should not be tested for equivalence in round-trip testing
-const ROUND_TRIP_SKIP_LIST: &[&str] = &[
-    // we need a structural equality (IonEq) for these (amzn/ion-rust#220)
-    "ion-tests/iontestdata/good/float32.10n",
-    "ion-tests/iontestdata/good/floatSpecials.ion",
-    "ion-tests/iontestdata/good/non-equivs/floats.ion",
-    // appears to be a bug with Ion C or ion-c-sys (specifically binary) (amzn/ion-rust#235)
-    "ion-tests/iontestdata/good/equivs/bigInts.ion",
-    "ion-tests/iontestdata/good/subfieldUInt.ion",
-];
-
-/// Files that should only be skipped in equivalence file testing
-const EQUIVS_SKIP_LIST: &[&str] = &[];
-
-/// Files that should only be skipped in non-equivalence file testing
-const NON_EQUIVS_SKIP_LIST: &[&str] = &[
-    // we need a structural equality (IonEq) for these (amzn/ion-rust#220)
-    "ion-tests/iontestdata/good/non-equivs/decimals.ion",
-    "ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion",
-    "ion-tests/iontestdata/good/non-equivs/floats.ion",
-    // these have symbols with unknown text (amzn/ion-rust#219)
-    "ion-tests/iontestdata/good/non-equivs/symbolTablesUnknownText.ion",
-];
-
 /// Concatenates two slices of string slices together.
 #[inline]
 fn concat<'a>(left: &[&'a str], right: &[&'a str]) -> Vec<&'a str> {
@@ -80,277 +30,311 @@ fn contains_path(paths: &[&str], file_name: &str) -> bool {
         .any(|p| p == file_name)
 }
 
-fn read_file<R: ElementReader>(reader: &R, file_name: &str) -> IonResult<Vec<OwnedElement>> {
-    // TODO have a better API that doesn't require buffering into memory everything...
-    let data = read(file_name)?;
-    let result = reader.read_all(&data);
+// Statically defined arrays containing test file paths to skip in various contexts.
+type SkipList = &'static [&'static str];
 
-    // do some simple single value reading tests
-    let single_result = reader.read_one(&data);
-    match &result {
-        Ok(elems) => {
-            if elems.len() == 1 {
-                match single_result {
-                    Ok(elem) => {
-                        // only compare if we know equality to work
-                        if !contains_path(READ_ONE_EQUIVS_SKIP_LIST, file_name) {
-                            assert_eq!(elems[0], elem)
-                        }
-                    }
-                    Err(e) => panic!("Expected element {:?}, got {:?}", elems, e),
-                }
-            } else {
-                match single_result {
-                    Ok(elem) => panic!(
-                        "Did not expect element for duplicates: {:?}, {:?}",
-                        elems, elem
-                    ),
-                    Err(e) => match e {
-                        IonError::DecodingError { description: _ } => (),
-                        other => {
-                            panic!("Got an error we did not expect for duplicates: {:?}", other)
-                        }
-                    },
-                }
+trait ElementApi {
+    type ElementReader: ElementReader;
+
+    fn global_skip_list() -> SkipList;
+    fn read_one_equivs_skip_list() -> SkipList;
+    fn round_trip_skip_list() -> SkipList;
+    fn equivs_skip_list() -> SkipList;
+    fn non_equivs_skip_list() -> SkipList;
+
+    fn make_reader() -> Self::ElementReader;
+
+    // TODO: These are currently all ion-c specific method signatures. SliceElementWriter takes a
+    //       lifetime, so we can't specify it as an associated type until GATs is stable. That's
+    //       ok for the moment because we don't have a native ElementWriter to test yet.
+    fn make_text_writer(buffer: &mut [u8]) -> IonResult<SliceElementWriter>;
+    fn make_pretty_text_writer(buffer: &mut [u8]) -> IonResult<SliceElementWriter>;
+    fn make_binary_writer(buffer: &mut [u8]) -> IonResult<SliceElementWriter>;
+
+    /// Asserts the given elements can be round-tripped and equivalent, then returns the new elements.
+    fn assert_round_trip<F>(
+        source_elements: &Vec<OwnedElement>,
+        make_writer: F,
+    ) -> IonResult<Vec<OwnedElement>>
+    where
+        F: FnOnce(&mut [u8]) -> IonResult<SliceElementWriter>,
+    {
+        let mut buf = vec![0u8; WRITE_BUF_LENGTH];
+        let mut writer = make_writer(&mut buf)?;
+        writer.write_all(source_elements)?;
+        let output = writer.finish()?;
+        let new_elements = element_reader().read_all(output)?;
+        assert_eq!(*source_elements, new_elements, "{:?}", output.hex_dump());
+        Ok(new_elements)
+    }
+
+    fn assert_three_way_round_trip<F1, F2>(
+        file_name: &str,
+        first_writer: F1,
+        second_writer: F2,
+    ) -> IonResult<()>
+    where
+        F1: FnOnce(&mut [u8]) -> IonResult<SliceElementWriter>,
+        F2: FnOnce(&mut [u8]) -> IonResult<SliceElementWriter>,
+    {
+        let source_elements = Self::read_file(&Self::make_reader(), file_name)?;
+        if contains_path(Self::round_trip_skip_list(), file_name) {
+            return Ok(());
+        }
+        let first_write_elements = Self::assert_round_trip(&source_elements, first_writer)?;
+        let second_write_elements = Self::assert_round_trip(&first_write_elements, second_writer)?;
+        assert_eq!(source_elements, second_write_elements);
+        Ok(())
+    }
+
+    fn assert_file<T, F: FnOnce() -> IonResult<T>>(
+        skip_list: &[&str],
+        file_name: &str,
+        asserter: F,
+    ) {
+        // TODO if frehberg/test-generator#7 gets implemented we could do a proper ignore
+
+        // print the paths here either way so it is easy to copy/paste to investigate failures
+        // use the --show-output argument to see it
+        if contains_path(skip_list, file_name) {
+            println!("IGNORING: {}", file_name);
+        } else {
+            println!("TESTING: {}", file_name);
+            asserter().unwrap();
+        }
+    }
+
+    /// Parses the elements of a given sequence as text Ion data and tests a grouping on the read
+    /// documents.
+    ///
+    /// For example, for the given group:
+    ///
+    /// ```plain
+    /// embedded_documents::(
+    ///   "a b c"
+    ///   "'a' 'b' 'c'"
+    /// )
+    /// ```
+    ///
+    /// This will parse each string as a [`Vec`] of [`Element`] and apply the `group_assert` function
+    /// for every pair of the parsed data including the identity case (a parsed document is
+    /// compared against itself).
+    fn read_group_embedded<R, S, F>(reader: &R, raw_group: &S, group_assert: &F) -> IonResult<()>
+    where
+        R: ElementReader,
+        S: Sequence,
+        F: Fn(&Vec<OwnedElement>, &Vec<OwnedElement>),
+    {
+        let group_res: IonResult<Vec<_>> = raw_group
+            .iter()
+            .map(|elem| reader.read_all(elem.as_str().unwrap().as_bytes()))
+            .collect();
+        let group = group_res?;
+        for this in group.iter() {
+            for that in group.iter() {
+                group_assert(this, that);
             }
         }
-        Err(_) => assert!(
-            single_result.is_err(),
-            "Expected error from read_one: {:?}",
-            single_result
-        ),
-    };
+        Ok(())
+    }
 
-    result
+    /// Parses a document that has top-level `list`/`sexp` values that represent a *group*.
+    /// If this top-level value is annotated with `embedded_documents`, then [`read_group_embedded`]
+    /// is executed for that grouping.  Otherwise, the `value_assert` function is invoked for
+    /// every pair of values in a group including the identity case (a value in a group is compared
+    /// against itself).
+    ///
+    /// Here is an example with two groups that might be used for equivalence testing:
+    ///
+    /// ```plain
+    /// (name $2 'name')
+    /// embedded_documents::(
+    ///   "a name"
+    ///   "a $2"
+    ///   "'a' 'name'"
+    /// )
+    /// ```
+    ///
+    /// This would have two groups, one with direct values that will be compared and another
+    /// with embedded Ion text that will be parsed and compared.
+    fn read_group<F1, F2>(
+        reader: Self::ElementReader,
+        file_name: &str,
+        value_assert: F1,
+        group_assert: F2,
+    ) -> IonResult<()>
+    where
+        F1: Fn(&OwnedElement, &OwnedElement),
+        F2: Fn(&Vec<OwnedElement>, &Vec<OwnedElement>),
+    {
+        let group_lists = Self::read_file(&reader, file_name)?;
+        for group_list in group_lists.iter() {
+            // every grouping set is a list/sexp
+            // look for the embedded annotation to parse/test as the underlying value
+            let is_embedded = group_list
+                .annotations()
+                .any(|annotation| annotation.text() == Some("embedded_documents"));
+            match (group_list.as_sequence(), is_embedded) {
+                (Some(group), true) => {
+                    Self::read_group_embedded(&reader, group, &group_assert)?;
+                }
+                (Some(group), false) => {
+                    for this in group.iter() {
+                        for that in group.iter() {
+                            value_assert(this, that);
+                        }
+                    }
+                }
+                _ => {
+                    return decoding_error(format!(
+                        "Expected a sequence for group: {:?}",
+                        group_list
+                    ))
+                }
+            };
+        }
+        Ok(())
+    }
+
+    fn read_file(reader: &Self::ElementReader, file_name: &str) -> IonResult<Vec<OwnedElement>> {
+        // TODO have a better API that doesn't require buffering into memory everything...
+        let data = read(file_name)?;
+        let result = reader.read_all(&data);
+
+        // do some simple single value reading tests
+        let single_result = reader.read_one(&data);
+        match &result {
+            Ok(elems) => {
+                if elems.len() == 1 {
+                    match single_result {
+                        Ok(elem) => {
+                            // only compare if we know equality to work
+                            if !contains_path(Self::read_one_equivs_skip_list(), file_name) {
+                                assert_eq!(elems[0], elem)
+                            }
+                        }
+                        Err(e) => panic!("Expected element {:?}, got {:?}", elems, e),
+                    }
+                } else {
+                    match single_result {
+                        Ok(elem) => panic!(
+                            "Did not expect element for duplicates: {:?}, {:?}",
+                            elems, elem
+                        ),
+                        Err(e) => match e {
+                            IonError::DecodingError { description: _ } => (),
+                            other => {
+                                panic!("Got an error we did not expect for duplicates: {:?}", other)
+                            }
+                        },
+                    }
+                }
+            }
+            Err(_) => assert!(
+                single_result.is_err(),
+                "Expected error from read_one: {:?}",
+                single_result
+            ),
+        };
+
+        result
+    }
 }
 
-/// Asserts the given elements can be round-tripped and equivalent, then returns the new elements.
-fn assert_round_trip<F>(
-    source_elements: &Vec<OwnedElement>,
-    make_writer: F,
-) -> IonResult<Vec<OwnedElement>>
-where
-    F: FnOnce(&mut [u8]) -> IonResult<SliceElementWriter>,
-{
-    let mut buf = vec![0u8; WRITE_BUF_LENGTH];
-    let mut writer = make_writer(&mut buf)?;
-    writer.write_all(source_elements)?;
-    let output = writer.finish()?;
-    let new_elements = element_reader().read_all(output)?;
-    assert_eq!(*source_elements, new_elements, "{:?}", output.hex_dump());
-    Ok(new_elements)
-}
-
-fn assert_three_way_round_trip<F1, F2>(
+/// Reads the data in `file_name` and writes it to an in-memory buffer (`b1`) using the writer provided
+/// by `first_writer_provider`. Then reads the data from the `b1` and writes it to another buffer (`b2`)
+/// using the writer provided by `second_writer_provider`. Finally, compares the data read from `b2`
+/// to the data in `file_name` and asserts that they are equivalent, demonstrating that no data has
+/// been lost.
+fn good_roundtrip<E: ElementApi, F1, F2>(
+    _element_api: E,
+    skip_list: &[&str],
     file_name: &str,
-    first_writer: F1,
-    second_writer: F2,
-) -> IonResult<()>
-where
+    first_writer_provider: F1,
+    second_writer_provider: F2,
+) where
     F1: FnOnce(&mut [u8]) -> IonResult<SliceElementWriter>,
     F2: FnOnce(&mut [u8]) -> IonResult<SliceElementWriter>,
 {
-    let source_elements = read_file(&element_reader(), file_name)?;
-    if contains_path(ROUND_TRIP_SKIP_LIST, file_name) {
-        return Ok(());
-    }
-    let first_write_elements = assert_round_trip(&source_elements, first_writer)?;
-    let second_write_elements = assert_round_trip(&first_write_elements, second_writer)?;
-    assert_eq!(source_elements, second_write_elements);
-    Ok(())
-}
-
-fn assert_file<T, F: FnOnce() -> IonResult<T>>(skip_list: &[&str], file_name: &str, asserter: F) {
-    // TODO if frehberg/test-generator#7 gets implemented we could do a proper ignore
-
-    // print the paths here either way so it is easy to copy/paste to investigate failures
-    // use the --show-output argument to see it
-    if contains_path(skip_list, file_name) {
-        println!("IGNORING: {}", file_name);
-    } else {
-        println!("TESTING: {}", file_name);
-        asserter().unwrap();
-    }
-}
-
-#[test_resources("ion-tests/iontestdata/good/**/*.ion")]
-#[test_resources("ion-tests/iontestdata/good/**/*.10n")]
-fn good_roundtrip_text_binary(file_name: &str) {
-    assert_file(ALL_SKIP_LIST, file_name, || {
-        assert_three_way_round_trip(
-            file_name,
-            |slice| Format::Text(TextKind::Compact).element_writer_for_slice(slice),
-            |slice| Format::Binary.element_writer_for_slice(slice),
-        )
+    E::assert_file(skip_list, file_name, || {
+        E::assert_three_way_round_trip(file_name, first_writer_provider, second_writer_provider)
     });
 }
 
-#[test_resources("ion-tests/iontestdata/good/**/*.ion")]
-#[test_resources("ion-tests/iontestdata/good/**/*.10n")]
-fn good_roundtrip_binary_text(file_name: &str) {
-    assert_file(ALL_SKIP_LIST, file_name, || {
-        assert_three_way_round_trip(
-            file_name,
-            |slice| Format::Binary.element_writer_for_slice(slice),
-            |slice| Format::Text(TextKind::Compact).element_writer_for_slice(slice),
-        )
-    });
+fn good_roundtrip_text_binary<E: ElementApi>(element_api: E, file_name: &str) {
+    good_roundtrip(
+        element_api,
+        E::global_skip_list(),
+        file_name,
+        |slice| E::make_text_writer(slice),
+        |slice| E::make_binary_writer(slice),
+    )
 }
 
-#[test_resources("ion-tests/iontestdata/good/**/*.ion")]
-#[test_resources("ion-tests/iontestdata/good/**/*.10n")]
-fn good_roundtrip_text_pretty(file_name: &str) {
-    assert_file(ALL_SKIP_LIST, file_name, || {
-        assert_three_way_round_trip(
-            file_name,
-            |slice| Format::Text(TextKind::Compact).element_writer_for_slice(slice),
-            |slice| Format::Text(TextKind::Pretty).element_writer_for_slice(slice),
-        )
-    });
+fn good_roundtrip_binary_text<E: ElementApi>(element_api: E, file_name: &str) {
+    good_roundtrip(
+        element_api,
+        E::global_skip_list(),
+        file_name,
+        |slice| E::make_binary_writer(slice),
+        |slice| E::make_text_writer(slice),
+    )
 }
 
-#[test_resources("ion-tests/iontestdata/good/**/*.ion")]
-#[test_resources("ion-tests/iontestdata/good/**/*.10n")]
-fn good_roundtrip_pretty_text(file_name: &str) {
-    assert_file(ALL_SKIP_LIST, file_name, || {
-        assert_three_way_round_trip(
-            file_name,
-            |slice| Format::Text(TextKind::Pretty).element_writer_for_slice(slice),
-            |slice| Format::Text(TextKind::Compact).element_writer_for_slice(slice),
-        )
-    });
+fn good_roundtrip_text_pretty<E: ElementApi>(element_api: E, file_name: &str) {
+    good_roundtrip(
+        element_api,
+        E::global_skip_list(),
+        file_name,
+        |slice| E::make_text_writer(slice),
+        |slice| E::make_pretty_text_writer(slice),
+    )
 }
 
-#[test_resources("ion-tests/iontestdata/good/**/*.ion")]
-#[test_resources("ion-tests/iontestdata/good/**/*.10n")]
-fn good_roundtrip_pretty_binary(file_name: &str) {
-    assert_file(ALL_SKIP_LIST, file_name, || {
-        assert_three_way_round_trip(
-            file_name,
-            |slice| Format::Text(TextKind::Pretty).element_writer_for_slice(slice),
-            |slice| Format::Binary.element_writer_for_slice(slice),
-        )
-    });
+fn good_roundtrip_pretty_text<E: ElementApi>(element_api: E, file_name: &str) {
+    good_roundtrip(
+        element_api,
+        E::global_skip_list(),
+        file_name,
+        |slice| E::make_pretty_text_writer(slice),
+        |slice| E::make_text_writer(slice),
+    )
 }
 
-#[test_resources("ion-tests/iontestdata/good/**/*.ion")]
-#[test_resources("ion-tests/iontestdata/good/**/*.10n")]
-fn good_roundtrip_binary_pretty(file_name: &str) {
-    assert_file(ALL_SKIP_LIST, file_name, || {
-        assert_three_way_round_trip(
-            file_name,
-            |slice| Format::Binary.element_writer_for_slice(slice),
-            |slice| Format::Text(TextKind::Pretty).element_writer_for_slice(slice),
-        )
-    });
+fn good_roundtrip_pretty_binary<E: ElementApi>(element_api: E, file_name: &str) {
+    good_roundtrip(
+        element_api,
+        E::global_skip_list(),
+        file_name,
+        |slice| E::make_pretty_text_writer(slice),
+        |slice| E::make_binary_writer(slice),
+    )
 }
 
-#[test_resources("ion-tests/iontestdata/bad/**/*.ion")]
-#[test_resources("ion-tests/iontestdata/bad/**/*.10n")]
-fn bad(file_name: &str) {
-    assert_file(ALL_SKIP_LIST, file_name, || {
-        match read_file(&element_reader(), file_name) {
+fn good_roundtrip_binary_pretty<E: ElementApi>(element_api: E, file_name: &str) {
+    good_roundtrip(
+        element_api,
+        E::global_skip_list(),
+        file_name,
+        |slice| E::make_binary_writer(slice),
+        |slice| E::make_pretty_text_writer(slice),
+    )
+}
+
+fn bad<E: ElementApi>(_element_api: E, file_name: &str) {
+    E::assert_file(E::global_skip_list(), file_name, || {
+        match E::read_file(&E::make_reader(), file_name) {
             Ok(items) => panic!("Expected error, got: {:?}", items),
             Err(_) => Ok(()),
         }
     });
 }
 
-/// Parses the elements of a given sequence as text Ion data and tests a grouping on the read
-/// documents.
-///
-/// For example, for the given group:
-///
-/// ```plain
-/// embedded_documents::(
-///   "a b c"
-///   "'a' 'b' 'c'"
-/// )
-/// ```
-///
-/// This will parse each string as a [`Vec`] of [`Element`] and apply the `group_assert` function
-/// for every pair of the parsed data including the identity case (a parsed document is
-/// compared against itself).
-fn read_group_embedded<R, S, F>(reader: &R, raw_group: &S, group_assert: &F) -> IonResult<()>
-where
-    R: ElementReader,
-    S: Sequence,
-    F: Fn(&Vec<OwnedElement>, &Vec<OwnedElement>),
-{
-    let group_res: IonResult<Vec<_>> = raw_group
-        .iter()
-        .map(|elem| reader.read_all(elem.as_str().unwrap().as_bytes()))
-        .collect();
-    let group = group_res?;
-    for this in group.iter() {
-        for that in group.iter() {
-            group_assert(this, that);
-        }
-    }
-    Ok(())
-}
-
-/// Parses a document that has top-level `list`/`sexp` values that represent a *group*.
-/// If this top-level value is annotated with `embedded_documents`, then [`read_group_embedded`]
-/// is executed for that grouping.  Otherwise, the `value_assert` function is invoked for
-/// every pair of values in a group including the identity case (a value in a group is compared
-/// against itself).
-///
-/// Here is an example with two groups that might be used for equivalence testing:
-///
-/// ```plain
-/// (name $2 'name')
-/// embedded_documents::(
-///   "a name"
-///   "a $2"
-///   "'a' 'name'"
-/// )
-/// ```
-///
-/// This would have two groups, one with direct values that will be compared and another
-/// with embedded Ion text that will be parsed and compared.
-fn read_group<R, F1, F2>(
-    reader: R,
-    file_name: &str,
-    value_assert: F1,
-    group_assert: F2,
-) -> IonResult<()>
-where
-    R: ElementReader,
-    F1: Fn(&OwnedElement, &OwnedElement),
-    F2: Fn(&Vec<OwnedElement>, &Vec<OwnedElement>),
-{
-    let group_lists = read_file(&reader, file_name)?;
-    for group_list in group_lists.iter() {
-        // every grouping set is a list/sexp
-        // look for the embedded annotation to parse/test as the underlying value
-        let is_embedded = group_list
-            .annotations()
-            .any(|annotation| annotation.text() == Some("embedded_documents"));
-        match (group_list.as_sequence(), is_embedded) {
-            (Some(group), true) => {
-                read_group_embedded(&reader, group, &group_assert)?;
-            }
-            (Some(group), false) => {
-                for this in group.iter() {
-                    for that in group.iter() {
-                        value_assert(this, that);
-                    }
-                }
-            }
-            _ => return decoding_error(format!("Expected a sequence for group: {:?}", group_list)),
-        };
-    }
-    Ok(())
-}
-
-#[test_resources("ion-tests/iontestdata/good/equivs/**/*.ion")]
-#[test_resources("ion-tests/iontestdata/good/equivs/**/*.10n")]
-fn equivs(file_name: &str) {
-    let skip_list = concat(ALL_SKIP_LIST, EQUIVS_SKIP_LIST);
-    assert_file(&skip_list[..], file_name, || {
-        read_group(
-            element_reader(),
+fn equivs<E: ElementApi>(_element_api: E, file_name: &str) {
+    let skip_list = concat(E::global_skip_list(), E::equivs_skip_list());
+    E::assert_file(&skip_list[..], file_name, || {
+        E::read_group(
+            E::make_reader(),
             file_name,
             |this, that| assert_eq!(this, that),
             |this_group, that_group| assert_eq!(this_group, that_group),
@@ -358,15 +342,11 @@ fn equivs(file_name: &str) {
     });
 }
 
-#[test_resources("ion-tests/iontestdata/good/non-equivs/**/*.ion")]
-// no binary files exist and the macro doesn't like empty globs...
-// see frehberg/test-generator#12
-//#[test_resources("ion-tests/iontestdata/good/non-equivs/**/*.10n")]
-fn non_equivs(file_name: &str) {
-    let skip_list = concat(ALL_SKIP_LIST, NON_EQUIVS_SKIP_LIST);
-    assert_file(&skip_list[..], file_name, || {
-        read_group(
-            element_reader(),
+fn non_equivs<E: ElementApi>(_element_api: E, file_name: &str) {
+    let skip_list = concat(E::global_skip_list(), E::non_equivs_skip_list());
+    E::assert_file(&skip_list[..], file_name, || {
+        E::read_group(
+            E::make_reader(),
             file_name,
             |this, that| {
                 if std::ptr::eq(this, that) {
@@ -384,4 +364,561 @@ fn non_equivs(file_name: &str) {
             },
         )
     });
+}
+
+#[cfg(test)]
+mod ion_c_element_api_tests {
+    use super::*;
+    use ion_rs::value::ion_c_reader::IonCElementReader;
+    use ion_rs::value::reader::ion_c_element_reader;
+
+    struct IonCElementApi {}
+
+    /// Files that should always be skipped for some reason.
+    const GLOBAL_SKIP_LIST: SkipList = &[
+        // ion-c does not currently support these
+        // see: https://github.com/amzn/ion-c/blob/master/test/gather_vectors.cpp
+        "ion-tests/iontestdata/good/utf16.ion",
+        "ion-tests/iontestdata/good/utf32.ion",
+        "ion-tests/iontestdata/good/subfieldVarUInt32bit.ion",
+        "ion-tests/iontestdata/good/typecodes/T6-large.10n",
+        "ion-tests/iontestdata/good/typecodes/T7-large.10n",
+        "ion-tests/iontestdata/good/typecodes/type_6_length_0.10n",
+        // these appear to have a problem specific to how we're calling ion-c (amzn/ion-rust#218)
+        "ion-tests/iontestdata/good/item1.10n",
+        "ion-tests/iontestdata/good/subfieldVarInt.ion",
+        // these are symbols with unknown text (amzn/ion-rust#219)
+        "ion-tests/iontestdata/good/symbolExplicitZero.10n",
+        "ion-tests/iontestdata/good/symbolImplicitZero.10n",
+        "ion-tests/iontestdata/good/symbolZero.ion",
+        "ion-tests/iontestdata/good/typecodes/T7-small.10n",
+    ];
+
+    /// Files that should not be tested for equivalence with read_one against read_all
+    const READ_ONE_EQUIVS_SKIP_LIST: SkipList = &[
+        // we need a structural equality (IonEq) for these (amzn/ion-rust#220)
+        "ion-tests/iontestdata/good/floatSpecials.ion",
+    ];
+
+    /// Files that should not be tested for equivalence in round-trip testing
+    const ROUND_TRIP_SKIP_LIST: SkipList = &[
+        // we need a structural equality (IonEq) for these (amzn/ion-rust#220)
+        "ion-tests/iontestdata/good/float32.10n",
+        "ion-tests/iontestdata/good/floatSpecials.ion",
+        "ion-tests/iontestdata/good/non-equivs/floats.ion",
+        // appears to be a bug with Ion C or ion-c-sys (specifically binary) (amzn/ion-rust#235)
+        "ion-tests/iontestdata/good/equivs/bigInts.ion",
+        "ion-tests/iontestdata/good/subfieldUInt.ion",
+    ];
+
+    /// Files that should only be skipped in equivalence file testing
+    const EQUIVS_SKIP_LIST: SkipList = &[];
+
+    /// Files that should only be skipped in non-equivalence file testing
+    const NON_EQUIVS_SKIP_LIST: SkipList = &[
+        // we need a structural equality (IonEq) for these (amzn/ion-rust#220)
+        "ion-tests/iontestdata/good/non-equivs/decimals.ion",
+        "ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion",
+        "ion-tests/iontestdata/good/non-equivs/floats.ion",
+        // these have symbols with unknown text (amzn/ion-rust#219)
+        "ion-tests/iontestdata/good/non-equivs/symbolTablesUnknownText.ion",
+    ];
+
+    impl ElementApi for IonCElementApi {
+        type ElementReader = IonCElementReader;
+
+        fn global_skip_list() -> SkipList {
+            GLOBAL_SKIP_LIST
+        }
+
+        fn read_one_equivs_skip_list() -> SkipList {
+            READ_ONE_EQUIVS_SKIP_LIST
+        }
+
+        fn round_trip_skip_list() -> SkipList {
+            ROUND_TRIP_SKIP_LIST
+        }
+
+        fn equivs_skip_list() -> SkipList {
+            EQUIVS_SKIP_LIST
+        }
+
+        fn non_equivs_skip_list() -> SkipList {
+            NON_EQUIVS_SKIP_LIST
+        }
+
+        fn make_reader() -> Self::ElementReader {
+            ion_c_element_reader()
+        }
+
+        fn make_text_writer(buffer: &mut [u8]) -> IonResult<SliceElementWriter> {
+            Format::Text(TextKind::Compact).element_writer_for_slice(buffer)
+        }
+
+        fn make_pretty_text_writer(buffer: &mut [u8]) -> IonResult<SliceElementWriter> {
+            Format::Text(TextKind::Pretty).element_writer_for_slice(buffer)
+        }
+
+        fn make_binary_writer(buffer: &mut [u8]) -> IonResult<SliceElementWriter> {
+            Format::Binary.element_writer_for_slice(buffer)
+        }
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn ion_c_good_roundtrip_text_binary(file_name: &str) {
+        good_roundtrip_text_binary(IonCElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn ion_c_good_roundtrip_binary_text(file_name: &str) {
+        good_roundtrip_binary_text(IonCElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn ion_c_good_roundtrip_text_pretty(file_name: &str) {
+        good_roundtrip_text_pretty(IonCElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn ion_c_good_roundtrip_pretty_text(file_name: &str) {
+        good_roundtrip_pretty_text(IonCElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn ion_c_good_roundtrip_pretty_binary(file_name: &str) {
+        good_roundtrip_pretty_binary(IonCElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn ion_c_good_roundtrip_binary_pretty(file_name: &str) {
+        good_roundtrip_binary_pretty(IonCElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/bad/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/bad/**/*.10n")]
+    fn ion_c_bad(file_name: &str) {
+        bad(IonCElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/equivs/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/equivs/**/*.10n")]
+    fn ion_c_equivs(file_name: &str) {
+        equivs(IonCElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/non-equivs/**/*.ion")]
+    // no binary files exist and the macro doesn't like empty globs...
+    // see frehberg/test-generator#12
+    //#[test_resources("ion-tests/iontestdata/good/non-equivs/**/*.10n")]
+    fn ion_c_non_equivs(file_name: &str) {
+        non_equivs(IonCElementApi {}, file_name)
+    }
+}
+
+#[cfg(test)]
+mod native_element_tests {
+    use super::*;
+    use ion_rs::value::native_reader::NativeElementReader;
+    use ion_rs::value::reader::native_element_reader;
+
+    struct NativeElementApi {}
+
+    impl ElementApi for NativeElementApi {
+        type ElementReader = NativeElementReader;
+
+        fn global_skip_list() -> SkipList {
+            &[
+                "ion-tests/iontestdata/bad/annotationLengthTooLongContainer.10n",
+                "ion-tests/iontestdata/bad/annotationLengthTooLongScalar.10n",
+                "ion-tests/iontestdata/bad/annotationLengthTooShortContainer.10n",
+                "ion-tests/iontestdata/bad/annotationLengthTooShortScalar.10n",
+                "ion-tests/iontestdata/bad/annotationNested.10n",
+                "ion-tests/iontestdata/bad/annotationWithNoValue.10n",
+                "ion-tests/iontestdata/bad/badMagicE00100E0.10n",
+                "ion-tests/iontestdata/bad/clobWithNonAsciiCharacter.ion",
+                "ion-tests/iontestdata/bad/clobWithNonAsciiCharacterMultiline.ion",
+                "ion-tests/iontestdata/bad/clobWithNullCharacter.ion",
+                "ion-tests/iontestdata/bad/clobWithValidUtf8ButNonAsciiCharacter.ion",
+                "ion-tests/iontestdata/bad/emptyAnnotatedInt.10n",
+                "ion-tests/iontestdata/bad/invalidVersionMarker_ion_0_0.ion",
+                "ion-tests/iontestdata/bad/invalidVersionMarker_ion_1_1.ion",
+                "ion-tests/iontestdata/bad/invalidVersionMarker_ion_1234_0.ion",
+                "ion-tests/iontestdata/bad/invalidVersionMarker_ion_2_0.ion",
+                "ion-tests/iontestdata/bad/ivmInAnnotationWrapper.10n",
+                "ion-tests/iontestdata/bad/ivmInList.10n",
+                "ion-tests/iontestdata/bad/ivmInSexp.10n",
+                "ion-tests/iontestdata/bad/ivmInStruct.10n",
+                "ion-tests/iontestdata/bad/ivmInSymbolTableImport.10n",
+                "ion-tests/iontestdata/bad/listWithValueLargerThanSize.10n",
+                "ion-tests/iontestdata/bad/localSymbolTableWithMultipleImportsFields.10n",
+                "ion-tests/iontestdata/bad/localSymbolTableWithMultipleSymbolsAndImportsFields.10n",
+                "ion-tests/iontestdata/bad/localSymbolTableWithMultipleSymbolsFields.10n",
+                "ion-tests/iontestdata/bad/longStringRawControlCharacter.ion",
+                "ion-tests/iontestdata/bad/longStringSlashE.ion",
+                "ion-tests/iontestdata/bad/longStringSplitEscape_1.ion",
+                "ion-tests/iontestdata/bad/longStringSplitEscape_2.ion",
+                "ion-tests/iontestdata/bad/negativeIntZero.10n",
+                "ion-tests/iontestdata/bad/negativeIntZeroLn.10n",
+                "ion-tests/iontestdata/bad/stringRawControlCharacter.ion",
+                "ion-tests/iontestdata/bad/stringWithEol.ion",
+                "ion-tests/iontestdata/bad/structOrderedEmpty.10n",
+                "ion-tests/iontestdata/bad/structOrderedEmptyInList.10n",
+                "ion-tests/iontestdata/bad/timestamp/outOfRange/offsetMinutes_1.ion",
+                "ion-tests/iontestdata/bad/timestamp/outOfRange/offsetMinutes_2.ion",
+                "ion-tests/iontestdata/bad/timestamp/outOfRange/offsetMinutes_3.ion",
+                "ion-tests/iontestdata/bad/timestamp/timestampFraction10d-1.10n",
+                "ion-tests/iontestdata/bad/timestamp/timestampFraction11d-1.10n",
+                "ion-tests/iontestdata/bad/timestamp/timestampFraction1d0.10n",
+                "ion-tests/iontestdata/bad/timestamp/timestampNegativeFraction.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_0.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_1.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_10.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_11.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_12.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_13.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_14.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_15.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_2.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_3.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_4.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_5.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_6.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_7.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_8.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_15_length_9.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_3_length_0.10n",
+                "ion-tests/iontestdata/bad/typecodes/type_6_length_0.10n",
+                "ion-tests/iontestdata/bad/utf8/outOfUnicodeBounds_1.ion",
+                "ion-tests/iontestdata/bad/utf8/outOfUnicodeBounds_2.ion",
+                "ion-tests/iontestdata/bad/utf8/shortUtf8Sequence_1.ion",
+                "ion-tests/iontestdata/bad/utf8/shortUtf8Sequence_2.ion",
+                "ion-tests/iontestdata/bad/utf8/shortUtf8Sequence_3.ion",
+                "ion-tests/iontestdata/bad/utf8/surrogate_10.ion",
+                "ion-tests/iontestdata/bad/utf8/surrogate_5.ion",
+                "ion-tests/iontestdata/bad/utf8/surrogate_8.ion",
+                "ion-tests/iontestdata/bad/utf8/wrongUtf8LeadingBits_1.ion",
+                "ion-tests/iontestdata/bad/utf8/wrongUtf8LeadingBits_2.ion",
+                "ion-tests/iontestdata/bad/utf8/wrongUtf8LeadingBits_3.ion",
+                // ROUND TRIP
+                "ion-tests/iontestdata/good/blobs.ion",
+                "ion-tests/iontestdata/good/clobs.ion",
+                "ion-tests/iontestdata/good/decimal_e_values.ion",
+                "ion-tests/iontestdata/good/decimal_values.ion",
+                "ion-tests/iontestdata/good/decimal_zeros.ion",
+                "ion-tests/iontestdata/good/decimalNegativeZeroDot.10n",
+                "ion-tests/iontestdata/good/decimalNegativeZeroDotZero.10n",
+                "ion-tests/iontestdata/good/equivs/annotatedIvms.ion",
+                "ion-tests/iontestdata/good/equivs/annotatedSymbols.ion",
+                "ion-tests/iontestdata/good/equivs/blobs.ion",
+                "ion-tests/iontestdata/good/equivs/clobNewlines.ion",
+                "ion-tests/iontestdata/good/equivs/clobs.ion",
+                "ion-tests/iontestdata/good/equivs/decimals.ion",
+                "ion-tests/iontestdata/good/equivs/emptyStrings.ion",
+                "ion-tests/iontestdata/good/equivs/floats.ion",
+                "ion-tests/iontestdata/good/equivs/longStringsWithComments.ion",
+                "ion-tests/iontestdata/good/equivs/sexps.ion",
+                "ion-tests/iontestdata/good/equivs/strings.ion",
+                "ion-tests/iontestdata/good/equivs/structWhitespace.ion",
+                "ion-tests/iontestdata/good/equivs/structs.ion",
+                "ion-tests/iontestdata/good/equivs/structsFieldsDiffOrder.ion",
+                "ion-tests/iontestdata/good/equivs/structsFieldsRepeatedNames.ion",
+                "ion-tests/iontestdata/good/equivs/symbols.ion",
+                "ion-tests/iontestdata/good/equivs/textNewlines.ion",
+                "ion-tests/iontestdata/good/equivs/timestampFractions.10n",
+                "ion-tests/iontestdata/good/equivs/timestampsLargeFractionalPrecision.ion",
+                "ion-tests/iontestdata/good/equivs/utf8/stringU0001D11E.ion",
+                "ion-tests/iontestdata/good/equivs/utf8/stringUtf8.ion",
+                "ion-tests/iontestdata/good/equivs/zeroDecimals.ion",
+                "ion-tests/iontestdata/good/equivs/zeroFloats.ion",
+                "ion-tests/iontestdata/good/float_values.ion",
+                "ion-tests/iontestdata/good/float_zeros.ion",
+                "ion-tests/iontestdata/good/float32.10n",
+                "ion-tests/iontestdata/good/floatDblMin.ion",
+                "ion-tests/iontestdata/good/floatSpecials.ion",
+                "ion-tests/iontestdata/good/innerVersionIdentifiers.ion",
+                "ion-tests/iontestdata/good/item1.10n",
+                "ion-tests/iontestdata/good/localSymbolTableImportZeroMaxId.ion",
+                "ion-tests/iontestdata/good/message2.ion",
+                "ion-tests/iontestdata/good/non/equivs/annotatedIvms.ion",
+                "ion-tests/iontestdata/good/non/equivs/clobs.ion",
+                "ion-tests/iontestdata/good/non/equivs/decimals.ion",
+                "ion-tests/iontestdata/good/non/equivs/floats.ion",
+                "ion-tests/iontestdata/good/non/equivs/floatsVsDecimals.ion",
+                "ion-tests/iontestdata/good/non/equivs/sexps.ion",
+                "ion-tests/iontestdata/good/non/equivs/structs.ion",
+                "ion-tests/iontestdata/good/notVersionMarkers.ion",
+                "ion-tests/iontestdata/good/sexps.ion",
+                "ion-tests/iontestdata/good/structs.ion",
+                "ion-tests/iontestdata/good/subfieldInt.ion",
+                "ion-tests/iontestdata/good/subfieldUInt.ion",
+                "ion-tests/iontestdata/good/subfieldVarInt.ion",
+                "ion-tests/iontestdata/good/subfieldVarUInt.ion",
+                "ion-tests/iontestdata/good/subfieldVarUInt15bit.ion",
+                "ion-tests/iontestdata/good/subfieldVarUInt16bit.ion",
+                "ion-tests/iontestdata/good/subfieldVarUInt32bit.ion",
+                "ion-tests/iontestdata/good/symbolEmpty.ion",
+                "ion-tests/iontestdata/good/symbolEmptyWithCR.ion",
+                "ion-tests/iontestdata/good/symbolEmptyWithCRLF.ion",
+                "ion-tests/iontestdata/good/testfile0.ion",
+                "ion-tests/iontestdata/good/testfile12.ion",
+                "ion-tests/iontestdata/good/testfile23.ion",
+                "ion-tests/iontestdata/good/testfile29.ion",
+                "ion-tests/iontestdata/good/testfile3.ion",
+                "ion-tests/iontestdata/good/testfile31.ion",
+                "ion-tests/iontestdata/good/testfile35.ion",
+                "ion-tests/iontestdata/good/testfile7.ion",
+                "ion-tests/iontestdata/good/testfile8.ion",
+                "ion-tests/iontestdata/good/timestamp/equivTimeline/timestamps.ion",
+                "ion-tests/iontestdata/good/timestamp/timestamp2011-02-20T19_30_59_100-08_00.10n",
+                "ion-tests/iontestdata/good/typecodes/T5.10n",
+                "ion-tests/iontestdata/good/typecodes/T6-large.10n",
+                "ion-tests/iontestdata/good/utf16.ion",
+                "ion-tests/iontestdata/good/utf32.ion",
+                "ion-tests/iontestdata/good/whitespace.ion",
+                // EQUIVS
+                "ion-tests/iontestdata/good/equivs/annotatedIvms.ion",
+                "ion-tests/iontestdata/good/equivs/annotatedSymbols.ion",
+                "ion-tests/iontestdata/good/equivs/blobs.ion",
+                "ion-tests/iontestdata/good/equivs/clobNewlines.ion",
+                "ion-tests/iontestdata/good/equivs/clobs.ion",
+                "ion-tests/iontestdata/good/equivs/decimals.ion",
+                "ion-tests/iontestdata/good/equivs/emptyStrings.ion",
+                "ion-tests/iontestdata/good/equivs/floats.ion",
+                "ion-tests/iontestdata/good/equivs/localSymbolTableAppend.ion",
+                "ion-tests/iontestdata/good/equivs/localSymbolTableNullSlots.ion",
+                "ion-tests/iontestdata/good/equivs/longStringsWithComments.ion",
+                "ion-tests/iontestdata/good/equivs/nonIVMNoOps.ion",
+                "ion-tests/iontestdata/good/equivs/sexps.ion",
+                "ion-tests/iontestdata/good/equivs/strings.ion",
+                "ion-tests/iontestdata/good/equivs/structWhitespace.ion",
+                "ion-tests/iontestdata/good/equivs/structs.ion",
+                "ion-tests/iontestdata/good/equivs/structsFieldsDiffOrder.ion",
+                "ion-tests/iontestdata/good/equivs/structsFieldsRepeatedNames.ion",
+                "ion-tests/iontestdata/good/equivs/symbols.ion",
+                "ion-tests/iontestdata/good/equivs/textNewlines.ion",
+                "ion-tests/iontestdata/good/equivs/timestampFractions.10n",
+                "ion-tests/iontestdata/good/equivs/utf8/stringU0001D11E.ion",
+                "ion-tests/iontestdata/good/equivs/utf8/stringUtf8.ion",
+                "ion-tests/iontestdata/good/equivs/zeroFloats.ion",
+                // NON-EQUIVS
+                "ion-tests/iontestdata/good/non-equivs/annotatedIvms.ion",
+                "ion-tests/iontestdata/good/non-equivs/clobs.ion",
+                "ion-tests/iontestdata/good/non-equivs/decimals.ion",
+                "ion-tests/iontestdata/good/non-equivs/floats.ion",
+                "ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion",
+                "ion-tests/iontestdata/good/non-equivs/localSymbolTableWithAnnotations.ion",
+                "ion-tests/iontestdata/good/non-equivs/sexps.ion",
+                "ion-tests/iontestdata/good/non-equivs/structs.ion",
+                "ion-tests/iontestdata/good/non-equivs/symbolTablesUnknownText.ion",
+            ]
+        }
+
+        fn read_one_equivs_skip_list() -> SkipList {
+            &[]
+        }
+
+        fn round_trip_skip_list() -> SkipList {
+            &[
+                "ion-tests/iontestdata/good/blobs.ion",
+                "ion-tests/iontestdata/good/clobs.ion",
+                "ion-tests/iontestdata/good/decimal_e_values.ion",
+                "ion-tests/iontestdata/good/decimal_values.ion",
+                "ion-tests/iontestdata/good/decimal_zeros.ion",
+                "ion-tests/iontestdata/good/decimalNegativeZeroDot.10n",
+                "ion-tests/iontestdata/good/decimalNegativeZeroDotZero.10n",
+                "ion-tests/iontestdata/good/equivs/annotatedIvms.ion",
+                "ion-tests/iontestdata/good/equivs/annotatedSymbols.ion",
+                "ion-tests/iontestdata/good/equivs/blobs.ion",
+                "ion-tests/iontestdata/good/equivs/clobNewlines.ion",
+                "ion-tests/iontestdata/good/equivs/clobs.ion",
+                "ion-tests/iontestdata/good/equivs/decimals.ion",
+                "ion-tests/iontestdata/good/equivs/emptyStrings.ion",
+                "ion-tests/iontestdata/good/equivs/floats.ion",
+                "ion-tests/iontestdata/good/equivs/longStringsWithComments.ion",
+                "ion-tests/iontestdata/good/equivs/sexps.ion",
+                "ion-tests/iontestdata/good/equivs/strings.ion",
+                "ion-tests/iontestdata/good/equivs/structWhitespace.ion",
+                "ion-tests/iontestdata/good/equivs/structs.ion",
+                "ion-tests/iontestdata/good/equivs/structsFieldsDiffOrder.ion",
+                "ion-tests/iontestdata/good/equivs/structsFieldsRepeatedNames.ion",
+                "ion-tests/iontestdata/good/equivs/symbols.ion",
+                "ion-tests/iontestdata/good/equivs/textNewlines.ion",
+                "ion-tests/iontestdata/good/equivs/timestampFractions.10n",
+                "ion-tests/iontestdata/good/equivs/timestampsLargeFractionalPrecision.ion",
+                "ion-tests/iontestdata/good/equivs/utf8/stringU0001D11E.ion",
+                "ion-tests/iontestdata/good/equivs/utf8/stringUtf8.ion",
+                "ion-tests/iontestdata/good/equivs/zeroDecimals.ion",
+                "ion-tests/iontestdata/good/equivs/zeroFloats.ion",
+                "ion-tests/iontestdata/good/float_values.ion",
+                "ion-tests/iontestdata/good/float_zeros.ion",
+                "ion-tests/iontestdata/good/float32.10n",
+                "ion-tests/iontestdata/good/floatDblMin.ion",
+                "ion-tests/iontestdata/good/floatSpecials.ion",
+                "ion-tests/iontestdata/good/innerVersionIdentifiers.ion",
+                "ion-tests/iontestdata/good/item1.10n",
+                "ion-tests/iontestdata/good/localSymbolTableImportZeroMaxId.ion",
+                "ion-tests/iontestdata/good/message2.ion",
+                "ion-tests/iontestdata/good/non/equivs/annotatedIvms.ion",
+                "ion-tests/iontestdata/good/non/equivs/clobs.ion",
+                "ion-tests/iontestdata/good/non/equivs/decimals.ion",
+                "ion-tests/iontestdata/good/non/equivs/floats.ion",
+                "ion-tests/iontestdata/good/non/equivs/floatsVsDecimals.ion",
+                "ion-tests/iontestdata/good/non/equivs/sexps.ion",
+                "ion-tests/iontestdata/good/non/equivs/structs.ion",
+                "ion-tests/iontestdata/good/notVersionMarkers.ion",
+                "ion-tests/iontestdata/good/sexps.ion",
+                "ion-tests/iontestdata/good/structs.ion",
+                "ion-tests/iontestdata/good/subfieldInt.ion",
+                "ion-tests/iontestdata/good/subfieldUInt.ion",
+                "ion-tests/iontestdata/good/subfieldVarInt.ion",
+                "ion-tests/iontestdata/good/subfieldVarUInt.ion",
+                "ion-tests/iontestdata/good/subfieldVarUInt15bit.ion",
+                "ion-tests/iontestdata/good/subfieldVarUInt16bit.ion",
+                "ion-tests/iontestdata/good/subfieldVarUInt32bit.ion",
+                "ion-tests/iontestdata/good/symbolEmpty.ion",
+                "ion-tests/iontestdata/good/symbolEmptyWithCR.ion",
+                "ion-tests/iontestdata/good/symbolEmptyWithCRLF.ion",
+                "ion-tests/iontestdata/good/testfile0.ion",
+                "ion-tests/iontestdata/good/testfile12.ion",
+                "ion-tests/iontestdata/good/testfile23.ion",
+                "ion-tests/iontestdata/good/testfile29.ion",
+                "ion-tests/iontestdata/good/testfile3.ion",
+                "ion-tests/iontestdata/good/testfile31.ion",
+                "ion-tests/iontestdata/good/testfile35.ion",
+                "ion-tests/iontestdata/good/testfile7.ion",
+                "ion-tests/iontestdata/good/testfile8.ion",
+                "ion-tests/iontestdata/good/timestamp/equivTimeline/timestamps.ion",
+                "ion-tests/iontestdata/good/timestamp/timestamp2011-02-20T19_30_59_100-08_00.10n",
+                "ion-tests/iontestdata/good/typecodes/T5.10n",
+                "ion-tests/iontestdata/good/typecodes/T6-large.10n",
+                "ion-tests/iontestdata/good/utf16.ion",
+                "ion-tests/iontestdata/good/utf32.ion",
+                "ion-tests/iontestdata/good/whitespace.ion",
+            ]
+        }
+
+        fn equivs_skip_list() -> SkipList {
+            &[
+                "ion-tests/iontestdata/good/equivs/annotatedIvms.ion",
+                "ion-tests/iontestdata/good/equivs/annotatedSymbols.ion",
+                "ion-tests/iontestdata/good/equivs/blobs.ion",
+                "ion-tests/iontestdata/good/equivs/clobNewlines.ion",
+                "ion-tests/iontestdata/good/equivs/clobs.ion",
+                "ion-tests/iontestdata/good/equivs/decimals.ion",
+                "ion-tests/iontestdata/good/equivs/emptyStrings.ion",
+                "ion-tests/iontestdata/good/equivs/floats.ion",
+                "ion-tests/iontestdata/good/equivs/localSymbolTableAppend.ion",
+                "ion-tests/iontestdata/good/equivs/localSymbolTableNullSlots.ion",
+                "ion-tests/iontestdata/good/equivs/longStringsWithComments.ion",
+                "ion-tests/iontestdata/good/equivs/nonIVMNoOps.ion",
+                "ion-tests/iontestdata/good/equivs/sexps.ion",
+                "ion-tests/iontestdata/good/equivs/strings.ion",
+                "ion-tests/iontestdata/good/equivs/structWhitespace.ion",
+                "ion-tests/iontestdata/good/equivs/structs.ion",
+                "ion-tests/iontestdata/good/equivs/structsFieldsDiffOrder.ion",
+                "ion-tests/iontestdata/good/equivs/structsFieldsRepeatedNames.ion",
+                "ion-tests/iontestdata/good/equivs/symbols.ion",
+                "ion-tests/iontestdata/good/equivs/textNewlines.ion",
+                "ion-tests/iontestdata/good/equivs/timestampFractions.10n",
+                "ion-tests/iontestdata/good/equivs/utf8/stringU0001D11E.ion",
+                "ion-tests/iontestdata/good/equivs/utf8/stringUtf8.ion",
+                "ion-tests/iontestdata/good/equivs/zeroFloats.ion",
+            ]
+        }
+
+        fn non_equivs_skip_list() -> SkipList {
+            &[
+                "ion-tests/iontestdata/good/non-equivs/annotatedIvms.ion",
+                "ion-tests/iontestdata/good/non-equivs/clobs.ion",
+                "ion-tests/iontestdata/good/non-equivs/decimals.ion",
+                "ion-tests/iontestdata/good/non-equivs/floats.ion",
+                "ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion",
+                "ion-tests/iontestdata/good/non-equivs/localSymbolTableWithAnnotations.ion",
+                "ion-tests/iontestdata/good/non-equivs/sexps.ion",
+                "ion-tests/iontestdata/good/non-equivs/structs.ion",
+                "ion-tests/iontestdata/good/non-equivs/symbolTablesUnknownText.ion",
+            ]
+        }
+
+        fn make_reader() -> Self::ElementReader {
+            native_element_reader()
+        }
+
+        // TODO: These methods return an ion-c writer for the time being.
+        //       Once we have a native ElementWriter impl and the reader is passing (most of) its
+        //       ion-tests, we can modify this.
+        fn make_text_writer(buffer: &mut [u8]) -> IonResult<SliceElementWriter> {
+            Format::Text(TextKind::Compact).element_writer_for_slice(buffer)
+        }
+
+        fn make_pretty_text_writer(buffer: &mut [u8]) -> IonResult<SliceElementWriter> {
+            Format::Text(TextKind::Pretty).element_writer_for_slice(buffer)
+        }
+
+        fn make_binary_writer(buffer: &mut [u8]) -> IonResult<SliceElementWriter> {
+            Format::Binary.element_writer_for_slice(buffer)
+        }
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn native_good_roundtrip_text_binary(file_name: &str) {
+        good_roundtrip_text_binary(NativeElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn native_good_roundtrip_binary_text(file_name: &str) {
+        good_roundtrip_binary_text(NativeElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn native_good_roundtrip_text_pretty(file_name: &str) {
+        good_roundtrip_text_pretty(NativeElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn native_good_roundtrip_pretty_text(file_name: &str) {
+        good_roundtrip_pretty_text(NativeElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn native_good_roundtrip_pretty_binary(file_name: &str) {
+        good_roundtrip_pretty_binary(NativeElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/**/*.10n")]
+    fn native_good_roundtrip_binary_pretty(file_name: &str) {
+        good_roundtrip_binary_pretty(NativeElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/bad/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/bad/**/*.10n")]
+    fn native_bad(file_name: &str) {
+        bad(NativeElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/equivs/**/*.ion")]
+    #[test_resources("ion-tests/iontestdata/good/equivs/**/*.10n")]
+    fn native_equivs(file_name: &str) {
+        equivs(NativeElementApi {}, file_name)
+    }
+
+    #[test_resources("ion-tests/iontestdata/good/non-equivs/**/*.ion")]
+    // no binary files exist and the macro doesn't like empty globs...
+    // see frehberg/test-generator#12
+    //#[test_resources("ion-tests/iontestdata/good/non-equivs/**/*.10n")]
+    fn native_non_equivs(file_name: &str) {
+        non_equivs(NativeElementApi {}, file_name)
+    }
 }


### PR DESCRIPTION
This PR:
* Adds `NativeElementReader`, a pure-Rust implementation of the
`ElementReader` API. Iterates over a given byte slice and returns
materialized `OwnedElement` representations of the data.
* Modifies `tests/element_test_vectors.rs` to be able to run the
same `ion-tests` logic using both the `IonCElementReader` and the
new `NativeElementReader`. This includes the creation of a (very
long) skip list for the `NativeElementReader`.
* Renames `AnyInt` to `Integer` and moves it to the 'types' module
alongside `Decimal` and `Timestamp`.
* Renames `AnyUInt` to `UInteger` and moves it to the `types` module.
* Modifies the `UInt` decoder to be able to return `UInt`s of any
size, not just `u64`s.
* Modifies the `StreamReader` trait (and all implementations) to include
a `fn read_integer(&mut self) -> IonResult<Integer>` method that can
return an integer of any size.
* Fixes a bug in the `RawTextReader` that caused it to try and step into
container-typed `null` values.
* Adds a check to the `Timestamp` builder to make sure that the year
provided is in the range `1-9999` inclusive.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
