### PR TITLE
Writer tests; fixes:symbols, timestamps, big Ints

### DIFF
--- a/ion-hash/src/representation.rs
+++ b/ion-hash/src/representation.rs
@@ -69,7 +69,7 @@ where
                 0 => {}
                 _ => {
                     let magnitude = v.abs() as u64;
-                    let encoded = binary::uint::encode_uint(magnitude);
+                    let encoded = binary::uint::encode_u64(magnitude);
                     self.update_escaping(encoded.as_bytes());
                 }
             },

--- a/src/binary/binary_writer.rs
+++ b/src/binary/binary_writer.rs
@@ -6,8 +6,7 @@ use crate::types::decimal::Decimal;
 use crate::types::timestamp::Timestamp;
 use crate::types::SymbolId;
 use crate::writer::Writer;
-use crate::IonType;
-use crate::SymbolTable;
+use crate::{Integer, IonType, SymbolTable};
 use delegate::delegate;
 use std::io::Write;
 
@@ -129,7 +128,7 @@ impl<W: Write> Writer for BinaryWriter<W> {
                     symbol_id
                 } else {
                     return illegal_operation(format!(
-                        "Cannot set symbol ID ${} as annotation. It is undefined.",
+                        "Cannot set symbol ID ${} as a symbol value. It is undefined.",
                         symbol_id
                     ));
                 }
