### PR TITLE
Adds `NativeElementWriter`, string/clob validation, big `DecodedInt`s

### DIFF
--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -6,7 +6,9 @@ use arrayvec::ArrayVec;
 use bigdecimal::Zero;
 
 use crate::{
-    binary::{int::Int, raw_binary_writer::MAX_INLINE_LENGTH, var_int::VarInt, var_uint::VarUInt},
+    binary::{
+        int::DecodedInt, raw_binary_writer::MAX_INLINE_LENGTH, var_int::VarInt, var_uint::VarUInt,
+    },
     result::IonResult,
     types::{
         coefficient::{Coefficient, Sign},
@@ -55,7 +57,7 @@ where
         bytes_written += VarInt::write_i64(self, decimal.exponent)?;
 
         if decimal.coefficient.is_negative_zero() {
-            bytes_written += Int::write_negative_zero(self)?;
+            bytes_written += DecodedInt::write_negative_zero(self)?;
             return Ok(bytes_written);
         }
 
@@ -66,7 +68,7 @@ where
             // has zero length) when the coefficient’s value is (positive)
             // zero."
             if !small_coefficient.is_zero() {
-                bytes_written += Int::write_i64(self, small_coefficient)?;
+                bytes_written += DecodedInt::write_i64(self, small_coefficient)?;
             }
         } else {
             // Otherwise, allocate a Vec<u8> with the necessary representation.

--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -2,31 +2,40 @@ use std::mem;
 
 use crate::data_source::IonDataSource;
 use crate::result::{decoding_error, IonResult};
+use crate::types::coefficient;
+use crate::types::coefficient::Coefficient;
+use crate::Integer;
+use num_bigint::{BigInt, Sign};
+use num_traits::Zero;
 use std::io::Write;
 
 type IntStorage = i64;
-const MAX_INT_SIZE_IN_BYTES: usize = mem::size_of::<IntStorage>();
 const INT_NEGATIVE_ZERO: u8 = 0x80;
+
+// This limit is used for stack-allocating buffer space to encode/decode Ints.
+const INT_STACK_BUFFER_SIZE: usize = 16;
+// This number was chosen somewhat arbitrarily and could be lifted if a use case demands it.
+const MAX_INT_SIZE_IN_BYTES: usize = 2048;
 
 /// Represents a fixed-length signed integer. See the
 /// [UInt and Int Fields](http://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields)
 /// section of the binary Ion spec for more details.
 #[derive(Debug)]
-pub struct Int {
+pub struct DecodedInt {
     size_in_bytes: usize,
-    value: IntStorage,
-    // [IntStorage] is not capable of natively representing negative zero. We track the sign
+    value: Integer,
+    // [Integer] is not capable of natively representing negative zero. We track the sign
     // of the value separately so we can distinguish between 0 and -0.
     is_negative: bool,
 }
 
-impl Int {
+impl DecodedInt {
     /// Reads an Int with `length` bytes from the provided data source.
-    pub fn read<R: IonDataSource>(data_source: &mut R, length: usize) -> IonResult<Int> {
+    pub fn read<R: IonDataSource>(data_source: &mut R, length: usize) -> IonResult<DecodedInt> {
         if length == 0 {
-            return Ok(Int {
+            return Ok(DecodedInt {
                 size_in_bytes: 0,
-                value: 0,
+                value: Integer::I64(0),
                 is_negative: false,
             });
         } else if length > MAX_INT_SIZE_IN_BYTES {
@@ -36,29 +45,65 @@ impl Int {
             ));
         }
 
-        // Create a stack-allocated buffer to hold the data we're going to read in.
-        let mut buffer = [0u8; MAX_INT_SIZE_IN_BYTES];
+        if length <= INT_STACK_BUFFER_SIZE {
+            let buffer = &mut [0u8; INT_STACK_BUFFER_SIZE];
+            DecodedInt::read_using_buffer(data_source, length, buffer)
+        } else {
+            // We're reading an enormous int. Heap-allocate a Vec to use as storage.
+            let mut buffer = vec![0u8; length];
+            DecodedInt::read_using_buffer(data_source, length, buffer.as_mut_slice())
+        }
+    }
+
+    pub fn read_using_buffer<R: IonDataSource>(
+        data_source: &mut R,
+        length: usize,
+        buffer: &mut [u8],
+    ) -> IonResult<DecodedInt> {
         // Get a mutable reference to a portion of the buffer just big enough to fit
         // the requested number of bytes.
         let buffer = &mut buffer[0..length];
 
         data_source.read_exact(buffer)?;
         let mut byte_iter = buffer.iter();
+        let mut is_negative: bool = false;
 
-        let first_byte: i64 = i64::from(byte_iter.next().copied().unwrap());
-        let sign: IntStorage = if first_byte & 0b1000_0000 == 0 { 1 } else { -1 };
-        let mut magnitude: IntStorage = first_byte & 0b0111_1111;
+        let value = if length <= mem::size_of::<i64>() {
+            // This Int will fit in an i64.
+            let first_byte: i64 = i64::from(byte_iter.next().copied().unwrap());
+            let sign: i64 = if first_byte & 0b1000_0000 == 0 {
+                1
+            } else {
+                is_negative = true;
+                -1
+            };
+            let mut magnitude: i64 = first_byte & 0b0111_1111;
+            for &byte in byte_iter {
+                let byte = i64::from(byte);
+                magnitude <<= 8;
+                magnitude |= byte;
+            }
+            Integer::I64(sign * magnitude)
+        } else {
+            // This Int is too big for an i64, we'll need to use a BigInt
+            let sign: num_bigint::Sign = if buffer[0] & 0b1000_0000 == 0 {
+                Sign::Plus
+            } else {
+                is_negative = true;
+                Sign::Minus
+            };
+            // We're going to treat the buffer's contents like the big-endian bytes of an
+            // unsigned integer. Now that we've made a note of the sign, set the sign bit
+            // in the buffer to zero.
+            buffer[0] &= 0b0111_1111;
+            let value = BigInt::from_bytes_be(sign, buffer);
+            Integer::BigInt(value)
+        };
 
-        for &byte in byte_iter {
-            let byte = i64::from(byte);
-            magnitude <<= 8;
-            magnitude |= byte;
-        }
-
-        Ok(Int {
+        Ok(DecodedInt {
             size_in_bytes: length,
-            value: magnitude * sign,
-            is_negative: sign == -1,
+            value,
+            is_negative,
         })
     }
 
@@ -97,13 +142,13 @@ impl Int {
         // `self.value` can natively represent any negative integer _except_ -0.
         // To check for negative zero, we need to also look at the sign bit that was encoded
         // in the stream.
-        self.value == 0 && self.is_negative
+        self.value.is_zero() && self.is_negative
     }
 
     /// Returns the value of the signed integer.
     #[inline(always)]
-    pub fn value(&self) -> IntStorage {
-        self.value
+    pub fn value(&self) -> &Integer {
+        &self.value
     }
 
     /// Returns the number of bytes that were read from the data source to construct this
@@ -112,12 +157,49 @@ impl Int {
     pub fn size_in_bytes(&self) -> usize {
         self.size_in_bytes
     }
+
+    /// Constructs a DecodedInt that represents zero. This is useful when reading from a stream
+    /// where a zero-length Int is found, meaning that it is implicitly positive zero.
+    pub fn zero() -> Self {
+        DecodedInt {
+            size_in_bytes: 0,
+            value: Integer::I64(0),
+            is_negative: false,
+        }
+    }
+}
+
+impl From<DecodedInt> for Integer {
+    /// Note that if the DecodedInt represents -0, converting it to an Integer will result in a 0.
+    /// If negative zero is significant to your use case, check it using [DecodedInt::is_negative_zero]
+    /// before converting it to an Integer.
+    fn from(uint: DecodedInt) -> Self {
+        let DecodedInt {
+            value,
+            .. // Ignore 'size_in_bytes' and 'is_negative'
+        } = uint;
+        value
+    }
+}
+
+impl From<DecodedInt> for Coefficient {
+    fn from(int: DecodedInt) -> Self {
+        let DecodedInt {
+            value,
+            is_negative,
+            .. // ignore `size_in_bytes`
+        } = int;
+        use coefficient::Sign::{Negative, Positive};
+        let sign = if is_negative { Negative } else { Positive };
+        Coefficient::new(sign, value)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Int;
+    use super::*;
     use crate::result::IonResult;
+    use crate::Integer;
     use std::io;
     use std::io::Cursor;
 
@@ -126,71 +208,73 @@ mod tests {
     #[test]
     fn test_read_three_byte_positive_int() {
         let data = &[0b0011_1100, 0b1000_0111, 0b1000_0001];
-        let int = Int::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(int.size_in_bytes(), 3);
-        assert_eq!(int.value(), 3_966_849);
+        assert_eq!(int.value(), &Integer::I64(3_966_849));
     }
 
     #[test]
     fn test_read_three_byte_negative_int() {
         let data = &[0b1011_1100, 0b1000_0111, 0b1000_0001];
-        let int = Int::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(int.size_in_bytes(), 3);
-        assert_eq!(int.value(), -3_966_849);
+        assert_eq!(int.value(), &Integer::I64(-3_966_849));
     }
 
     #[test]
     fn test_read_int_negative_zero() {
         let data = &[0b1000_0000]; // Negative zero
-        let int = Int::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(int.size_in_bytes(), 1);
-        assert_eq!(int.value(), 0);
+        assert_eq!(int.value(), &Integer::I64(0));
         assert!(int.is_negative_zero());
     }
 
     #[test]
     fn test_read_int_positive_zero() {
         let data = &[0b0000_0000]; // Positive zero
-        let int = Int::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(int.size_in_bytes(), 1);
-        assert_eq!(int.value(), 0);
+        assert_eq!(int.value(), &Integer::I64(0));
         assert!(!int.is_negative_zero());
     }
 
     #[test]
     fn test_read_two_byte_positive_int() {
         let data = &[0b0111_1111, 0b1111_1111];
-        let int = Int::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(int.size_in_bytes(), 2);
-        assert_eq!(int.value(), 32_767);
+        assert_eq!(int.value(), &Integer::I64(32_767));
     }
 
     #[test]
     fn test_read_two_byte_negative_int() {
         let data = &[0b1111_1111, 0b1111_1111];
-        let int = Int::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(int.size_in_bytes(), 2);
-        assert_eq!(int.value(), -32_767);
+        assert_eq!(int.value(), &Integer::I64(-32_767));
     }
 
     #[test]
     fn test_read_int_length_zero() {
         let data = &[];
-        let int = Int::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
+        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(int.size_in_bytes(), 0);
-        assert_eq!(int.value(), 0);
+        assert_eq!(int.value(), &Integer::I64(0));
     }
 
     #[test]
     fn test_read_int_overflow() {
-        let data = &[0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01];
-        let _int = Int::read(&mut Cursor::new(data), data.len())
-            .expect_err("This should have failed due to overflow.");
+        // A Vec of bytes that's one beyond the maximum allowable Int size. Each byte is a 1.
+        let buffer = vec![1; MAX_INT_SIZE_IN_BYTES + 1];
+        let data = buffer.as_slice();
+        let _int = DecodedInt::read(&mut Cursor::new(data), data.len())
+            .expect_err("This exceeded the configured max Int size.");
     }
 
     fn write_int_test(value: i64, expected_bytes: &[u8]) -> IonResult<()> {
         let mut buffer: Vec<u8> = vec![];
-        Int::write_i64(&mut buffer, value)?;
+        DecodedInt::write_i64(&mut buffer, value)?;
         assert_eq!(buffer.as_slice(), expected_bytes);
         Ok(())
     }
@@ -203,7 +287,7 @@ mod tests {
     #[test]
     fn test_write_int_negative_zero() -> IonResult<()> {
         let mut buffer: Vec<u8> = vec![];
-        Int::write_negative_zero(&mut buffer)?;
+        DecodedInt::write_negative_zero(&mut buffer)?;
         assert_eq!(buffer.as_slice(), &[0b1000_0000]);
         Ok(())
     }
@@ -237,9 +321,9 @@ mod tests {
     #[test]
     fn test_write_int_max_i64() -> IonResult<()> {
         let mut buffer: Vec<u8> = vec![];
-        let length = Int::write_i64(&mut buffer, i64::MAX)?;
-        let i = Int::read(&mut io::Cursor::new(buffer.as_slice()), length)?;
-        assert_eq!(i.value, i64::MAX);
+        let length = DecodedInt::write_i64(&mut buffer, i64::MAX)?;
+        let i = DecodedInt::read(&mut io::Cursor::new(buffer.as_slice()), length)?;
+        assert_eq!(i.value, Integer::I64(i64::MAX));
         Ok(())
     }
 }

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -7,7 +7,7 @@ pub mod binary_writer;
 pub(crate) mod constants;
 pub mod decimal;
 mod header;
-mod int;
+pub mod int;
 mod nibbles;
 pub(crate) mod raw_binary_reader;
 pub mod raw_binary_writer;

--- a/src/text/parsers/clob.rs
+++ b/src/text/parsers/clob.rs
@@ -151,6 +151,9 @@ fn short_clob_fragment_without_escaped_text(input: &str) -> IonParseResult<Strin
                 // Stop parsing and return a match for everything leading up to this.
                 return text_support::string_fragment_or_mismatch(input, byte_index);
             }
+            '\n' => {
+                return fatal_parse_error(input, "short clobs cannot contain unescaped newlines");
+            }
             c if char_is_legal_clob_ascii(c) => {
                 // Do nothing; this will be part of the substring we return.
             }

--- a/src/text/parsers/clob.rs
+++ b/src/text/parsers/clob.rs
@@ -199,11 +199,6 @@ mod clob_parsing_tests {
     }
 
     #[test]
-    fn del_test() {
-        assert!('\x7F'.is_ascii())
-    }
-
-    #[test]
     fn test_parse_clobs() {
         // parse tests for short clob
         parse_equals("{{\"hello\"}}\n", "hello");

--- a/src/text/parsers/decimal.rs
+++ b/src/text/parsers/decimal.rs
@@ -40,6 +40,7 @@ fn decimal_with_exponent(input: &str) -> IonParseResult<TextValue> {
         )),
         decimal_exponent_marker_followed_by_digits,
     )(input)?;
+
     let decimal =
         decimal_from_text_components(input, sign, digits_before, digits_after, exponent)?.1;
     Ok((remaining, TextValue::Decimal(decimal)))

--- a/src/text/parsers/mod.rs
+++ b/src/text/parsers/mod.rs
@@ -27,17 +27,17 @@ pub(crate) mod top_level;
 pub(crate) mod value;
 
 const WHITESPACE_CHARACTERS: &[char] = &[
-    ' ',        // Space
-    '\t',       // Tab
-    '\r',       // Carriage return
-    '\n',       // Newline
-    '\u{0009}', // Horizontal tab
-    '\u{000B}', // Vertical tab
-    '\u{000C}', // Form feed
+    ' ',    // Space
+    '\t',   // Tab
+    '\r',   // Carriage return
+    '\n',   // Newline
+    '\x09', // Horizontal tab
+    '\x0B', // Vertical tab
+    '\x0C', // Form feed
 ];
 
 /// Same as [WHITESPACE_CHARACTERS], but formatted as a string for use in some `nom` APIs
-const WHITESPACE_CHARACTERS_AS_STR: &str = " \t\r\n\u{0009}\u{000B}\u{000C}";
+const WHITESPACE_CHARACTERS_AS_STR: &str = " \t\r\n\x09\x0B\x0C";
 
 // ===== The functions below are used by several modules and live here for common access. =====
 

--- a/src/text/parsers/string.rs
+++ b/src/text/parsers/string.rs
@@ -179,7 +179,6 @@ mod string_parsing_tests {
         parse_equals("\"\" ", "");
         parse_equals("\"Hello, world!\" ", "Hello, world!");
         // Escape literals
-        parse_equals("\"Hello\nworld!\" ", "Hello\nworld!");
         parse_equals("\"Hello\tworld!\" ", "Hello\tworld!");
         parse_equals("\"\\\"Hello, world!\\\"\" ", "\"Hello, world!\"");
         // 2-digit Unicode hex escape sequences

--- a/src/text/parsers/string.rs
+++ b/src/text/parsers/string.rs
@@ -1,11 +1,14 @@
-use crate::text::parse_result::{IonParseError, IonParseResult, UpgradeIResult};
+use crate::text::parse_result::{fatal_parse_error, IonParseResult};
 use crate::text::parsers::comments::whitespace_or_comments;
-use crate::text::parsers::text_support::{escaped_char, escaped_newline, StringFragment};
+use crate::text::parsers::text_support::{
+    escaped_char, escaped_newline, normalized_newline, string_fragment_or_mismatch, StringFragment,
+};
+use crate::text::parsers::WHITESPACE_CHARACTERS;
 use crate::text::text_value::TextValue;
 use nom::branch::alt;
-use nom::bytes::streaming::{is_not, tag};
+use nom::bytes::streaming::tag;
 use nom::character::streaming::char;
-use nom::combinator::{map, not, opt, peek, verify};
+use nom::combinator::{map, not, opt, peek};
 use nom::multi::{fold_many0, many1};
 use nom::sequence::{delimited, terminated};
 use nom::Err::Incomplete;
@@ -59,6 +62,7 @@ fn long_string_body(input: &str) -> IonParseResult<String> {
 /// Matches an escaped character or a substring without any escapes in a long string.
 fn long_string_fragment(input: &str) -> IonParseResult<StringFragment> {
     alt((
+        normalized_newline,
         escaped_newline,
         escaped_char,
         long_string_fragment_without_escaped_text,
@@ -70,67 +74,33 @@ fn long_string_fragment(input: &str) -> IonParseResult<StringFragment> {
 pub(in crate::text::parsers) fn long_string_fragment_without_escaped_text(
     input: &str,
 ) -> IonParseResult<StringFragment> {
-    // In contrast with the `short_string_fragment_without_escaped_text` function, this parser is
-    // hand-written because has two possible 'end' sequences to detect:
-    //   1. A slash (`\`), indicating the beginning of an escape sequence.
-    //   2. A triple-single-quote (`'''`), indicating the end of the string fragment.
-    // `nom` provides parser combinators that can detect multiple single-character 'end' markers
-    // or a single multiple-charracter 'end' marker. However, it does not provide one to detect
-    // multiple 'end' markers that may be more than one character. If that functionality is added
-    // in a future release, we can replace this implementation.
-
-    // Detecting a `'''` requires keeping track of some state as we traverse the input.
-    // We'll record the first byte offset at which we encountered a quote...
-    let mut first_single_quote_index = 0usize;
-    // ..as well as how many quotes in a row we've found.
-    let mut quote_count = 0usize;
-    // We'll iterate across each 'char' (Unicode codepoint) in the input string. Each char can
-    // take multiple input bytes to represent, so we'll use `char_indices()` to get both the char
-    // itself and the byte index at which it started.
-    for (index, char) in input.char_indices() {
-        if char == '\\' {
-            if index == 0 {
-                // The input starts with a `\`; the parser doesn't match.
-                return Err(nom::Err::Error(IonParseError::new(input)));
+    for (byte_index, character) in input.char_indices() {
+        match character {
+            '\\' | '\r' => {
+                // Escapes and carriage returns are handled by other clob fragment parsers.
+                // Return a match for everything leading up to this.
+                return string_fragment_or_mismatch(input, byte_index);
             }
-            // We found a `\`; return a match for all of the text up to `index`, exclusive.
-            return Ok((&input[index..], StringFragment::Substring(&input[0..index])));
-        } else if char == '\'' {
-            // We found a single quote. Increment the count.
-            quote_count += 1;
-            match quote_count {
-                1 => {
-                    // If this is the first quote we've found, keep track of its byte offset.
-                    // When we're ready to return a matching substring, we'll need it to end at
-                    // that index.
-                    first_single_quote_index = index;
+            '\'' => {
+                // This might be the terminating `'''`. Look ahead to see if it's followed by two
+                // more `'`s. If so, return a match for everything leading up to it.
+                let remaining = &input[byte_index..];
+                if remaining.starts_with("'''") {
+                    return string_fragment_or_mismatch(input, byte_index);
                 }
-                2 => {}
-                3 => {
-                    // We've found a third single quote in a row.
-                    if first_single_quote_index == 0 {
-                        // The `'''` was at the beginning of the input; the parser doesn't match.
-                        // We'll return an Err so the `long_string_fragment` parser will know
-                        // there weren't any more string fragments in the input. The `'''` we just
-                        // ran into will be consumed later by `long_string`.
-                        return Err(nom::Err::Error(IonParseError::new(input)));
-                    }
-                    // This `'''` indicates the end of the string fragment. Return a match for all
-                    // of the text leading up to the offset of the first single quote, exclusive.
-                    return Ok((
-                        &input[first_single_quote_index..],
-                        StringFragment::Substring(&input[0..first_single_quote_index]),
-                    ));
-                }
-                _ => unreachable!("quote_count was greater than 3"),
             }
-        } else {
-            quote_count = 0;
-        }
+            c if u32::from(c) < 0x20 && !WHITESPACE_CHARACTERS.contains(&c) => {
+                return fatal_parse_error(
+                    input,
+                    "strings cannot contain unescaped control characters",
+                );
+            }
+            _ => {
+                // Any other character is allowed
+            }
+        };
     }
-    // We got to the end of the input without encountering either a `\` or a `'''`. We can't
-    // say for sure whether this would've matched successfully given more input, so we return
-    // `Incomplete`, indicating that the reader should load more data and try parsing it again.
+    // We never found an end-of-fragment; we need more input to tell if this is a valid string.
     Err(Incomplete(Needed::Unknown))
 }
 
@@ -160,16 +130,39 @@ fn short_string_fragment(input: &str) -> IonParseResult<StringFragment> {
 }
 
 /// Matches the next string fragment while respecting the short string delimiter (`"`).
-fn short_string_fragment_without_escaped_text(input: &str) -> IonParseResult<StringFragment> {
-    map(verify(is_not("\"\\\""), |s: &str| !s.is_empty()), |text| {
-        StringFragment::Substring(text)
-    })(input)
-    .upgrade()
+pub(in crate::text::parsers) fn short_string_fragment_without_escaped_text(
+    input: &str,
+) -> IonParseResult<StringFragment> {
+    for (byte_index, character) in input.char_indices() {
+        match character {
+            '\\' | '\r' | '\"' => {
+                // Escapes and carriage returns are handled by other clob fragment parsers, while
+                // a double quote (`"`) marks the end of this string fragment.
+                // Return a match for everything leading up to this character.
+                return string_fragment_or_mismatch(input, byte_index);
+            }
+            '\n' => {
+                return fatal_parse_error(input, "short strings cannot contain unescaped newlines");
+            }
+            c if u32::from(c) < 0x20 && !WHITESPACE_CHARACTERS.contains(&c) => {
+                return fatal_parse_error(
+                    input,
+                    "strings cannot contain unescaped control characters",
+                );
+            }
+            _ => {
+                // Any other character is allowed
+            }
+        };
+    }
+    // We never found an end-of-fragment; we need more input to tell if this is a valid string.
+    Err(Incomplete(Needed::Unknown))
 }
 
 #[cfg(test)]
 mod string_parsing_tests {
     use crate::text::parsers::string::parse_string;
+
     use crate::text::parsers::unit_test_support::{parse_test_err, parse_test_ok};
     use crate::text::text_value::TextValue;
 

--- a/src/text/parsers/symbol.rs
+++ b/src/text/parsers/symbol.rs
@@ -54,7 +54,7 @@ fn quoted_symbol_string_fragment(input: &str) -> IonParseResult<StringFragment> 
 
 /// Matches the next quoted symbol string fragment while respecting the symbol delimiter (`'`).
 fn quoted_symbol_fragment_without_escaped_text(input: &str) -> IonParseResult<StringFragment> {
-    map(verify(is_not("'\\'"), |s: &str| !s.is_empty()), |text| {
+    map(verify(is_not("'\\"), |s: &str| !s.is_empty()), |text| {
         StringFragment::Substring(text)
     })(input)
 }

--- a/src/text/parsers/text_support.rs
+++ b/src/text/parsers/text_support.rs
@@ -1,18 +1,21 @@
 // Parsing functions that are common to textual types
 
-use crate::text::parse_result::{fatal_parse_error, IonParseError, IonParseResult, UpgradeIResult};
+use crate::text::parse_result::{
+    fatal_parse_error, IonParseError, IonParseResult, OrFatalParseError, UpgradeIResult,
+};
 use nom::branch::alt;
 use nom::bytes::streaming::tag;
 use nom::character::streaming::{char, satisfy};
 use nom::combinator::{map, recognize, value};
 use nom::sequence::{preceded, tuple};
 use nom::{AsChar, IResult, Parser};
+use std::str;
 
 /// The text Ion types each need to be able to read strings that contain escaped characters.
 /// This type represents the possible types of substring that make up any given piece of text from
 /// the parser's perspective. escaped characters that need to be replaced, escaped characters that
 /// need to be discarded, and unescaped substrings that are valid as-is.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum StringFragment<'a> {
     /// A substring that contains no escaped characters and which is valid as-is.
     Substring(&'a str),
@@ -110,8 +113,35 @@ pub(crate) fn escaped_hex_char(input: &str) -> IonParseResult<char> {
     decode_hex_digits_to_char(remaining_input, hex_digits)
 }
 
+/// Returns `true` if the provided code point is a utf-16 high surrogate.
+///
+/// Terse primer: Unicode text is made up of a stream of unsigned integers called 'code points'.
+/// What a person might think of as a 'character' (for example: 'a', '本', or '🥸') can be made up
+/// of one or more code points.
+///
+/// A single code point can require up to 21 bits. Depending on which Unicode encoding you're using,
+/// these 21 bits can come with different amounts of additional overhead bits:
+/// * In utf-8, a code point can be 1, 2, 3, or 4 bytes, with some bits in each byte being used
+///   for the code point and others being used to indicate whether more bytes are coming.
+/// * In utf-16, a code point can be 2 bytes or 4 bytes. If it's four bytes, the first two bytes will
+///   be a 'high surrogate' (a value between 0xD800 and 0xDFFF) to communicate that another two
+///   bytes are coming to complete the code point.
+/// * In utf-32, a code point is always 32 bits. This is a bit wasteful, but makes for simple
+///   processing.
+///
+/// This helper function detects high surrogates (which are only used in utf-16) so the parser
+/// can know to require a second one immediately following.
+///
+/// Further reading:
+/// * <https://doc.rust-lang.org/std/primitive.char.html>
+/// * <https://www.unicode.org/glossary/#surrogate_code_point>
+fn code_point_is_a_high_surrogate(value: u32) -> bool {
+    (0xD800..=0xDFFF).contains(&value)
+}
+
 /// Matches a Unicode escape (starting with '\x', '\u', or '\U'), returning the appropriate
-/// substitute character.
+/// substitute character. If the value represented by the escape is a utf-16 high surrogate,
+/// another Unicode escape will be matched from input to produce a Unicode scalar.
 pub(crate) fn escaped_char_unicode(input: &str) -> IonParseResult<char> {
     // First, try to match the input to a Unicode escape sequence. If successful, extract the hex
     // digits that were included in the sequence. If matching fails, this isn't an escape sequence.
@@ -123,9 +153,78 @@ pub(crate) fn escaped_char_unicode(input: &str) -> IonParseResult<char> {
     ))(input)
     .upgrade()?;
 
-    // Now that we have our hex digits, we'll try to convert them to Unicode code points.
-    // If this fails, it will return a fatal error.
-    decode_hex_digits_to_char(remaining_input, hex_digits)
+    // We matched on a sequence of hex digits of some length; convert it to a `u32`.
+    let (_, number_value) = u32::from_str_radix(hex_digits, 16)
+        .or_fatal_parse_error(hex_digits, "could not parse escape hex sequence")?;
+
+    // Check to see if this is a high surrogate; if it is, our code point isn't complete. Another
+    // unicode escape representing the low surrogate has to be next in the input to complete it.
+    // See the docs for this helper function for details. (Note: this will only ever be true for
+    // 4- and 8-digit escape sequences. `\x` escapes don't have enough digits to represent a
+    // high surrogate.)
+    if code_point_is_a_high_surrogate(number_value) {
+        // It's a high surrogate. It needs to be followed by a low surrogate to complete the
+        // codepoint.
+        return complete_surrogate_pair(input, remaining_input, hex_digits, number_value);
+    }
+
+    // A Rust `char` can represent any Unicode scalar value-- a code point that is not part of a
+    // surrogate pair. If the value we found isn't a high surrogate, then it's a complete scalar
+    // value. We can safely convert it to a `char`.
+    let character = char::from_u32(number_value).unwrap();
+
+    Ok((remaining_input, character))
+}
+
+/// Rust's [char] type represents any Unicode code point EXCEPT a surrogate. If we encounter a high
+/// surrogate in the stream, we cannot convert it to a `char` yet. We must find the (mandatory)
+/// low surrogate that follows it in the stream; then we can combine the high and low surrogates
+/// into a complete code point. This code point can then be returned as a Rust [char].
+fn complete_surrogate_pair<'a>(
+    input: &'a str,
+    input_after_high_surrogate: &'a str,
+    high_surrogate_hex_digits: &'a str,
+    high_surrogate_number_value: u32,
+) -> IonParseResult<'a, char> {
+    let (_, (input_after_low_surrogate, low_surrogate_hex_digits)) =
+        preceded(
+            char('\\'),
+            alt((
+                escaped_char_unicode_4_digit_hex,
+                escaped_char_unicode_8_digit_hex,
+            )),
+        )(input_after_high_surrogate)
+        .or_fatal_parse_error(
+            input_after_high_surrogate,
+            "encountered an incomplete surrogate pair",
+        )?;
+
+    // Convert the second set of hex digits to a `u32`.
+    let second_number_value = u32::from_str_radix(low_surrogate_hex_digits, 16)
+        .or_fatal_parse_error(
+            high_surrogate_hex_digits,
+            "could not parse escape hex sequence for trailing surrogate",
+        )?
+        .1;
+
+    // Convert our pair of surrogate number values into u16s so we can feed them into the utf-16
+    // decoder. We know the first surrogate number value will fit in a u16 because we checked
+    // its range above, so we can safely unwrap it.
+    let high_surrogate: u16 = u16::try_from(high_surrogate_number_value).unwrap();
+    let low_surrogate: u16 = u16::try_from(second_number_value)
+        .or_fatal_parse_error(
+            low_surrogate_hex_digits,
+            "trailing surrogate number value did not fit in a u16",
+        )?
+        .1;
+
+    let character = char::decode_utf16([high_surrogate, low_surrogate])
+        .next()
+        .unwrap() // We provided enough data to produce either a char or an Err
+        .or_fatal_parse_error(input, "encountered invalid surrogate pair")?
+        .1;
+
+    Ok((input_after_low_surrogate, character))
 }
 
 /// Treats a given string as the hex-encoded byte representation of a char
@@ -193,4 +292,35 @@ pub(crate) fn escaped_char_unicode_8_digit_hex(input: &str) -> IResult<&str, &st
 /// Matches and returns a single base-16 digit.
 pub(crate) fn single_hex_digit(input: &str) -> IResult<&str, char> {
     satisfy(<char as AsChar>::is_hex_digit)(input)
+}
+
+/// Matches a `\r` or `\r\n` and returns a StringFragment::EscapedChar('\n').
+pub(crate) fn normalized_newline(input: &str) -> IonParseResult<StringFragment> {
+    // In a long string, \r and \r\n are both normalized to `\n`
+    value(
+        // Return a newline...
+        StringFragment::EscapedChar('\n'),
+        // ...if the input is one of the following:
+        alt((tag("\r\n"), tag("\r"))),
+    )(input)
+    .upgrade()
+}
+
+/// If `byte_index` is zero, returns an `Err` signaling that the input was not matched. Otherwise,
+/// splits the text at `byte_index` and returns a match on the head with the tail as remaining
+/// input.
+///
+/// This is used by the string and clob parsers to detect non-empty long-string-formatted text
+/// fragments. (e.g. '''hello''' ''' world!''')
+pub(crate) fn string_fragment_or_mismatch(
+    input: &str,
+    byte_index: usize,
+) -> IonParseResult<StringFragment> {
+    if byte_index == 0 {
+        return Err(nom::Err::Error(IonParseError::new(input)));
+    }
+    Ok((
+        &input[byte_index..],
+        StringFragment::Substring(&input[0..byte_index]),
+    ))
 }

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -248,7 +248,6 @@ impl<T: TextIonDataSource> RawTextReader<T> {
     /// If the parser encounters an error, it will be returned as-is.
     fn parse_expected<P, O>(&mut self, entity_name: &str, parser: P) -> IonResult<O>
     where
-        O: Debug,
         P: Fn(&str) -> IonParseResult<O>,
     {
         match self.parse_next(parser) {
@@ -271,7 +270,6 @@ impl<T: TextIonDataSource> RawTextReader<T> {
 
     fn parse_next<P, O>(&mut self, parser: P) -> IonResult<Option<O>>
     where
-        O: Debug,
         P: Fn(&str) -> IonParseResult<O>,
     {
         match self.parse_next_nom(parser) {
@@ -297,7 +295,6 @@ impl<T: TextIonDataSource> RawTextReader<T> {
     /// If EOF is encountered, returns `Ok(None)`.
     fn parse_next_nom<P, O>(&mut self, parser: P) -> RootParseResult<O>
     where
-        O: Debug,
         P: Fn(&str) -> IonParseResult<O>,
     {
         let RawTextReader {

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 use nom::Err::{Error, Failure, Incomplete};
 
@@ -248,6 +248,7 @@ impl<T: TextIonDataSource> RawTextReader<T> {
     /// If the parser encounters an error, it will be returned as-is.
     fn parse_expected<P, O>(&mut self, entity_name: &str, parser: P) -> IonResult<O>
     where
+        O: Debug,
         P: Fn(&str) -> IonParseResult<O>,
     {
         match self.parse_next(parser) {
@@ -270,6 +271,7 @@ impl<T: TextIonDataSource> RawTextReader<T> {
 
     fn parse_next<P, O>(&mut self, parser: P) -> IonResult<Option<O>>
     where
+        O: Debug,
         P: Fn(&str) -> IonParseResult<O>,
     {
         match self.parse_next_nom(parser) {
@@ -295,6 +297,7 @@ impl<T: TextIonDataSource> RawTextReader<T> {
     /// If EOF is encountered, returns `Ok(None)`.
     fn parse_next_nom<P, O>(&mut self, parser: P) -> RootParseResult<O>
     where
+        O: Debug,
         P: Fn(&str) -> IonParseResult<O>,
     {
         let RawTextReader {

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use std::fmt::Display;
 
 use nom::Err::{Error, Failure, Incomplete};
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -65,6 +65,26 @@ impl IonType {
     }
 }
 
+/// Returns the number of base-10 digits needed to represent `value`.
+fn num_decimal_digits_in_u64(value: u64) -> u64 {
+    if value == 0 {
+        return 1;
+    }
+    let log_base_ten = (value as f64).log10();
+    let count = log_base_ten.ceil();
+    if log_base_ten == count {
+        // If ceil() didn't change the count, then `value` is an exact power of ten.
+        // We need to add one to get the correct count.
+        // Examples:
+        //    (1).log10() ==   (1).log10().ceil() == 0
+        //   (10).log10() ==  (10).log10().ceil() == 1
+        //  (100).log10() == (100).log10().ceil() == 2
+        count as u64 + 1
+    } else {
+        count as u64
+    }
+}
+
 impl TryFrom<ION_TYPE> for IonType {
     type Error = IonError;
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -215,6 +215,7 @@ use std::fmt::Debug;
 pub mod borrowed;
 pub mod ion_c_reader;
 pub mod native_reader;
+pub mod native_writer;
 pub mod owned;
 pub mod reader;
 pub mod writer;

--- a/src/value/native_writer.rs
+++ b/src/value/native_writer.rs
@@ -1,0 +1,114 @@
+use crate::types::integer::IntAccess;
+use crate::value::writer::ElementWriter;
+use crate::value::{Element, Sequence, Struct, SymbolToken};
+use crate::{IonResult, IonType, RawSymbolTokenRef, Writer};
+
+/// Writes [Element] instances to the underlying [Writer] implementation.
+pub struct NativeElementWriter<W: Writer> {
+    writer: W,
+}
+
+impl<W: Writer> ElementWriter for NativeElementWriter<W> {
+    type Output = W;
+
+    fn write<E: Element>(&mut self, element: &E) -> IonResult<()> {
+        self.write_element(None, element)
+    }
+
+    fn finish(mut self) -> IonResult<Self::Output> {
+        self.writer.flush()?;
+        Ok(self.writer)
+    }
+}
+
+impl<W: Writer> NativeElementWriter<W> {
+    /// Constructs a new `NativeElementWriter` that wraps the provided [Writer] implementation.
+    pub fn new(writer: W) -> Self {
+        NativeElementWriter { writer }
+    }
+
+    /// Recursively writes the given `element` and its child elements (if any) to the underlying
+    /// writer.
+    fn write_element<E: Element>(
+        &mut self,
+        field_name: Option<&str>,
+        element: &E,
+    ) -> IonResult<()> {
+        if let Some(field_name) = field_name {
+            self.writer.set_field_name(field_name);
+        }
+
+        let element_annotations = element.annotations().map(|token| {
+            if let Some(text) = token.text() {
+                RawSymbolTokenRef::Text(text)
+            } else if let Some(sid) = token.local_sid() {
+                RawSymbolTokenRef::SymbolId(sid)
+            } else {
+                unreachable!("cannot write annotation with neither text nor symbol ID")
+            }
+        });
+        self.writer.set_annotations(element_annotations);
+
+        if element.is_null() {
+            return self.writer.write_null(element.ion_type());
+        }
+
+        match element.ion_type() {
+            IonType::Null => unreachable!("element has IonType::Null but is_null() was false"),
+            IonType::Boolean => self.writer.write_bool(element.as_bool().unwrap()),
+            IonType::Integer => self
+                .writer
+                .write_i64(element.as_integer().unwrap().as_i64().unwrap()),
+            IonType::Float => self.writer.write_f64(element.as_f64().unwrap()),
+            IonType::Decimal => self.writer.write_decimal(element.as_decimal().unwrap()),
+            IonType::Timestamp => self.writer.write_timestamp(element.as_timestamp().unwrap()),
+            IonType::Symbol => self
+                .writer
+                .write_symbol(element.as_sym().unwrap().text().unwrap()),
+            IonType::String => self.writer.write_string(element.as_str().unwrap()),
+            IonType::Clob => self.writer.write_clob(element.as_bytes().unwrap()),
+            IonType::Blob => self.writer.write_blob(element.as_bytes().unwrap()),
+            IonType::List | IonType::SExpression => {
+                self.writer.step_in(element.ion_type())?;
+                for value in element.as_sequence().unwrap().iter() {
+                    self.write(value)?;
+                }
+                self.writer.step_out()
+            }
+            IonType::Struct => {
+                self.writer.step_in(IonType::Struct)?;
+                for (field, value) in element.as_struct().unwrap().iter() {
+                    self.write_element(Some(field.text().unwrap()), value)?;
+                }
+                self.writer.step_out()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ion_eq::IonEq;
+    use crate::value::native_writer::NativeElementWriter;
+    use crate::value::reader::{native_element_reader, ElementReader};
+    use crate::value::writer::ElementWriter;
+    use crate::{IonResult, RawTextWriter, TextWriter};
+    use nom::AsBytes;
+
+    #[test]
+    fn element_roundtrip() -> IonResult<()> {
+        let mut buffer = Vec::new();
+        let writer = TextWriter::new(RawTextWriter::new(&mut buffer));
+        let mut element_writer = NativeElementWriter::new(writer);
+
+        let ion = r#"
+            null true 0 1e0 2.0 2022T foo "bar" (foo bar baz) [foo, bar, baz] {foo: true, bar: false}
+        "#;
+        let expected_elements = native_element_reader().read_all(ion.as_bytes())?;
+        element_writer.write_all(&expected_elements)?;
+        let _ = element_writer.finish()?;
+        let actual_elements = native_element_reader().read_all(buffer.as_bytes())?;
+        assert!(expected_elements.ion_eq(&actual_elements));
+        Ok(())
+    }
+}

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -119,11 +119,8 @@ trait ElementApi {
         source_elements: &Vec<OwnedElement>,
         format: Format,
     ) -> IonResult<Vec<OwnedElement>> {
-        let new_elements = Self::RoundTripper::roundtrip(
-            source_elements,
-            format,
-            Self::make_reader(), /*HERE*/
-        )?;
+        let new_elements =
+            Self::RoundTripper::roundtrip(source_elements, format, Self::make_reader())?;
         assert!(
             source_elements.ion_eq(&new_elements),
             "Roundtrip via {:?} failed: {}",


### PR DESCRIPTION
This PR makes the following changes:

* A native Rust `ElementWriter` implementation (`NativeElementWriter`)
has been added with basic testing; it is not yet being used in
`ion-tests`.
* ion-tests integration has been refactored to facilitate running
roundtrip tests with either the `IonCSliceElementWriter` or the
`NativeElementWriter` as desired.
* Fixed a bug in the ion-tests integration that caused the ion-c reader
to be used in some tests even when the native reader had been requested.
This change surfaced some additional failing ion-tests that have been
addressed in the changes below.
* The 64-bit size limit on the binary encoding primitive `Int` has been
lifted. This allows Timestamps and Decimals of arbitrary precision to be
read; write support for big `Int`s has not been added yet.
* Clobs now disallow unescaped non-ASCII characters and unescaped ASCII
control characters.
* Strings now disallow unescaped ASCII control characters.
* Strings and clobs now correctly decode utf-16 surrogate pairs.
* Long-form clobs and strings now normalize unescaped newlines.
* Fixed a bug in the `TextBuffer` that could cause a panic if restacking
the buffer's contents caused `truncate` to evaluate garbage data beyond
the truncation point.
* Fixed a bug in the way that Timestamp fractional seconds were being
converted to a Decimal.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
