### PR TITLE
Version bumps: ion-rs to v0.10, ion-hash to v0.0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 
 [workspace]

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -16,11 +16,11 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 
 [dependencies]
-ion-rs = { path = "../", version = "0.9" }
+ion-rs = { path = "../", version = "0.10" }
 ion-c-sys = { path = "../ion-c-sys", version = "0.4" }
 num-bigint = "0.3"
 digest = "0.9"


### PR DESCRIPTION
*Description of changes:*

Version bumps:
* `ion-rs` is now v0.10.0
* `ion-hash` is now v0.0.7 and depends on `ion-rs` v0.10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