@@ -172,6 +171,7 @@ impl<W: Write> Writer for BinaryWriter<W> {
             fn write_null(&mut self, ion_type: IonType) -> IonResult<()>;
             fn write_bool(&mut self, value: bool) -> IonResult<()>;
             fn write_i64(&mut self, value: i64) -> IonResult<()>;
+            fn write_integer(&mut self, value: &Integer) -> IonResult<()>;
             fn write_f32(&mut self, value: f32) -> IonResult<()>;
             fn write_f64(&mut self, value: f64) -> IonResult<()>;
             fn write_decimal(&mut self, value: &Decimal) -> IonResult<()>;

--- a/src/binary/binary_writer.rs
+++ b/src/binary/binary_writer.rs
@@ -128,7 +128,7 @@ impl<W: Write> Writer for BinaryWriter<W> {
                     symbol_id
                 } else {
                     return illegal_operation(format!(
-                        "Cannot set symbol ID ${} as a symbol value. It is undefined.",
+                        "Cannot write symbol ID ${} as a symbol value. It is undefined.",
                         symbol_id
                     ));
                 }

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -74,7 +74,7 @@ impl DecodedUInt {
 
     /// Encodes the provided `magnitude` as a UInt and writes it to the provided `sink`.
     pub fn write_u64<W: Write>(sink: &mut W, magnitude: u64) -> IonResult<usize> {
-        let encoded = encode_uint(magnitude);
+        let encoded = encode_u64(magnitude);
         let bytes_to_write = encoded.as_ref();
 
         sink.write_all(bytes_to_write)?;
@@ -105,21 +105,30 @@ impl From<DecodedUInt> for Integer {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum UIntBeBytes {
+    Stack([u8; mem::size_of::<u64>()]),
+    Heap(Vec<u8>),
+}
+
 /// The big-endian, compact slice of bytes for a UInt (`u64`). Leading zero
 /// octets are not part of the representation. See the [spec] for more
 /// information.
 ///
 /// [spec]: https://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct EncodedUInt {
-    be_bytes: [u8; mem::size_of::<u64>()],
+    be_bytes: UIntBeBytes,
     first_occupied_byte: usize,
 }
 
 impl EncodedUInt {
     /// Returns the slice view of the encoded UInt.
     pub fn as_bytes(&self) -> &[u8] {
-        &self.be_bytes[self.first_occupied_byte..]
+        match self.be_bytes {
+            UIntBeBytes::Stack(ref byte_array) => &byte_array[self.first_occupied_byte..],
+            UIntBeBytes::Heap(ref byte_vec) => &byte_vec[self.first_occupied_byte..],
+        }
     }
 }
 
@@ -135,13 +144,13 @@ impl AsRef<[u8]> for EncodedUInt {
 /// ```
 /// use ion_rs::binary::uint;
 ///
-/// let repr = uint::encode_uint(5u64);
+/// let repr = uint::encode_u64(5u64);
 /// assert_eq!(&[0x05], repr.as_bytes());
 ///
-/// let two_bytes = uint::encode_uint(256u64);
+/// let two_bytes = uint::encode_u64(256u64);
 /// assert_eq!(&[0x01, 0x00], two_bytes.as_bytes());
 /// ```
-pub fn encode_uint(magnitude: u64) -> EncodedUInt {
+pub fn encode_u64(magnitude: u64) -> EncodedUInt {
     // We can divide the number of leading zero bits by 8
     // to to get the number of leading zero bytes.
     let empty_leading_bytes: u32 = magnitude.leading_zeros() / 8;
@@ -150,7 +159,22 @@ pub fn encode_uint(magnitude: u64) -> EncodedUInt {
     let magnitude_bytes: [u8; mem::size_of::<u64>()] = magnitude.to_be_bytes();
 
     EncodedUInt {
-        be_bytes: magnitude_bytes,
+        be_bytes: UIntBeBytes::Stack(magnitude_bytes),
+        first_occupied_byte,
+    }
+}
+
+pub fn encode_uinteger(magnitude: &UInteger) -> EncodedUInt {
+    let magnitude: &BigUint = match magnitude {
+        UInteger::U64(m) => return encode_u64(*m),
+        UInteger::BigUInt(m) => m,
+    };
+
+    let be_bytes = UIntBeBytes::Heap(magnitude.to_bytes_be());
+    let first_occupied_byte = 0;
+
+    EncodedUInt {
+        be_bytes,
         first_occupied_byte,
     }
 }
@@ -158,6 +182,7 @@ pub fn encode_uint(magnitude: u64) -> EncodedUInt {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use num_traits::Num;
     use std::io::Cursor;
 
     const READ_ERROR_MESSAGE: &str = "Failed to read a UInt from the provided cursor.";
@@ -188,6 +213,18 @@ mod tests {
     }
 
     #[test]
+    fn test_read_ten_byte_uint() {
+        let data = vec![0xFFu8; 10];
+        let uint = DecodedUInt::read(&mut Cursor::new(data.as_slice()), data.len())
+            .expect(READ_ERROR_MESSAGE);
+        assert_eq!(uint.size_in_bytes(), 10);
+        assert_eq!(
+            uint.value(),
+            &UInteger::BigUInt(BigUint::from_str_radix("ffffffffffffffffffff", 16).unwrap())
+        );
+    }
+
+    #[test]
     fn test_read_uint_too_large() {
         let mut buffer = Vec::with_capacity(MAX_UINT_SIZE_IN_BYTES + 1);
         for _ in 0..(MAX_UINT_SIZE_IN_BYTES + 1) {
@@ -196,6 +233,17 @@ mod tests {
         let data = buffer.as_slice();
         let _uint = DecodedUInt::read(&mut Cursor::new(data), data.len())
             .expect_err("This exceeded the configured max UInt size.");
+    }
+
+    #[test]
+    fn test_write_ten_byte_uint() {
+        let value = UInteger::BigUInt(BigUint::from_str_radix("ffffffffffffffffffff", 16).unwrap());
+        let mut buffer: Vec<u8> = vec![];
+        // TODO: Move this method to `EncodedUInt`? `from_uinteger()`? generic?
+        let encoded = super::encode_uinteger(&value);
+        buffer.write_all(&encoded.as_bytes()).unwrap();
+        let expected_bytes = vec![0xFFu8; 10];
+        assert_eq!(expected_bytes.as_slice(), buffer.as_slice());
     }
 
     #[test]

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -242,7 +242,6 @@ mod tests {
     fn test_write_ten_byte_uint() {
         let value = UInteger::BigUInt(BigUint::from_str_radix("ffffffffffffffffffff", 16).unwrap());
         let mut buffer: Vec<u8> = vec![];
-        // TODO: Move this method to `EncodedUInt`? `from_uinteger()`? generic?
         let encoded = super::encode_uinteger(&value);
         buffer.write_all(&encoded.as_bytes()).unwrap();
         let expected_bytes = vec![0xFFu8; 10];

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -105,6 +105,8 @@ impl From<DecodedUInt> for Integer {
     }
 }
 
+/// A buffer for storing a UInt's Big Endian bytes. UInts that can fit in a `u64` will use the
+/// `Stack` storage variant, meaning that no heap allocations are required in the common case.
 #[derive(Clone, Debug, PartialEq)]
 pub enum UIntBeBytes {
     Stack([u8; mem::size_of::<u64>()]),
@@ -164,6 +166,7 @@ pub fn encode_u64(magnitude: u64) -> EncodedUInt {
     }
 }
 
+/// Returns the magnitude as big-endian bytes.
 pub fn encode_uinteger(magnitude: &UInteger) -> EncodedUInt {
     let magnitude: &BigUint = match magnitude {
         UInteger::U64(m) => return encode_u64(*m),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,13 @@ pub use text::text_writer::TextWriter;
 pub use writer::Writer;
 
 pub use binary::raw_binary_reader::RawBinaryReader;
+pub use binary::raw_binary_writer::RawBinaryWriter;
 pub use raw_reader::{RawReader, RawStreamItem};
 pub use reader::Reader;
 pub use reader::StreamItem;
 pub use stream_reader::StreamReader;
 pub use system_reader::{SystemReader, SystemStreamItem};
+pub use text::raw_text_reader::RawTextReader;
 pub use text::raw_text_writer::RawTextWriter;
 
 pub use result::IonError;

--- a/src/text/parsers/float.rs
+++ b/src/text/parsers/float.rs
@@ -81,6 +81,15 @@ mod float_parsing_tests {
         } else {
             panic!("Expected NaN, but got: {:?}", value);
         }
+
+        // -0 keeps its negative sign
+        let value = parse_unwrap(parse_float, "-0e0 ");
+        if let TextValue::Float(f) = value {
+            assert!(f == 0.0f64);
+            assert!(f.is_sign_negative())
+        } else {
+            panic!("Expected -0e0, but got: {:?}", value);
+        }
     }
 
     #[test]

--- a/src/text/parsers/symbol.rs
+++ b/src/text/parsers/symbol.rs
@@ -54,7 +54,7 @@ fn quoted_symbol_string_fragment(input: &str) -> IonParseResult<StringFragment> 
 
 /// Matches the next quoted symbol string fragment while respecting the symbol delimiter (`'`).
 fn quoted_symbol_fragment_without_escaped_text(input: &str) -> IonParseResult<StringFragment> {
-    map(verify(is_not("'\\"), |s: &str| !s.is_empty()), |text| {
+    map(verify(is_not(r"'\"), |s: &str| !s.is_empty()), |text| {
         StringFragment::Substring(text)
     })(input)
 }
@@ -185,6 +185,9 @@ mod symbol_parsing_tests {
         parse_equals("'foo bar baz' ", "foo bar baz");
         parse_equals("'foo \"bar\" baz' ", "foo \"bar\" baz");
         parse_equals("'7@#$%^&*()!' ", "7@#$%^&*()!");
+        parse_equals(r"'$99' ", r"$99");
+
+        parse_equals(r"'foo \' foo' ", "foo ' foo");
 
         // Leading whitespace not accepted
         parse_fails(" 'foo' ");

--- a/src/text/parsers/timestamp.rs
+++ b/src/text/parsers/timestamp.rs
@@ -1,4 +1,3 @@
-use std::ops::DivAssign;
 use std::str::FromStr;
 
 use nom::branch::alt;
@@ -163,14 +162,7 @@ fn assign_fractional_seconds(
                 "parsing fractional seconds as BigUInt failed",
             )?
             .1;
-        let mut digit_count = 1i64;
-        let mut tmp_coefficient = coefficient.clone();
-        let ten = BigUint::from(10u32);
-        while tmp_coefficient > ten {
-            tmp_coefficient.div_assign(&ten);
-            digit_count += 1;
-        }
-        let decimal = Decimal::new(coefficient, -digit_count);
+        let decimal = Decimal::new(coefficient, -(number_of_digits as i64));
         setter = setter.with_fractional_seconds(decimal);
     }
     Ok(("", setter))

--- a/src/text/text_writer.rs
+++ b/src/text/text_writer.rs
@@ -4,8 +4,7 @@ use crate::text::raw_text_writer::RawTextWriter;
 use crate::types::decimal::Decimal;
 use crate::types::timestamp::Timestamp;
 use crate::writer::Writer;
-use crate::IonType;
-use crate::SymbolTable;
+use crate::{Integer, IonType, SymbolTable};
 use delegate::delegate;
 use std::io::Write;
 
@@ -106,6 +105,7 @@ impl<W: Write> Writer for TextWriter<W> {
             fn write_null(&mut self, ion_type: IonType) -> IonResult<()>;
             fn write_bool(&mut self, value: bool) -> IonResult<()>;
             fn write_i64(&mut self, value: i64) -> IonResult<()>;
+            fn write_integer(&mut self, value: &Integer) -> IonResult<()>;
             fn write_f32(&mut self, value: f32) -> IonResult<()>;
             fn write_f64(&mut self, value: f64) -> IonResult<()>;
             fn write_decimal(&mut self, value: &Decimal) -> IonResult<()>;

--- a/src/types/coefficient.rs
+++ b/src/types/coefficient.rs
@@ -44,6 +44,7 @@ impl Coefficient {
         self.magnitude.number_of_decimal_digits()
     }
 
+    /// Constructs a new Coefficient that represents negative zero.
     pub(crate) fn negative_zero() -> Self {
         Coefficient {
             sign: Sign::Negative,
@@ -51,10 +52,29 @@ impl Coefficient {
         }
     }
 
+    /// Returns true if the Coefficient represents positive zero.
     pub(crate) fn is_negative_zero(&self) -> bool {
         match (self.sign, &self.magnitude) {
             (Sign::Negative, Magnitude::U64(0)) => true,
             (Sign::Negative, Magnitude::BigUInt(b)) if b.is_zero() => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the Coefficient represents positive zero.
+    pub(crate) fn is_positive_zero(&self) -> bool {
+        match (self.sign, &self.magnitude) {
+            (Sign::Positive, Magnitude::U64(0)) => true,
+            (Sign::Positive, Magnitude::BigUInt(b)) if b.is_zero() => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the Coefficient represents a zero of any sign.
+    pub(crate) fn is_zero(&self) -> bool {
+        match (self.sign, &self.magnitude) {
+            (_, Magnitude::U64(0)) => true,
+            (_, Magnitude::BigUInt(b)) if b.is_zero() => true,
             _ => false,
         }
     }

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -170,7 +170,7 @@ impl Decimal {
         // We do this by multiplying it times 10^exponent_delta, which is 1 in this case.
         // This lets us compare 80 and 80, determining that the decimals are equal.
         let mut scaled_coefficient: BigUint = d1.coefficient.magnitude().to_biguint().unwrap();
-        scaled_coefficient *= 10u64.pow(exponent_delta as u32);
+        scaled_coefficient *= BigUint::from(10u64).pow(exponent_delta as u32);
         Magnitude::BigUInt(scaled_coefficient).cmp(d2.coefficient.magnitude())
     }
 }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -238,7 +238,6 @@ impl Timestamp {
             (None, None) => true,
             (Some(m), None) => m.is_empty(),
             (None, Some(m)) => m.is_empty(),
-            // (Some(m1), Some(m2)) => m1.eq(m2),
             (Some(Digits(d1)), Some(Digits(d2))) => {
                 if d1 != d2 {
                     // Different precisions

--- a/src/value/native_writer.rs
+++ b/src/value/native_writer.rs
@@ -1,4 +1,3 @@
-use crate::types::integer::IntAccess;
 use crate::value::writer::ElementWriter;
 use crate::value::{Element, Sequence, Struct, SymbolToken};
 use crate::{IonResult, IonType, RawSymbolTokenRef, Writer};
@@ -56,9 +55,7 @@ impl<W: Writer> NativeElementWriter<W> {
         match element.ion_type() {
             IonType::Null => unreachable!("element has IonType::Null but is_null() was false"),
             IonType::Boolean => self.writer.write_bool(element.as_bool().unwrap()),
-            IonType::Integer => self
-                .writer
-                .write_i64(element.as_integer().unwrap().as_i64().unwrap()),
+            IonType::Integer => self.writer.write_integer(element.as_integer().unwrap()),
             IonType::Float => self.writer.write_f64(element.as_f64().unwrap()),
             IonType::Decimal => self.writer.write_decimal(element.as_decimal().unwrap()),
             IonType::Timestamp => self.writer.write_timestamp(element.as_timestamp().unwrap()),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -3,6 +3,7 @@ use crate::result::IonResult;
 use crate::types::decimal::Decimal;
 use crate::types::timestamp::Timestamp;
 use crate::types::IonType;
+use crate::Integer;
 
 /**
  * This trait captures the format-agnostic encoding functionality needed to write native Rust types
@@ -39,6 +40,9 @@ pub trait Writer {
 
     /// Writes an Ion `integer` with the specified value to the output stream.
     fn write_i64(&mut self, value: i64) -> IonResult<()>;
+
+    /// Writes an Ion `integer` with the specified value to the output stream.
+    fn write_integer(&mut self, value: &Integer) -> IonResult<()>;
 
     /// Writes an Ion `float` with the specified value to the output stream.
     fn write_f32(&mut self, value: f32) -> IonResult<()>;

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -151,14 +151,11 @@ trait ElementApi {
         format1: Format,
         format2: Format,
     ) -> IonResult<()> {
-        println!("reading source elements");
         let source_elements = Self::read_file(&Self::make_reader(), file_name)?;
         if contains_path(Self::round_trip_skip_list(), file_name) {
             return Ok(());
         }
-        println!("writing first elements");
         let first_write_elements = Self::assert_round_trip(&source_elements, format1)?;
-        println!("writing second elements");
         let second_write_elements = Self::assert_round_trip(&first_write_elements, format2)?;
         assert!(source_elements.ion_eq(&second_write_elements));
         Ok(())


### PR DESCRIPTION
This PR makes the following changes:

* Enables `ion-tests` integration for the `NativeElementWriter`,
the pure-Rust DOM writing API. The `IonCSliceElementWriter` is now only
used when paired with the `IonCElementReader`.
* Adds a `Writer::write_integer` method that can encode an `Integer` of
any size.
* Lifts the size restriction on the `Int` encoding primitive, allowing
`ion-rs` to support `Timestamp`s and `Decimal`s of truly arbitrary
precision when necessary.
* Modifies the `RawTextWriter` to:
   * escape literals like `\n` and `\r`
   * detect symbols whose text resembles a symbol ID (for example:
`'$99'`) and wrap them in quotes to keep them from being interpreted
     after roundtripping
* Removes the `FractionalSeconds` variant of `Precision`, making it more
straightforward to compare `Timestamp`s that specify 'empty' fractional
seconds values like `0d0` with `Timestamp`s that specify no fractional
seconds at all.
* Makes it possible to downgrade a high-precision `Timestamp` to a
`DateTime` with nanoseconds (potentially losing precision in the process).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
