### PR TITLE
Makes doc links into build errors

### DIFF
--- a/ion-c-sys/src/result.rs
+++ b/ion-c-sys/src/result.rs
@@ -22,7 +22,7 @@ pub struct IonCError {
 }
 
 /// Represents a position in a data source. For example, consider a file
-/// containing Ion data that is being parsed using an [`IonCReader`].
+/// containing Ion data that is being parsed using an [IonCReader](crate::reader::IonCReader).
 ///
 /// If a position is set, `bytes` will always be hydrated while `lines` and
 /// `offset` will only be populated for text readers.

--- a/src/binary/raw_binary_writer.rs
+++ b/src/binary/raw_binary_writer.rs
@@ -114,7 +114,7 @@ impl EncodingLevel {
 /// management; symbol-related operations (e.g. setting field IDs and annotations or writing symbol
 /// values) require a valid symbol ID to be provided by the caller.
 ///
-/// To produce a valid binary Ion stream, the writer MUST call [write_ion_version_marker] before
+/// To produce a valid binary Ion stream, the writer MUST call [Writer::write_ion_version_marker] before
 /// writing any data.
 #[derive(Debug)]
 pub struct RawBinaryWriter<W: Write> {

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -124,7 +124,7 @@ impl EncodedUInt {
 }
 
 impl AsRef<[u8]> for EncodedUInt {
-    /// The same as [`as_bytes`].
+    /// The same as [EncodedUInt::as_bytes].
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 /// A [`try`]-like macro to workaround the [`Option`]/[`Result`] nested APIs.
 /// These API require checking the type and then calling the appropriate getter function
@@ -37,13 +38,25 @@ pub use raw_reader::RawStreamItem;
 pub use reader::Reader;
 pub use reader::StreamItem;
 pub use stream_reader::StreamReader;
-pub use symbol_table::SymbolTable;
+pub use symbol_table::{SymbolTable, Symbol};
+pub use raw_symbol_token::RawSymbolToken;
 pub use system_reader::{SystemReader, SystemStreamItem};
+
 pub use types::IonType;
+pub use types::timestamp::Timestamp;
+pub use types::decimal::Decimal;
+pub use types::integer::Integer;
+
+pub use writer::Writer;
+pub use binary::binary_writer::BinaryWriter;
+pub use text::text_writer::TextWriter;
+
+pub use result::IonResult;
+pub use result::IonError;
 
 /// Re-exports of third party dependencies that are part of our public API.
 ///
-/// See also: https://github.com/amzn/ion-rust/issues/302.
+/// See also: <https://github.com/amzn/ion-rust/issues/302>
 pub mod external {
     pub use bigdecimal;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,24 +35,24 @@ mod writer;
 pub use binary::raw_binary_reader::RawBinaryReader;
 pub use data_source::IonDataSource;
 pub use raw_reader::RawStreamItem;
+pub use raw_symbol_token::RawSymbolToken;
 pub use reader::Reader;
 pub use reader::StreamItem;
 pub use stream_reader::StreamReader;
-pub use symbol_table::{SymbolTable, Symbol};
-pub use raw_symbol_token::RawSymbolToken;
+pub use symbol_table::{Symbol, SymbolTable};
 pub use system_reader::{SystemReader, SystemStreamItem};
 
-pub use types::IonType;
-pub use types::timestamp::Timestamp;
 pub use types::decimal::Decimal;
 pub use types::integer::Integer;
+pub use types::timestamp::Timestamp;
+pub use types::IonType;
 
-pub use writer::Writer;
 pub use binary::binary_writer::BinaryWriter;
 pub use text::text_writer::TextWriter;
+pub use writer::Writer;
 
-pub use result::IonResult;
 pub use result::IonError;
+pub use result::IonResult;
 
 /// Re-exports of third party dependencies that are part of our public API.
 ///

--- a/src/raw_reader.rs
+++ b/src/raw_reader.rs
@@ -3,7 +3,7 @@ use crate::stream_reader::StreamReader;
 use crate::types::IonType;
 use std::fmt::{Display, Formatter};
 
-/// `RawReader` is a shorthand for a [Reader] implementation that returns [RawStreamItem]s and
+/// `RawReader` is a shorthand for a [Reader](crate::Reader) implementation that returns [RawStreamItem]s and
 /// uses [RawSymbolToken] to represent its field names, annotations, and symbol values.
 pub trait RawReader: StreamReader<Item = RawStreamItem, Symbol = RawSymbolToken> {
     // Defines no additional functionality

--- a/src/stream_reader.rs
+++ b/src/stream_reader.rs
@@ -12,7 +12,7 @@ use crate::types::IonType;
  * calling that function again may return an Err. This is left to the discretion of the implementor.
  */
 pub trait StreamReader {
-    /// The type returned by calls to [next], indicating the next entity in the stream.
+    /// The type returned by calls to [Self::next], indicating the next entity in the stream.
     /// Reader implementations representing different levels of abstraction will surface
     /// different sets of encoding artifacts. While an application-level Reader would only surface
     /// Ion values, a lower level Reader might surface symbol tables, Ion version markers, etc.
@@ -60,7 +60,7 @@ pub trait StreamReader {
     }
 
     /// If the current item is a field within a struct, returns `Ok(_)` with a [Self::Symbol]
-    /// representing the field's name; otherwise, returns an [IonError::IllegalOperation].
+    /// representing the field's name; otherwise, returns an [crate::IonError::IllegalOperation].
     ///
     /// Implementations may also return an error for other reasons; for example, if [Self::Symbol]
     /// is a text data type but the field name is an undefined symbol ID, the reader may return
@@ -71,36 +71,37 @@ pub trait StreamReader {
     fn is_null(&self) -> bool;
 
     /// Attempts to read the current item as an Ion null and return its Ion type. If the current
-    /// item is not a null or an IO error is encountered while reading, returns [IonError].
+    /// item is not a null or an IO error is encountered while reading, returns [crate::IonError].
     fn read_null(&mut self) -> IonResult<IonType>;
 
     /// Attempts to read the current item as an Ion boolean and return it as a bool. If the current
-    /// item is not a boolean or an IO error is encountered while reading, returns [IonError].
+    /// item is not a boolean or an IO error is encountered while reading, returns [crate::IonError].
     fn read_bool(&mut self) -> IonResult<bool>;
 
     /// Attempts to read the current item as an Ion integer and return it as an i64. If the current
     /// item is not an integer, the integer is too large to be represented as an `i64`, or an IO
-    /// error is encountered while reading, returns [IonError].
+    /// error is encountered while reading, returns [crate::IonError].
     fn read_i64(&mut self) -> IonResult<i64>;
 
-    /// Attempts to read the current item as an Ion integer and return it as an [Integer]. If the
-    /// current item is not an integer or an IO error is encountered while reading, returns [IonError].
+    /// Attempts to read the current item as an Ion integer and return it as an [crate::Integer]. If the
+    /// current item is not an integer or an IO error is encountered while reading, returns
+    /// [crate::IonError].
     fn read_integer(&mut self) -> IonResult<Integer>;
 
     /// Attempts to read the current item as an Ion float and return it as an f32. If the current
-    /// item is not a float or an IO error is encountered while reading, returns [IonError].
+    /// item is not a float or an IO error is encountered while reading, returns [crate::IonError].
     fn read_f32(&mut self) -> IonResult<f32>;
 
     /// Attempts to read the current item as an Ion float and return it as an f64. If the current
-    /// item is not a float or an IO error is encountered while reading, returns [IonError].
+    /// item is not a float or an IO error is encountered while reading, returns [crate::IonError].
     fn read_f64(&mut self) -> IonResult<f64>;
 
-    /// Attempts to read the current item as an Ion decimal and return it as a [Decimal]. If the current
-    /// item is not a decimal or an IO error is encountered while reading, returns [IonError].
+    /// Attempts to read the current item as an Ion decimal and return it as a [crate::Decimal]. If the current
+    /// item is not a decimal or an IO error is encountered while reading, returns [crate::IonError].
     fn read_decimal(&mut self) -> IonResult<Decimal>;
 
     /// Attempts to read the current item as an Ion string and return it as a [String]. If the current
-    /// item is not a string or an IO error is encountered while reading, returns [IonError].
+    /// item is not a string or an IO error is encountered while reading, returns [crate::IonError].
     fn read_string(&mut self) -> IonResult<String>;
 
     /// Takes a function that expects a string and, once the string's bytes are loaded, calls that
@@ -123,11 +124,11 @@ pub trait StreamReader {
         F: FnOnce(&[u8]) -> U;
 
     /// Attempts to read the current item as an Ion symbol and return it as a [Self::Symbol]. If the
-    /// current item is not a symbol or an IO error is encountered while reading, returns [IonError].
+    /// current item is not a symbol or an IO error is encountered while reading, returns [crate::IonError].
     fn read_symbol(&mut self) -> IonResult<Self::Symbol>;
 
     /// Attempts to read the current item as an Ion blob and return it as a [Vec<u8>]. If the
-    /// current item is not a blob or an IO error is encountered while reading, returns [IonError].
+    /// current item is not a blob or an IO error is encountered while reading, returns [crate::IonError].
     fn read_blob(&mut self) -> IonResult<Vec<u8>>;
 
     /// Takes a function that expects a byte slice and, once the blob's bytes are loaded, calls that
@@ -140,7 +141,7 @@ pub trait StreamReader {
         F: FnOnce(&[u8]) -> U;
 
     /// Attempts to read the current item as an Ion clob and return it as a [Vec<u8>]. If the
-    /// current item is not a clob or an IO error is encountered while reading, returns [IonError].
+    /// current item is not a clob or an IO error is encountered while reading, returns [crate::IonError].
     fn read_clob(&mut self) -> IonResult<Vec<u8>>;
 
     /// Takes a function that expects a byte slice and, once the clob's bytes are loaded, calls that
@@ -152,23 +153,23 @@ pub trait StreamReader {
     where
         F: FnOnce(&[u8]) -> U;
 
-    /// Attempts to read the current item as an Ion timestamp and return [Timestamp]. If the current
-    /// item is not a timestamp or an IO error is encountered while reading, returns [IonError].
+    /// Attempts to read the current item as an Ion timestamp and return [crate::Timestamp]. If the current
+    /// item is not a timestamp or an IO error is encountered while reading, returns [crate::IonError].
     fn read_timestamp(&mut self) -> IonResult<Timestamp>;
 
     /// If the current value is a container (i.e. a struct, list, or s-expression), positions the
     /// cursor at the beginning of that container's sequence of child values. The application must
-    /// call [next()] to advance to the first child value. If the current value is not a container,
-    /// returns [IonError].
+    /// call [Self::next()] to advance to the first child value. If the current value is not a container,
+    /// returns [crate::IonError].
     fn step_in(&mut self) -> IonResult<()>;
 
-    /// Positions the cursor at the end of the container currently being traversed. Calling [next()]
+    /// Positions the cursor at the end of the container currently being traversed. Calling [Self::next()]
     /// will position the cursor over the item that follows the container. If the cursor is not in
-    /// a container (i.e. it is already at the top level), returns [IonError].
+    /// a container (i.e. it is already at the top level), returns [crate::IonError].
     fn step_out(&mut self) -> IonResult<()>;
 
     /// If the reader is positioned at the top level, returns `None`. Otherwise, returns
-    /// `Some(_)` with the parent container's [IonType].
+    /// `Some(_)` with the parent container's [crate::IonType].
     fn parent_type(&self) -> Option<IonType>;
 
     /// Returns a [usize] indicating the Reader's current level of nesting. That is: the number of

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -5,4 +5,4 @@ pub mod raw_text_writer;
 mod text_buffer;
 mod text_data_source;
 mod text_value;
-mod text_writer;
+pub(crate) mod text_writer;

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -632,7 +632,7 @@ impl SecondSetter {
         self.into_builder().build()
     }
 
-    /// Like [build_at_offset], but the fields provided for each time unit are understood
+    /// Like [Self::build_at_offset], but the fields provided for each time unit are understood
     /// to be in UTC rather than in the local time of the specified offset.
     pub fn build_utc_fields_at_offset(mut self, offset_minutes: i32) -> IonResult<Timestamp> {
         self.builder.fields_are_utc = true;
@@ -704,7 +704,7 @@ impl FractionalSecondSetter {
         self.into_builder().build()
     }
 
-    /// Like [build_at_offset], but the fields provided for each time unit are understood
+    /// Like [Self::build_at_offset], but the fields provided for each time unit are understood
     /// to be in UTC rather than in the local time of the specified offset.
     pub fn build_utc_fields_at_offset(mut self, offset_minutes: i32) -> IonResult<Timestamp> {
         self.builder.fields_are_utc = true;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -19,8 +19,9 @@ pub trait Writer {
     /// Returns `true` if this RawWriter supports writing field names, annotations, and
     /// symbol values directly as text; otherwise, returns `false`.
     ///
-    /// If this method returns `false`, passing a [RawSymbolTokenRef::Text] to the
-    /// [set_annotations], [set_field_name], or [write_symbol] methods may result in a panic.
+    /// If this method returns `false`, passing a [crate::RawSymbolToken::Text] to the
+    /// [Self::set_annotations], [Self::set_field_name], or [Self::write_symbol] methods may result
+    /// in a panic.
     fn supports_text_symbol_tokens(&self) -> bool;
 
     /// Sets a list of annotations that will be applied to the next value that is written.


### PR DESCRIPTION
Adds `#![deny(rustdoc::broken_intra_doc_links)]` to the crate,
requiring all references in doc comments to be valid before it
will build successfully. Also fixes any existing broken links.

Fixes #362.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
