### PR TITLE
Text reader fixes: escapes, whitespace, IVMs

### DIFF
--- a/src/text/parsers/annotations.rs
+++ b/src/text/parsers/annotations.rs
@@ -38,7 +38,7 @@ pub(crate) fn parse_annotation(input: &str) -> IonParseResult<RawSymbolToken> {
     )(input)
 }
 
-fn annotation_delimiter(input: &str) -> IonParseResult<&str> {
+pub(crate) fn annotation_delimiter(input: &str) -> IonParseResult<&str> {
     preceded(multispace0, tag("::"))(input).upgrade()
 }
 

--- a/src/text/parsers/comments.rs
+++ b/src/text/parsers/comments.rs
@@ -1,7 +1,7 @@
 use crate::text::parse_result::{IonParseResult, UpgradeIResult};
+use crate::text::parsers::whitespace;
 use nom::branch::alt;
 use nom::bytes::streaming::{is_not, tag, take_until};
-use nom::character::streaming::multispace1;
 use nom::combinator::recognize;
 use nom::multi::many0_count;
 use nom::sequence::{delimited, preceded};
@@ -11,8 +11,7 @@ use nom::sequence::{delimited, preceded};
 pub(crate) fn whitespace_or_comments(input: &str) -> IonParseResult<&str> {
     recognize(many0_count(alt((
         // At least one character of whitespace...
-        multispace1,
-        // ...or a comment of any format.
+        whitespace, // ...or a comment of any format.
         comment,
     ))))(input)
 }

--- a/src/text/parsers/mod.rs
+++ b/src/text/parsers/mod.rs
@@ -26,8 +26,18 @@ pub(crate) mod timestamp;
 pub(crate) mod top_level;
 pub(crate) mod value;
 
-const WHITESPACE_CHARACTERS: &[char] = &[' ', '\t', '\r', '\n'];
-const WHITESPACE_CHARACTERS_AS_STR: &str = " \t\r\n";
+const WHITESPACE_CHARACTERS: &[char] = &[
+    ' ',        // Space
+    '\t',       // Tab
+    '\r',       // Carriage return
+    '\n',       // Newline
+    '\u{0009}', // Horizontal tab
+    '\u{000B}', // Vertical tab
+    '\u{000C}', // Form feed
+];
+
+/// Same as [WHITESPACE_CHARACTERS], but formatted as a string for use in some `nom` APIs
+const WHITESPACE_CHARACTERS_AS_STR: &str = " \t\r\n\u{0009}\u{000B}\u{000C}";
 
 // ===== The functions below are used by several modules and live here for common access. =====
 

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -1,16 +1,38 @@
 use nom::branch::alt;
 use nom::bytes::streaming::tag;
 use nom::character::streaming::{digit0, one_of};
-use nom::combinator::recognize;
+use nom::combinator::{map, not, recognize};
 
 use crate::text::parse_result::{IonParseResult, OrFatalParseError, UpgradeIResult};
-use nom::sequence::{pair, preceded, tuple};
+use crate::text::parsers::annotations::annotation_delimiter;
+use nom::sequence::{delimited, pair, preceded, tuple};
 use std::str::FromStr;
 
 use crate::text::parsers::comments::whitespace_or_comments;
 
 use crate::text::parsers::value::annotated_value;
 use crate::text::text_value::AnnotatedTextValue;
+
+/// Represents a single item that can appear at the top level of a text stream.
+#[derive(PartialEq, Debug)]
+pub(crate) enum RawTextStreamItem {
+    /// An marker indicating that the stream's version is (major, minor).
+    IonVersionMarker(u32, u32),
+    /// A (possibly annotated) Ion value.
+    AnnotatedTextValue(AnnotatedTextValue),
+}
+
+/// Matches an Ion version marker or a (possibly annotated) value.
+pub(crate) fn stream_item(input: &str) -> IonParseResult<RawTextStreamItem> {
+    alt((
+        map(ion_version_marker, |(major, minor)| {
+            RawTextStreamItem::IonVersionMarker(major, minor)
+        }),
+        map(top_level_value, |value| {
+            RawTextStreamItem::AnnotatedTextValue(value)
+        }),
+    ))(input)
+}
 
 /// Matches an optional series of annotations and a TextValue at the beginning of the given
 /// string. If there are no annotations (or the TextValue found cannot have annotations), the
@@ -40,9 +62,10 @@ pub(crate) fn version_int(input: &str) -> IonParseResult<&str> {
 /// https://amzn.github.io/ion-docs/docs/symbols.html#ion-version-markers
 pub(crate) fn ion_version_marker(input: &str) -> IonParseResult<(u32, u32)> {
     // See if the input text matches an IVM. If not, return a non-fatal error.
-    let (remaining_input, (_, major_text, _, minor_text)) = preceded(
+    let (remaining_input, (_, major_text, _, minor_text)) = delimited(
         whitespace_or_comments,
         tuple((tag("$ion_"), version_int, tag("_"), version_int)),
+        not(annotation_delimiter),
     )(input)?;
 
     // If the text matched but parsing that into a major and minor version fails, it's a fatal
@@ -136,26 +159,34 @@ mod parse_top_level_values_tests {
         );
     }
 
+    // Each of these input strings is followed by a ` 1` so the parser can definitively say the
+    // IVM is not followed by a `::`, which would make it an annotation instead.
     #[rstest]
-    #[case("$ion_1_0 ")]
-    #[case("   \r  \t \n $ion_1_0 ")]
-    #[case(" /*comment 1*/\n//comment 2\n   $ion_1_0 ")]
+    #[case("$ion_1_0 1")]
+    #[case("   \r  \t \n $ion_1_0 1")]
+    #[case(" /*comment 1*/\n//comment 2\n   $ion_1_0 1")]
     fn test_parse_ion_1_0_ivm(#[case] text: &str) {
         parse_test_ok(ion_version_marker, text, (1, 0));
     }
 
+    // Each of these input strings is followed by a ` 1` so the parser can definitively say the
+    // IVM is not followed by a `::`, which would make it an annotation instead.
     #[rstest]
-    #[case("$ion_1_1 ", (1, 1))]
-    #[case("/*hello!*/ $ion_1_1 ", (1, 1))]
-    #[case("$ion_2_0 ", (2, 0))]
-    #[case("\n \n $ion_2_0 ", (2, 0))]
-    #[case("$ion_5_8 ", (5, 8))]
-    #[case("$ion_21_99 ", (21, 99))]
+    #[case("$ion_1_1 1", (1, 1))]
+    #[case("/*hello!*/ $ion_1_1 1", (1, 1))]
+    #[case("$ion_2_0 1", (2, 0))]
+    #[case("\n \n $ion_2_0 1", (2, 0))]
+    #[case("$ion_5_8 1", (5, 8))]
+    #[case("$ion_21_99 1", (21, 99))]
     fn test_parse_ivm_for_other_versions(#[case] text: &str, #[case] expected: (u32, u32)) {
         parse_test_ok(ion_version_marker, text, expected);
     }
 
     #[rstest]
+    // An annotation, not an IVM
+    #[case("$ion_1_0::foo")]
+    // An annotation, not an IVM
+    #[case("$ion_1_0      ::foo")]
     // Quoted, therefore a symbol
     #[case("'$ion_1_0' ")]
     // Not a literal, therefore a symbol

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -14,7 +14,7 @@ use crate::text::parsers::containers::{
     list_delimiter, list_value_or_end, s_expression_delimiter, s_expression_value_or_end,
     struct_delimiter, struct_field_name_or_end, struct_field_value,
 };
-use crate::text::parsers::top_level::{ion_version_marker, top_level_value};
+use crate::text::parsers::top_level::{stream_item, RawTextStreamItem};
 use crate::text::text_buffer::TextBuffer;
 use crate::text::text_data_source::TextIonDataSource;
 use crate::text::text_value::{AnnotatedTextValue, TextValue};
@@ -48,6 +48,7 @@ pub struct RawTextReader<T: TextIonDataSource> {
 /// making it difficult to perform the necessary bookkeeping that follows finding the next value.
 ///
 /// This type is intentionally limited in what it stores to avoid having a lifetime.
+#[derive(Eq, PartialEq, Debug)]
 pub(crate) enum RootParseResult<O> {
     Ok(O),
     Eof,
@@ -104,45 +105,8 @@ impl<T: TextIonDataSource> RawTextReader<T> {
                 return Ok(());
             }
 
-            // Otherwise, see if the next token in the stream is an Ion Version Marker.
-            match self.parse_next_nom(ion_version_marker) {
-                RootParseResult::Ok((1, 0)) => {
-                    // We found an IVM; we currently only support Ion 1.0.
-                    self.current_ivm = Some((1, 0));
-                    return Ok(());
-                }
-                RootParseResult::Ok((major, minor)) => {
-                    return decoding_error(format!(
-                        "Unsupported Ion version: v{}.{}. Only 1.0 is supported.",
-                        major, minor
-                    ));
-                }
-                RootParseResult::Failure(error_message) => {
-                    return decoding_error(error_message);
-                }
-                _ => {
-                    // Any other kind of error is a parse error; it's not an IVM.
-                    // Move on to trying to read a value.
-                    // EOFs are also handled below.
-                }
-            }
-
-            // If it wasn't an IVM, it has to be a value.
-            let value = self.next_top_level_value()?;
-            match value {
-                None => {
-                    // We hit EOF; make a note of it and clear the current value.
-                    self.is_eof = true;
-                    self.current_value = None;
-                }
-                Some(ref value) => {
-                    // We read a value successfully; set it as our current value.
-                    // TODO: This currently clones the loaded value. This will not be necessary
-                    //       when `next()` returns an IonType instead of an AnnotatedTextValue.
-                    self.current_value = Some(value.clone());
-                }
-            };
-            return Ok(());
+            let next_stream_item = self.parse_next_nom(stream_item);
+            return self.process_stream_item(next_stream_item);
         }
         // Otherwise, the `parents` stack is not empty. We're inside a container.
 
@@ -196,18 +160,55 @@ impl<T: TextIonDataSource> RawTextReader<T> {
         Ok(())
     }
 
-    /// Assumes that the reader is at the top level and attempts to parse the next value or IVM in
-    /// the stream.
-    fn next_top_level_value(&mut self) -> IonResult<Option<AnnotatedTextValue>> {
-        match self.parse_next(top_level_value) {
-            Ok(Some(value)) => Ok(Some(value)),
-            Ok(None) => {
+    fn process_stream_item(
+        &mut self,
+        read_result: RootParseResult<RawTextStreamItem>,
+    ) -> IonResult<()> {
+        match read_result {
+            RootParseResult::Ok(RawTextStreamItem::IonVersionMarker(1, 0)) => {
+                // We found an IVM; we currently only support Ion 1.0.
+                self.current_ivm = Some((1, 0));
+                Ok(())
+            }
+            RootParseResult::Ok(RawTextStreamItem::IonVersionMarker(major, minor)) => {
+                decoding_error(format!(
+                    "Unsupported Ion version: v{}.{}. Only 1.0 is supported.",
+                    major, minor
+                ))
+            }
+            RootParseResult::Ok(RawTextStreamItem::AnnotatedTextValue(value)) => {
+                // We read a value successfully; set it as our current value.
+                self.current_value = Some(value);
+                Ok(())
+            }
+            RootParseResult::Eof => {
                 // The top level is the only depth at which EOF is legal. If we encounter an EOF,
                 // double check that the buffer doesn't actually have a value in it. See the
                 // comments in [parse_value_at_eof] for a detailed explanation of this.
-                self.parse_value_at_eof()
+                let item = self.parse_value_at_eof();
+                if item == RootParseResult::Eof {
+                    // This is a genuine EOF; make a note of it and clear the current value.
+                    self.is_eof = true;
+                    self.current_value = None;
+                    return Ok(());
+                }
+                self.process_stream_item(item)
             }
-            Err(e) => Err(e),
+            RootParseResult::NoMatch => {
+                // The parser didn't recognize the text in the input buffer.
+                // Return an error that contains the text we were attempting to parse.
+                let error_message = format!(
+                    "unrecognized input near line {}: '{}'",
+                    self.buffer.lines_loaded(),
+                    self.buffer.remaining_text(),
+                );
+                decoding_error(error_message)
+            }
+            RootParseResult::Failure(error_message) => {
+                // A fatal error occurred while reading the next value.
+                // This could be an I/O error, malformed utf-8 data, or an invalid value.
+                decoding_error(error_message)
+            }
         }
     }
 
@@ -371,7 +372,7 @@ impl<T: TextIonDataSource> RawTextReader<T> {
     // https://github.com/amzn/ion-rust/issues/318
     // This method should only be called when the reader is at the top level. An EOF at any other
     // depth is an error.
-    fn parse_value_at_eof(&mut self) -> IonResult<Option<AnnotatedTextValue>> {
+    fn parse_value_at_eof(&mut self) -> RootParseResult<RawTextStreamItem> {
         // An arbitrary, cheap-to-parse Ion value that we append to the buffer when its contents at
         // EOF are ambiguous.
         const SENTINEL_ION_TEXT: &str = "\n0\n";
@@ -393,35 +394,43 @@ impl<T: TextIonDataSource> RawTextReader<T> {
         //   there aren't any more long-form string segments in the sequence.
         //
         // Attempt to parse the updated buffer.
-        let value = match top_level_value(self.buffer.remaining_text()) {
-            Ok(("\n", value))
+        let value = match stream_item(self.buffer.remaining_text()) {
+            Ok(("\n", RawTextStreamItem::AnnotatedTextValue(value)))
                 if value.annotations().is_empty()
                     && *value.value() == TextValue::Integer(Integer::I64(0)) =>
             {
                 // We found the unannotated zero that we appended to the end of the buffer.
                 // The "\n" in this pattern is the unparsed text left in the buffer,
                 // which indicates that our 0 was parsed.
-                Ok(None)
+                RootParseResult::Eof
             }
             Ok((_remaining_text, value)) => {
                 // We found something else. The zero is still in the buffer; we can leave it there.
                 // The reader's `is_eof` flag has been set, so the text buffer will never be used
                 // again. Return the value we found.
-                Ok(Some(value))
+                RootParseResult::Ok(value)
             }
             Err(Incomplete(_needed)) => {
-                decoding_error(format!(
+                RootParseResult::Failure(format!(
                     "Unexpected end of input on line {}: '{}'",
                     self.buffer.lines_loaded(),
                     &self.buffer.remaining_text()[..original_length] // Don't show the extra `\n0\n`
                 ))
             }
-            Err(e) => {
-                decoding_error(format!(
-                    "Parsing error occurred near line {}: '{}': '{}'",
+            Err(Error(ion_parse_error)) => {
+                RootParseResult::Failure(format!(
+                    "Parsing error occurred near line {}: '{}': '{:?}'",
                     self.buffer.lines_loaded(),
                     &self.buffer.remaining_text()[..original_length], // Don't show the extra `\n0\n`
-                    e
+                    ion_parse_error
+                ))
+            }
+            Err(Failure(ion_parse_error)) => {
+                RootParseResult::Failure(format!(
+                    "A fatal error occurred while reading near line {}: '{}': '{:?}'",
+                    self.buffer.lines_loaded(),
+                    &self.buffer.remaining_text()[..original_length], // Don't show the extra `\n0\n`
+                    ion_parse_error
                 ))
             }
         };

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -543,15 +543,6 @@ mod native_element_tests {
                 // The binary reader does not check whether nested values are longer than their
                 // parent container.
                 "ion-tests/iontestdata/bad/listWithValueLargerThanSize.10n",
-                // The text reader does not raise an error on unrecognized escapes. Instead,
-                // it treats them as uninterpreted literals. In this test, '\e' should raise
-                // an error but up appearing in the string as the literal text "\e".
-                "ion-tests/iontestdata/bad/longStringSlashE.ion",
-                // These fail because the string parser treats a truncated unicode escape at the end
-                // of a string fragment (e.g. '''\u''' with no digits) as a string literal instead
-                // of a malformed stream.
-                "ion-tests/iontestdata/bad/longStringSplitEscape_1.ion",
-                "ion-tests/iontestdata/bad/longStringSplitEscape_2.ion",
                 // These fail because non-displayable ASCII control characters are valid utf-8. A
                 // separate check is needed to confirm that raw control characters only show up
                 // as escape sequences.
@@ -559,7 +550,6 @@ mod native_element_tests {
                 "ion-tests/iontestdata/bad/stringRawControlCharacter.ion",
                 "ion-tests/iontestdata/bad/stringWithEol.ion",
                 // ROUND TRIP
-                "ion-tests/iontestdata/good/equivs/annotatedIvms.ion",
                 // These two tests fail because in most contexts, `NaN != NaN`, so Float(nan) != Float(nan).
                 // We need a structural equality (IonEq) for this (amzn/ion-rust#220)
                 "ion-tests/iontestdata/good/equivs/floats.ion",
@@ -585,15 +575,12 @@ mod native_element_tests {
                 // This test has a Decimal with an enormous exponent. We'd need to change
                 // DecodedInt to store an Integer instead of an i64.
                 "ion-tests/iontestdata/good/typecodes/T5.10n",
+                // These files are encoded in utf16 and utf32; the reader currently assumes utf8.
                 "ion-tests/iontestdata/good/utf16.ion",
                 "ion-tests/iontestdata/good/utf32.ion",
-                "ion-tests/iontestdata/good/whitespace.ion",
                 // EQUIVS
-                "ion-tests/iontestdata/good/equivs/annotatedIvms.ion",
-                "ion-tests/iontestdata/good/equivs/nonIVMNoOps.ion",
                 "ion-tests/iontestdata/good/equivs/utf8/stringUtf8.ion",
                 // NON-EQUIVS
-                "ion-tests/iontestdata/good/non-equivs/annotatedIvms.ion",
                 "ion-tests/iontestdata/good/non-equivs/decimals.ion",
                 "ion-tests/iontestdata/good/non-equivs/floats.ion",
                 "ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion",
@@ -611,7 +598,6 @@ mod native_element_tests {
                 "ion-tests/iontestdata/good/decimal_zeros.ion",
                 "ion-tests/iontestdata/good/decimalNegativeZeroDot.10n",
                 "ion-tests/iontestdata/good/decimalNegativeZeroDotZero.10n",
-                "ion-tests/iontestdata/good/equivs/annotatedIvms.ion",
                 "ion-tests/iontestdata/good/equivs/textNewlines.ion",
                 "ion-tests/iontestdata/good/equivs/timestampFractions.10n",
                 "ion-tests/iontestdata/good/equivs/timestampsLargeFractionalPrecision.ion",
@@ -625,7 +611,6 @@ mod native_element_tests {
                 "ion-tests/iontestdata/good/innerVersionIdentifiers.ion",
                 "ion-tests/iontestdata/good/item1.10n",
                 "ion-tests/iontestdata/good/localSymbolTableImportZeroMaxId.ion",
-                "ion-tests/iontestdata/good/non/equivs/annotatedIvms.ion",
                 "ion-tests/iontestdata/good/notVersionMarkers.ion",
                 "ion-tests/iontestdata/good/subfieldInt.ion",
                 "ion-tests/iontestdata/good/subfieldUInt.ion",
@@ -648,7 +633,6 @@ mod native_element_tests {
 
         fn equivs_skip_list() -> SkipList {
             &[
-                "ion-tests/iontestdata/good/equivs/annotatedIvms.ion",
                 "ion-tests/iontestdata/good/equivs/clobNewlines.ion",
                 "ion-tests/iontestdata/good/equivs/localSymbolTableAppend.ion",
                 "ion-tests/iontestdata/good/equivs/localSymbolTableNullSlots.ion",


### PR DESCRIPTION
Fixes include:
* Extending the parser's definition of whitespace to include less
common control characters like vertical tab and form feed.
* Recognizing IVMs that are followed by '::' as annotations
* Escape slashes `\` that are not followed by a complete escape
sequence result in a fatal error.

This PR also consolidates the `RawTextReader`'s I/O and error
handling for reading IVMs and values, which were largely
duplicates of one another.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
