### PR TITLE
Fixes most `bad` native reader tests from `ion-tests`

### DIFF
--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -962,7 +962,7 @@ where
         // TODO: Is cursor.value.ion_type redundant?
         self.cursor.value.ion_type = header.ion_type.ok_or_else(|| {
             decoding_error_raw(format!(
-                "Found an invalid type code: {:?}",
+                "found an invalid type code: {:?}",
                 header.ion_type_code
             ))
         })?;
@@ -1104,9 +1104,6 @@ where
         let num_annotations_before = self.cursor.annotations.len();
         // The first byte of the annotations envelope is now behind the cursor
         let annotations_offset = self.cursor.bytes_read - 1;
-        // The encoding allows us to skip over the annotations list and the value, but in practice
-        // we won't know if we want to skip this value until we've read the type descriptor byte.
-        // That means we need to read the length even though we have no intent to use it.
         let annotations_and_value_length = self.read_standard_length()?;
         let annotations_length = self.read_var_uint()?;
         if annotations_length.value() == 0 {

--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -975,9 +975,8 @@ where
         use IonTypeCode::*;
         let length = match header.ion_type_code {
             NullOrNop | Boolean => 0,
-            PositiveInteger | NegativeInteger | Decimal | String | Symbol | List | SExpression | Clob | Blob => {
-                self.read_standard_length()?
-            }
+            PositiveInteger | NegativeInteger | Decimal | String | Symbol | List | SExpression
+            | Clob | Blob => self.read_standard_length()?,
             Timestamp => {
                 let length = self.read_standard_length()?;
                 if length <= 1 && !self.cursor.value.is_null {

--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -975,31 +975,22 @@ where
         use IonTypeCode::*;
         let length = match header.ion_type_code {
             NullOrNop | Boolean => 0,
-            PositiveInteger | Decimal | String | Symbol | List | SExpression | Clob | Blob => {
+            PositiveInteger | NegativeInteger | Decimal | String | Symbol | List | SExpression | Clob | Blob => {
                 self.read_standard_length()?
-            }
-            NegativeInteger => {
-                let length = self.read_standard_length()?;
-                if length == 0 && !self.cursor.value.is_null {
-                    return decoding_error(
-                        "Found a non-null negative integer (typecode=3) with a length of 0.",
-                    );
-                }
-                length
             }
             Timestamp => {
                 let length = self.read_standard_length()?;
                 if length <= 1 && !self.cursor.value.is_null {
                     return decoding_error(
-                        "Found a non-null timestamp (typecode=6) with a length <= 1.",
+                        "found a non-null timestamp (typecode=6) with a length <= 1",
                     );
                 }
                 length
             }
             Float => self.read_float_length()?,
             Struct => self.read_struct_length()?,
-            Annotation => return decoding_error("Found an annotation wrapping an annotation."),
-            Reserved => return decoding_error("Found an Ion Value with a Reserved type code."),
+            Annotation => return decoding_error("found an annotation wrapping an annotation"),
+            Reserved => return decoding_error("found an Ion Value with a Reserved type code"),
         };
 
         self.cursor.value.header_length =

--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -26,6 +26,7 @@ use crate::stream_reader::StreamReader;
 use crate::types::decimal::Decimal;
 use crate::types::integer::{IntAccess, Integer};
 use crate::types::timestamp::Timestamp;
+use num_traits::Zero;
 use std::ops::Range;
 
 /// Information about the value over which the RawBinaryReader is currently positioned.
@@ -96,14 +97,15 @@ impl EncodedValue {
     /// Returns the length of this value's header, including the type descriptor byte and any
     /// additional bytes used to encode the value's length.
     fn header_length(&self) -> usize {
-        self.header_length as usize
+        // The `header_length` field does not include the type descriptor byte, so add 1.
+        self.header_length as usize + 1
     }
 
     /// Returns an offset Range containing this value's type descriptor
     /// byte and any additional bytes used to encode the `length`.
     fn header_range(&self) -> Range<usize> {
         let start = self.header_offset;
-        let end = start + self.header_length as usize + 1;
+        let end = start + self.header_length();
         start..end
     }
 
@@ -344,6 +346,7 @@ impl<R: IonDataSource> StreamReader for RawBinaryReader<R> {
         }
 
         self.clear_annotations();
+        let mut expected_annotated_value_length = None;
         if header.ion_type_code == IonTypeCode::Annotation {
             if header.length_code == 0 {
                 // This is actually the first byte in an Ion Version Marker
@@ -352,7 +355,7 @@ impl<R: IonDataSource> StreamReader for RawBinaryReader<R> {
             }
             // We've found an annotated value. Read all of the annotation symbols leading
             // up to the value
-            let _ = self.read_annotations()?;
+            expected_annotated_value_length = Some(self.read_annotations()?);
             // Now read the next header representing the value itself.
             header = match self.read_next_value_header()? {
                 Some(header) => header,
@@ -371,6 +374,19 @@ impl<R: IonDataSource> StreamReader for RawBinaryReader<R> {
 
         self.cursor.index_at_depth += 1;
         self.cursor.value.index_at_depth = self.cursor.index_at_depth;
+
+        // If this value had an annotations wrapper, make sure the length of the value we just
+        // found is the expected size.
+        if let Some(expected_length) = expected_annotated_value_length {
+            let value = &self.cursor.value;
+            let encoded_length = value.header_length() + value.value_length();
+            if encoded_length != expected_length {
+                return decoding_error(format!(
+                    "annotations wrapper expected a {}-byte value, but found a {}-byte {}",
+                    expected_length, encoded_length, value.ion_type
+                ));
+            }
+        }
 
         let item = RawStreamItem::nullable_value(self.cursor.value.ion_type, self.is_null());
         Ok(self.set_current_item(item))
@@ -450,8 +466,11 @@ impl<R: IonDataSource> StreamReader for RawBinaryReader<R> {
 
         use self::IonTypeCode::*;
         let value = match (self.cursor.value.header.ion_type_code, value) {
-            (PositiveInteger, any_int) => any_int,
-            (NegativeInteger, any_int) => -any_int,
+            (PositiveInteger, integer) => integer,
+            (NegativeInteger, integer) if integer.is_zero() => {
+                return decoding_error("found a negative integer (typecode=3) with a value of 0");
+            }
+            (NegativeInteger, integer) => -integer,
             itc => unreachable!("Unexpected IonTypeCode: {:?}", itc),
         };
 
@@ -883,6 +902,9 @@ where
     }
 
     fn read_ivm(&mut self) -> IonResult<RawStreamItem> {
+        if self.depth() > 0 {
+            return decoding_error("found a binary IVM inside a container");
+        }
         let (major, minor) = self.read_slice(3, |bytes| match *bytes {
             [major, minor, 0xEA] => Ok((major, minor)),
             [major, minor, other] => decoding_error(format!(
@@ -937,7 +959,13 @@ where
     }
 
     fn process_header_by_type_code(&mut self, header: Header) -> IonResult<()> {
-        self.cursor.value.ion_type = header.ion_type.unwrap(); // TODO: Is cursor.value.ion_type redundant?
+        // TODO: Is cursor.value.ion_type redundant?
+        self.cursor.value.ion_type = header.ion_type.ok_or_else(|| {
+            decoding_error_raw(format!(
+                "Found an invalid type code: {:?}",
+                header.ion_type_code
+            ))
+        })?;
         self.cursor.value.header = header;
         self.cursor.value.is_null = header.length_code == length_codes::NULL;
 
@@ -947,8 +975,27 @@ where
         use IonTypeCode::*;
         let length = match header.ion_type_code {
             NullOrNop | Boolean => 0,
-            PositiveInteger | NegativeInteger | Decimal | Timestamp | String | Symbol | List
-            | SExpression | Clob | Blob => self.read_standard_length()?,
+            PositiveInteger | Decimal | String | Symbol | List | SExpression | Clob | Blob => {
+                self.read_standard_length()?
+            }
+            NegativeInteger => {
+                let length = self.read_standard_length()?;
+                if length == 0 && !self.cursor.value.is_null {
+                    return decoding_error(
+                        "Found a non-null negative integer (typecode=3) with a length of 0.",
+                    );
+                }
+                length
+            }
+            Timestamp => {
+                let length = self.read_standard_length()?;
+                if length <= 1 && !self.cursor.value.is_null {
+                    return decoding_error(
+                        "Found a non-null timestamp (typecode=6) with a length <= 1.",
+                    );
+                }
+                length
+            }
             Float => self.read_float_length()?,
             Struct => self.read_struct_length()?,
             Annotation => return decoding_error("Found an annotation wrapping an annotation."),
@@ -991,7 +1038,18 @@ where
     fn read_struct_length(&mut self) -> IonResult<usize> {
         let length = match self.cursor.value.header.length_code {
             length_codes::NULL => 0,
-            1 | length_codes::VAR_UINT => self.read_var_uint()?.value(),
+            // If the length code is `1`, it indicates an ordered struct. This is a special case
+            // of struct; it cannot be empty, and its fields must appear in ascending order of
+            // symbol ID. For the time being, the binary reader doesn't implement any special
+            // handling for it.
+            1 => {
+                let length = self.read_var_uint()?.value();
+                if length == 0 {
+                    return decoding_error("found an empty ordered struct");
+                }
+                length
+            }
+            length_codes::VAR_UINT => self.read_var_uint()?.value(),
             magnitude => magnitude as usize,
         };
 
@@ -1049,16 +1107,28 @@ where
         Ok(field_id)
     }
 
-    fn read_annotations(&mut self) -> IonResult<()> {
+    /// Reads the annotations in the annotations wrapper and returns the expected length of the
+    /// wrapped value that will follow.
+    fn read_annotations(&mut self) -> IonResult<usize> {
         let num_annotations_before = self.cursor.annotations.len();
         // The first byte of the annotations envelope is now behind the cursor
         let annotations_offset = self.cursor.bytes_read - 1;
         // The encoding allows us to skip over the annotations list and the value, but in practice
         // we won't know if we want to skip this value until we've read the type descriptor byte.
         // That means we need to read the length even though we have no intent to use it.
-        let _annotations_and_value_length = self.read_standard_length()?;
+        let annotations_and_value_length = self.read_standard_length()?;
         let annotations_length = self.read_var_uint()?;
+        if annotations_length.value() == 0 {
+            return decoding_error("found an annotations wrapper with no annotations");
+        }
+        let expected_value_length = annotations_and_value_length
+            - annotations_length.size_in_bytes()
+            - annotations_length.value();
+        if expected_value_length == 0 {
+            return decoding_error("found an annotation wrapper with no value");
+        }
         let mut bytes_read: usize = 0;
+
         while bytes_read < annotations_length.value() {
             let var_uint = self.read_var_uint()?;
             bytes_read += var_uint.size_in_bytes();
@@ -1072,7 +1142,7 @@ where
 
         // The annotations type descriptor byte + the length of the annotations sequence
         self.cursor.value.annotations_length = (self.cursor.bytes_read - annotations_offset) as u8;
-        Ok(())
+        Ok(expected_value_length)
     }
 
     fn read_exact(&mut self, number_of_bytes: usize) -> IonResult<()> {

--- a/src/binary/raw_binary_writer.rs
+++ b/src/binary/raw_binary_writer.rs
@@ -315,6 +315,7 @@ impl<W: Write> RawBinaryWriter<W> {
         // 1. The length of the encoded annotations sequence
         // 2. The length of the VarUInt representation of #1 above.
         // 3. The length of the value being annotated.
+        // 4. The length of the VarUInt representation of the wrapper's length
         let wrapper_length = annotations_seq_io_range.len()
             + annotations_seq_length_io_range.len()
             + wrapped_value_length;
@@ -776,6 +777,8 @@ impl<'a, W: Write> Writer for RawBinaryWriter<W> {
             }
             Ok(())
         })?;
+
+        let container_size = container_size + header_io_range.len();
 
         // Retrieve this container's header byte range from io_ranges
         let td_io_range = self

--- a/src/binary/raw_binary_writer.rs
+++ b/src/binary/raw_binary_writer.rs
@@ -315,7 +315,6 @@ impl<W: Write> RawBinaryWriter<W> {
         // 1. The length of the encoded annotations sequence
         // 2. The length of the VarUInt representation of #1 above.
         // 3. The length of the value being annotated.
-        // 4. The length of the VarUInt representation of the wrapper's length
         let wrapper_length = annotations_seq_io_range.len()
             + annotations_seq_length_io_range.len()
             + wrapped_value_length;
@@ -778,6 +777,8 @@ impl<'a, W: Write> Writer for RawBinaryWriter<W> {
             Ok(())
         })?;
 
+        // Now that we know how large the container's header is, add its length to the
+        // calculate container size.
         let container_size = container_size + header_io_range.len();
 
         // Retrieve this container's header byte range from io_ranges

--- a/src/binary/raw_binary_writer.rs
+++ b/src/binary/raw_binary_writer.rs
@@ -778,7 +778,7 @@ impl<'a, W: Write> Writer for RawBinaryWriter<W> {
         })?;
 
         // Now that we know how large the container's header is, add its length to the
-        // calculate container size.
+        // calculated container size.
         let container_size = container_size + header_io_range.len();
 
         // Retrieve this container's header byte range from io_ranges

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -61,7 +61,7 @@ impl<R: RawReader> Reader<R> {
         let mut new_symbols = vec![];
 
         // It's illegal for a symbol table to have multiple `symbols` or `imports` fields.
-        // Keep track of whethe we've already encountered them.
+        // Keep track of whether we've already encountered them.
         let mut has_found_symbols_field = false;
         let mut has_found_imports_field = false;
 

--- a/src/text/parsers/string.rs
+++ b/src/text/parsers/string.rs
@@ -142,6 +142,8 @@ mod string_parsing_tests {
         parse_fails("\"Hello, world ");
         // Leading whitespace not accepted
         parse_fails(" \"Hello, world\" ");
+        // Unicode escape producing invalid surrogate
+        parse_fails(r#"'''\ud800'''\n"#);
     }
 
     #[test]

--- a/src/text/parsers/timestamp.rs
+++ b/src/text/parsers/timestamp.rs
@@ -271,7 +271,6 @@ fn timezone_offset(input: &str) -> IResult<&str, Option<i32>> {
 /// Recognizes the hours and minutes portions of a timezone offset. (`12` and `35` in `12:35`)
 fn timezone_offset_hours_minutes(input: &str) -> IResult<&str, (i32, i32)> {
     let (remaining_input, (hours, minutes)) = separated_pair(
-        // The parser does not restrict the range of hours/minutes allowed in the offset.
         recognize(pair(digit, digit)),
         tag(":"),
         recognize(pair(digit, digit)),

--- a/src/text/parsers/timestamp.rs
+++ b/src/text/parsers/timestamp.rs
@@ -6,8 +6,9 @@ use nom::bytes::streaming::tag;
 use nom::character::complete::digit1;
 use nom::character::streaming::{char, one_of};
 use nom::combinator::{map, map_res, opt, recognize};
+use nom::error::{make_error, ErrorKind};
 use nom::sequence::{pair, preceded, separated_pair, terminated, tuple};
-use nom::IResult;
+use nom::{Err, IResult};
 use num_bigint::BigUint;
 
 use crate::result::IonError;
@@ -257,8 +258,6 @@ fn timezone_offset(input: &str) -> IResult<&str, Option<i32>> {
         map(
             pair(one_of("-+"), timezone_offset_hours_minutes),
             |(sign, (hours, minutes))| {
-                let hours = trim_zeros_expect_i32(hours, "offset hours");
-                let minutes = trim_zeros_expect_i32(minutes, "offset minutes");
                 let offset_minutes = (hours * 60) + minutes;
                 if sign == '-' {
                     return Some(-offset_minutes);
@@ -270,13 +269,22 @@ fn timezone_offset(input: &str) -> IResult<&str, Option<i32>> {
 }
 
 /// Recognizes the hours and minutes portions of a timezone offset. (`12` and `35` in `12:35`)
-fn timezone_offset_hours_minutes(input: &str) -> IResult<&str, (&str, &str)> {
-    separated_pair(
+fn timezone_offset_hours_minutes(input: &str) -> IResult<&str, (i32, i32)> {
+    let (remaining_input, (hours, minutes)) = separated_pair(
         // The parser does not restrict the range of hours/minutes allowed in the offset.
         recognize(pair(digit, digit)),
         tag(":"),
         recognize(pair(digit, digit)),
-    )(input)
+    )(input)?;
+    let hour_int = trim_zeros_expect_i32(hours, "offset hours");
+    let minute_int = trim_zeros_expect_i32(minutes, "offset minutes");
+    if hour_int >= 24 {
+        return Err(Err::Failure(make_error(hours, ErrorKind::TooLarge)));
+    }
+    if minute_int >= 60 {
+        return Err(Err::Failure(make_error(minutes, ErrorKind::TooLarge)));
+    }
+    Ok((remaining_input, (hour_int, minute_int)))
 }
 
 #[cfg(test)]

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -91,10 +91,16 @@ impl<T: TextIonDataSource> RawTextReader<T> {
             }
 
             // Otherwise, see if the next token in the stream is an Ion Version Marker.
-            if let Ok(Some(_)) = self.parse_next(ion_1_0_version_marker) {
-                // We found an IVM; we currently only support Ion 1.0.
-                self.current_ivm = Some((1, 0));
-                return Ok(());
+            match self.parse_next(ion_1_0_version_marker) {
+                Ok(Some(_)) => {
+                    // We found an IVM; we currently only support Ion 1.0.
+                    self.current_ivm = Some((1, 0));
+                    return Ok(());
+                }
+                Err(e @ IonError::IoError { .. }) => return Err(e),
+                _ => {
+                    // Any other kind of error is a parse error; it's not an IVM.
+                }
             }
 
             // If it wasn't an IVM, it has to be a value.

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -494,6 +494,18 @@ impl TimestampBuilder {
 
         // Copy the fractional seconds from the builder to the Timestamp.
         if self.precision == Precision::FractionalSeconds {
+            if let Some(Mantissa::Arbitrary(ref decimal)) = self.fractional_seconds {
+                if decimal.is_less_than_zero() {
+                    return illegal_operation(
+                        "cannot create a timestamp with negative fractional seconds",
+                    );
+                }
+                if decimal.is_greater_than_or_equal_to_one() {
+                    return illegal_operation(
+                        "cannot create a timestamp with a fractional seconds >= 1.0",
+                    );
+                }
+            }
             timestamp.fractional_seconds = self.fractional_seconds;
         }
         Ok(timestamp)

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -534,77 +534,38 @@ mod native_element_tests {
 
         fn global_skip_list() -> SkipList {
             &[
-                "ion-tests/iontestdata/bad/annotationLengthTooLongContainer.10n",
-                "ion-tests/iontestdata/bad/annotationLengthTooLongScalar.10n",
-                "ion-tests/iontestdata/bad/annotationLengthTooShortContainer.10n",
-                "ion-tests/iontestdata/bad/annotationLengthTooShortScalar.10n",
-                "ion-tests/iontestdata/bad/annotationNested.10n",
-                "ion-tests/iontestdata/bad/annotationWithNoValue.10n",
-                "ion-tests/iontestdata/bad/badMagicE00100E0.10n",
+                // The text reader does not validate whether a clob's text contains unescaped
+                // characters outside of the displayable ASCII range.
                 "ion-tests/iontestdata/bad/clobWithNonAsciiCharacter.ion",
                 "ion-tests/iontestdata/bad/clobWithNonAsciiCharacterMultiline.ion",
                 "ion-tests/iontestdata/bad/clobWithNullCharacter.ion",
                 "ion-tests/iontestdata/bad/clobWithValidUtf8ButNonAsciiCharacter.ion",
-                "ion-tests/iontestdata/bad/emptyAnnotatedInt.10n",
+                // The text reader only recognizes `$ion_1_0`; it doesn't match on
+                // $ion_{DIGITS}_{DIGITS} yet. The IVMs in these tests are considered symbols.
+                // This means that the text reader would fail to recognize unsupported versions
+                // of Ion.
                 "ion-tests/iontestdata/bad/invalidVersionMarker_ion_0_0.ion",
                 "ion-tests/iontestdata/bad/invalidVersionMarker_ion_1_1.ion",
                 "ion-tests/iontestdata/bad/invalidVersionMarker_ion_1234_0.ion",
                 "ion-tests/iontestdata/bad/invalidVersionMarker_ion_2_0.ion",
-                "ion-tests/iontestdata/bad/ivmInAnnotationWrapper.10n",
-                "ion-tests/iontestdata/bad/ivmInList.10n",
-                "ion-tests/iontestdata/bad/ivmInSexp.10n",
-                "ion-tests/iontestdata/bad/ivmInStruct.10n",
-                "ion-tests/iontestdata/bad/ivmInSymbolTableImport.10n",
+                // The binary reader does not check whether nested values are longer than their
+                // parent container.
                 "ion-tests/iontestdata/bad/listWithValueLargerThanSize.10n",
-                "ion-tests/iontestdata/bad/localSymbolTableWithMultipleImportsFields.10n",
-                "ion-tests/iontestdata/bad/localSymbolTableWithMultipleSymbolsAndImportsFields.10n",
-                "ion-tests/iontestdata/bad/localSymbolTableWithMultipleSymbolsFields.10n",
-                "ion-tests/iontestdata/bad/longStringRawControlCharacter.ion",
+                // The text reader does not raise an error on unrecognized escapes. Instead,
+                // it treats them as uninterpreted literals. In this test, '\e' should raise
+                // an error but up appearing in the string as the literal text "\e".
                 "ion-tests/iontestdata/bad/longStringSlashE.ion",
+                // These fail because the string parser treats a truncated unicode escape at the end
+                // of a string fragment (e.g. '''\u''' with no digits) as a string literal instead
+                // of a malformed stream.
                 "ion-tests/iontestdata/bad/longStringSplitEscape_1.ion",
                 "ion-tests/iontestdata/bad/longStringSplitEscape_2.ion",
-                "ion-tests/iontestdata/bad/negativeIntZero.10n",
-                "ion-tests/iontestdata/bad/negativeIntZeroLn.10n",
+                // These fail because non-displayable ASCII control characters are valid utf-8. A
+                // separate check is needed to confirm that raw control characters only show up
+                // as escape sequences.
+                "ion-tests/iontestdata/bad/longStringRawControlCharacter.ion",
                 "ion-tests/iontestdata/bad/stringRawControlCharacter.ion",
                 "ion-tests/iontestdata/bad/stringWithEol.ion",
-                "ion-tests/iontestdata/bad/structOrderedEmpty.10n",
-                "ion-tests/iontestdata/bad/structOrderedEmptyInList.10n",
-                "ion-tests/iontestdata/bad/timestamp/outOfRange/offsetMinutes_1.ion",
-                "ion-tests/iontestdata/bad/timestamp/outOfRange/offsetMinutes_2.ion",
-                "ion-tests/iontestdata/bad/timestamp/outOfRange/offsetMinutes_3.ion",
-                "ion-tests/iontestdata/bad/timestamp/timestampFraction10d-1.10n",
-                "ion-tests/iontestdata/bad/timestamp/timestampFraction11d-1.10n",
-                "ion-tests/iontestdata/bad/timestamp/timestampFraction1d0.10n",
-                "ion-tests/iontestdata/bad/timestamp/timestampNegativeFraction.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_0.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_1.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_10.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_11.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_12.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_13.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_14.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_15.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_2.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_3.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_4.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_5.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_6.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_7.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_8.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_15_length_9.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_3_length_0.10n",
-                "ion-tests/iontestdata/bad/typecodes/type_6_length_0.10n",
-                "ion-tests/iontestdata/bad/utf8/outOfUnicodeBounds_1.ion",
-                "ion-tests/iontestdata/bad/utf8/outOfUnicodeBounds_2.ion",
-                "ion-tests/iontestdata/bad/utf8/shortUtf8Sequence_1.ion",
-                "ion-tests/iontestdata/bad/utf8/shortUtf8Sequence_2.ion",
-                "ion-tests/iontestdata/bad/utf8/shortUtf8Sequence_3.ion",
-                "ion-tests/iontestdata/bad/utf8/surrogate_10.ion",
-                "ion-tests/iontestdata/bad/utf8/surrogate_5.ion",
-                "ion-tests/iontestdata/bad/utf8/surrogate_8.ion",
-                "ion-tests/iontestdata/bad/utf8/wrongUtf8LeadingBits_1.ion",
-                "ion-tests/iontestdata/bad/utf8/wrongUtf8LeadingBits_2.ion",
-                "ion-tests/iontestdata/bad/utf8/wrongUtf8LeadingBits_3.ion",
                 // ROUND TRIP
                 "ion-tests/iontestdata/good/blobs.ion",
                 "ion-tests/iontestdata/good/clobs.ion",


### PR DESCRIPTION
* The `RawBinaryReader` now surfaces an error if it encounters...
   * an annotated value whose length doesn't match that of the
   annotations wrapper.
   * an annotations wrapper with no annotations
   * an annotations wrapper with no value
   * a negative integer (typecode=3) with a magnitude of 0.
   * a malformed IVM.
   * an IVM at any depth other than 0.
   * a value with with typecode=15. (Previously it panicked.)
   * a timestamp with a length <= 1 (missing required fields)
   * an empty ordered struct
* The `RawBinaryWriter` now correctly encodes the annotations wrapper
  length of annotated containers. Previously the reader would
  ignore this (often redundant) field, allowing tests to pass
  erroneously. The binary writer would omit the container's header
  bytes from its size calculations.
* The `RawTextReader` will now surface an error if it encounters...
   * a text value with invalid unicode escapes. (Previously it would
   fail to match the invalid escape and fall back to treating the
   escapes as uninterpreted text.)
   * a timestamp offset with `hours >= 24` or `minutes >= 60`.
   * a timestamp with a `Decimal` fractional seconds `< 0` or
   `>= 1`.
* The `Reader` will now surface an error if it encounters a symbol
  table with more than one `symbols` field or more than one
  `imports` field.

This patch also adds comments to the remaining `bad` tests in the
native reader's skip list describing what needs to be done to address
them in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
