### PR TITLE
Makes ion-c-sys an opt-in feature

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2022-01-10
+          toolchain: nightly-2022-05-01
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ members = [
   "ion-hash"
 ]
 
+[features]
+ion_c = ["dep:ion-c-sys"]
+
 [dependencies]
 base64 = "0.12"
 bigdecimal = "0.2"
@@ -42,11 +45,10 @@ arrayvec = "0.7"
 # NB: We use the tree dependency here for development and CI.
 #     Note that when publishing you should update the version
 #     so that users can get the correct underlying ion-c-sys version.
-ion-c-sys = { path = "./ion-c-sys", version = "0.4" }
+ion-c-sys = { path = "./ion-c-sys", version = "0.4", optional = true }
 
 [dev-dependencies]
 rstest = "0.9"
-
 # Used by ion-tests integration
 walkdir = "2.3"
 test-generator = "0.3"

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.0.7"
 edition = "2021"
 
 [dependencies]
-ion-rs = { path = "../", version = "0.10" }
+ion-rs = { path = "../", version = "0.10", features = ["ion_c"]}
 ion-c-sys = { path = "../ion-c-sys", version = "0.4" }
 num-bigint = "0.3"
 digest = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+#[cfg(feature = "ion_c")]
 /// A [`try`]-like macro to workaround the [`Option`]/[`Result`] nested APIs.
 /// These API require checking the type and then calling the appropriate getter function
 /// (which returns a None if you got it wrong). This macro turns the `None` into

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -6,12 +6,14 @@ use crate::types::magnitude::Magnitude;
 use chrono::{
     DateTime, Datelike, FixedOffset, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Timelike,
 };
-use ion_c_sys::timestamp::{IonDateTime, TSOffsetKind, TSPrecision};
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::ops::Div;
+
+#[cfg(feature = "ion_c")]
+use ion_c_sys::timestamp::{IonDateTime, TSOffsetKind, TSPrecision};
 
 /// Indicates the most precise time unit that has been specified in the accompanying [Timestamp].
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd)]
@@ -956,6 +958,7 @@ impl From<DateTime<FixedOffset>> for Timestamp {
     }
 }
 
+#[cfg(feature = "ion_c")]
 impl From<ion_c_sys::timestamp::IonDateTime> for Timestamp {
     fn from(ionc_dt: IonDateTime) -> Self {
         use ion_c_sys::timestamp::Mantissa as IonCMantissa;
@@ -993,6 +996,7 @@ impl From<ion_c_sys::timestamp::IonDateTime> for Timestamp {
 /// In general there should be 1-to-1 fidelity between these types, but there
 /// is no static way to guarantee this because of [`Decimal`] and the public constructor for
 /// [`IonDateTime`](ion_c_sys::timestamp::IonDateTime).
+#[cfg(feature = "ion_c")]
 impl TryInto<ion_c_sys::timestamp::IonDateTime> for Timestamp {
     type Error = IonError;
 
@@ -1499,7 +1503,7 @@ mod timestamp_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "ion_c"))]
 mod ionc_tests {
     use super::*;
     use bigdecimal::BigDecimal;

--- a/src/value/ion_c_reader.rs
+++ b/src/value/ion_c_reader.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "ion_c")]
+
 use crate::result::IonResult;
 use crate::value::owned::{text_token, OwnedElement, OwnedSequence, OwnedStruct};
 use crate::value::reader::ElementReader;

--- a/src/value/ion_c_writer.rs
+++ b/src/value/ion_c_writer.rs
@@ -1,0 +1,177 @@
+use crate::result::illegal_operation;
+use crate::value::writer::{Binary, Compact, ElementWriter, Format, Pretty, Text};
+use crate::value::{Element, Sequence, Struct, SymbolToken};
+use crate::{Integer, IonError, IonResult, IonType};
+use ion_c_sys::writer::{IonCValueWriter, IonCWriter, IonCWriterHandle};
+use ion_c_sys::ION_WRITER_OPTIONS;
+
+pub type SliceElementWriter<'a> = IonCSliceElementWriter<'a>;
+
+impl<'a> IonCSliceElementWriter<'a> {
+    pub(crate) fn new(buf: &'a mut [u8], format: Format) -> IonResult<Self> {
+        let data = buf.as_ptr();
+        let mut options: ION_WRITER_OPTIONS = Default::default();
+        match format {
+            Text(kind) => {
+                options.output_as_binary = 0;
+                match kind {
+                    Compact => options.pretty_print = 0,
+                    Pretty => options.pretty_print = 1,
+                };
+            }
+            Binary => {
+                options.output_as_binary = 1;
+            }
+        };
+        let writer = IonCWriterHandle::new_buf(buf, &mut options)?;
+        Ok(Self {
+            data,
+            writer,
+            error: None,
+        })
+    }
+
+    /// Writes an element with an optional field name context (if being written recursively).
+    /// This cannot be made generic due to the lack of GAT making it impossible for IonC's
+    /// writer to push down the context--it could be written in terms of
+    /// `IonCAnnotationsFieldWriterContext` but that would just complicate the code to work around
+    /// the lack of GAT.
+    pub(crate) fn write_element<E: Element>(
+        &mut self,
+        field_name_opt: Option<&str>,
+        element: &E,
+    ) -> IonResult<()> {
+        let annotations_opt: Option<Vec<_>> = element.annotations().map(|tok| tok.text()).collect();
+        if let Some(annotations) = annotations_opt {
+            // get a writing context with the annotations (which could be empty)
+            let mut af_writer = self.writer.annotations(&annotations);
+            if let Some(field_name) = field_name_opt {
+                // decorate the annotation context with the field name when we have one
+                af_writer.field(field_name);
+            }
+
+            let ion_type = element.ion_type();
+            if element.is_null() {
+                af_writer.write_null(ion_type.into())?;
+            } else {
+                // non-null element values
+                match ion_type {
+                    IonType::Null => {
+                        // handled in the null-arm
+                    }
+                    IonType::Boolean => {
+                        af_writer.write_bool(try_to!(element.as_bool()))?;
+                    }
+                    IonType::Integer => {
+                        let any_int = try_to!(element.as_integer());
+                        match any_int {
+                            Integer::I64(i64_val) => {
+                                af_writer.write_i64(*i64_val)?;
+                            }
+                            Integer::BigInt(big_val) => {
+                                af_writer.write_bigint(big_val)?;
+                            }
+                        }
+                    }
+                    IonType::Float => {
+                        af_writer.write_f64(try_to!(element.as_f64()))?;
+                    }
+                    IonType::Decimal => {
+                        // TODO reconsider Decimal/BigDecimal internal factoring to avoid the clone
+                        let decimal = try_to!(element.as_decimal());
+                        let big_decimal = decimal.clone().try_into()?;
+                        af_writer.write_bigdecimal(&big_decimal)?;
+                    }
+                    IonType::Timestamp => {
+                        // TODO reconsider Timestamp/IonDateTime factoring to avoid the clone
+                        let timestamp = try_to!(element.as_timestamp());
+                        let ion_dt = timestamp.clone().try_into()?;
+                        af_writer.write_datetime(&ion_dt)?;
+                    }
+                    IonType::Symbol => {
+                        af_writer.write_symbol(try_to!(element.as_str()))?;
+                    }
+                    IonType::String => {
+                        af_writer.write_string(try_to!(element.as_str()))?;
+                    }
+                    IonType::Clob => {
+                        af_writer.write_clob(try_to!(element.as_bytes()))?;
+                    }
+                    IonType::Blob => {
+                        af_writer.write_blob(try_to!(element.as_bytes()))?;
+                    }
+                    IonType::List | IonType::SExpression => {
+                        af_writer.start_container(ion_type.into())?;
+                        {
+                            let seq = try_to!(element.as_sequence());
+                            for child in seq.iter() {
+                                self.write(child)?;
+                            }
+                        }
+                        self.writer.finish_container()?;
+                    }
+                    IonType::Struct => {
+                        af_writer.start_container(ion_type.into())?;
+                        {
+                            let structure = try_to!(element.as_struct());
+                            for (field_name_token, child) in structure.iter() {
+                                let field_name = try_to!(field_name_token.text());
+                                self.write_element(Some(field_name), child)?;
+                            }
+                        }
+                        self.writer.finish_container()?;
+                    }
+                }
+            }
+            Ok(())
+        } else {
+            illegal_operation(format!(
+                "Could not serialize annotation(s) with no text: {:?}",
+                element
+            ))
+        }
+    }
+}
+
+impl<'a> ElementWriter for IonCSliceElementWriter<'a> {
+    type Output = &'a [u8];
+
+    #[inline]
+    fn write<E: Element>(&mut self, element: &E) -> IonResult<()> {
+        self.write_element(None, element)
+    }
+
+    fn finish(self) -> IonResult<Self::Output> {
+        if let Some(error) = self.error {
+            return Err(error);
+        }
+
+        // close out the writer and get the written length
+        let data = self.data;
+        let len = {
+            // consume the writer so that we drop it at the end
+            let mut writer = self.writer;
+            writer.finish()?
+        };
+
+        // at this point we can make a slice reference bound to the lifetime parameter
+        // because the writer is no longer borrowing it implicitly (and has been dropped)
+        let output = unsafe { std::slice::from_raw_parts(data, len) };
+        Ok(output)
+    }
+}
+
+/// Implementation of a [`ElementWriter`] to a slice.
+///
+/// Note that users should not take a dependency on this type name--it is exposed
+/// because an opaque type makes using this with the associated lifetimes of the
+/// output difficult.  A type alias [`SliceElementWriter`] is a better reference for this
+/// would be opaque type.
+pub struct IonCSliceElementWriter<'a> {
+    /// Raw pointer to the slice we write to--this is borrowed by the Ion C writer
+    /// opaquely, so we retain it such that we can return the written data as a
+    /// slice reference in `finish`.
+    data: *const u8,
+    writer: IonCWriterHandle<'a>,
+    error: Option<IonError>,
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -97,7 +97,7 @@
 //! To serialize data, users can use the [`ElementWriter`](writer::ElementWriter) trait to serialize data
 //! from [`Element`] to binary or text Ion:
 //!
-//! ```
+//! ```ignore
 //! use ion_rs::result::IonResult;
 //! use ion_rs::value::Element;
 //! use ion_rs::value::reader::{element_reader, ElementReader};
@@ -110,6 +110,7 @@
 //!     let elems = element_reader().read_all(b"null true 1")?;
 //!
 //!     let mut buf = vec![0u8; BUF_SIZE];
+//!     // This method requires the `ion-c-sys` feature to be enabled
 //!     let mut writer = Format::Binary.element_writer_for_slice(&mut buf)?;
 //!     writer.write_all(elems.iter())?;
 //!
@@ -213,12 +214,16 @@ use num_bigint::BigInt;
 use std::fmt::Debug;
 
 pub mod borrowed;
-pub mod ion_c_reader;
 pub mod native_reader;
 pub mod native_writer;
 pub mod owned;
 pub mod reader;
 pub mod writer;
+
+#[cfg(feature = "ion_c")]
+pub mod ion_c_reader;
+#[cfg(feature = "ion_c")]
+mod ion_c_writer;
 
 /// The shared symbol table source of a given [`SymbolToken`].
 pub trait ImportSource: Debug + PartialEq {

--- a/src/value/reader.rs
+++ b/src/value/reader.rs
@@ -4,9 +4,11 @@
 //! as slices or files.
 
 use crate::result::{decoding_error, IonResult};
-use crate::value::ion_c_reader::IonCElementReader;
 use crate::value::native_reader::NativeElementReader;
 use crate::value::owned::OwnedElement;
+
+#[cfg(feature = "ion_c")]
+use crate::value::ion_c_reader::IonCElementReader;
 
 // TODO add/refactor trait/implementation for borrowing over some context
 //      we could make it generic with generic associated types or just have a lifetime
@@ -67,6 +69,13 @@ pub trait ElementReader {
 }
 
 /// Returns an implementation defined [`ElementReader`] instance.
+#[cfg(not(feature = "ion_c"))]
+pub fn element_reader() -> impl ElementReader {
+    native_element_reader()
+}
+
+/// Returns an implementation defined [`ElementReader`] instance.
+#[cfg(feature = "ion_c")]
 pub fn element_reader() -> impl ElementReader {
     ion_c_element_reader()
 }
@@ -75,6 +84,7 @@ pub fn native_element_reader() -> NativeElementReader {
     NativeElementReader {}
 }
 
+#[cfg(feature = "ion_c")]
 pub fn ion_c_element_reader() -> IonCElementReader {
     IonCElementReader {}
 }

--- a/src/value/writer.rs
+++ b/src/value/writer.rs
@@ -3,14 +3,12 @@
 //! Provides utility to serialize Ion data from [`Element`](super::Element) into common targets
 //! such as byte buffers or files.
 
-use super::{Element, Sequence, Struct, SymbolToken};
-use crate::result::{illegal_operation, IonError, IonResult};
-use crate::IonType;
-use ion_c_sys::writer::{IonCValueWriter, IonCWriter, IonCWriterHandle};
-use ion_c_sys::ION_WRITER_OPTIONS;
-use std::convert::TryInto;
+use super::Element;
+use crate::result::IonResult;
 
-use crate::types::integer::Integer;
+#[cfg(feature = "ion_c")]
+use crate::value::ion_c_writer::{IonCSliceElementWriter, SliceElementWriter};
+
 pub use Format::*;
 pub use TextKind::*;
 
@@ -44,177 +42,6 @@ pub trait ElementWriter {
     fn finish(self) -> IonResult<Self::Output>;
 }
 
-/// Implementation of a [`ElementWriter`] to a slice.
-///
-/// Note that users should not take a dependency on this type name--it is exposed
-/// because an opaque type makes using this with the associated lifetimes of the
-/// output difficult.  A type alias [`SliceElementWriter`] is a better reference for this
-/// would be opaque type.
-pub struct IonCSliceElementWriter<'a> {
-    /// Raw pointer to the slice we write to--this is borrowed by the Ion C writer
-    /// opaquely, so we retain it such that we can return the written data as a
-    /// slice reference in `finish`.
-    data: *const u8,
-    writer: IonCWriterHandle<'a>,
-    error: Option<IonError>,
-}
-
-pub type SliceElementWriter<'a> = IonCSliceElementWriter<'a>;
-
-impl<'a> IonCSliceElementWriter<'a> {
-    fn new(buf: &'a mut [u8], format: Format) -> IonResult<Self> {
-        let data = buf.as_ptr();
-        let mut options: ION_WRITER_OPTIONS = Default::default();
-        match format {
-            Text(kind) => {
-                options.output_as_binary = 0;
-                match kind {
-                    Compact => options.pretty_print = 0,
-                    Pretty => options.pretty_print = 1,
-                };
-            }
-            Binary => {
-                options.output_as_binary = 1;
-            }
-        };
-        let writer = IonCWriterHandle::new_buf(buf, &mut options)?;
-        Ok(Self {
-            data,
-            writer,
-            error: None,
-        })
-    }
-
-    /// Writes an element with an optional field name context (if being written recursively).
-    /// This cannot be made generic due to the lack of GAT making it impossible for IonC's
-    /// writer to push down the context--it could be written in terms of
-    /// `IonCAnnotationsFieldWriterContext` but that would just complicate the code to work around
-    /// the lack of GAT.
-    fn write_element<E: Element>(
-        &mut self,
-        field_name_opt: Option<&str>,
-        element: &E,
-    ) -> IonResult<()> {
-        let annotations_opt: Option<Vec<_>> = element.annotations().map(|tok| tok.text()).collect();
-        if let Some(annotations) = annotations_opt {
-            // get a writing context with the annotations (which could be empty)
-            let mut af_writer = self.writer.annotations(&annotations);
-            if let Some(field_name) = field_name_opt {
-                // decorate the annotation context with the field name when we have one
-                af_writer.field(field_name);
-            }
-
-            let ion_type = element.ion_type();
-            if element.is_null() {
-                af_writer.write_null(ion_type.into())?;
-            } else {
-                // non-null element values
-                match ion_type {
-                    IonType::Null => {
-                        // handled in the null-arm
-                    }
-                    IonType::Boolean => {
-                        af_writer.write_bool(try_to!(element.as_bool()))?;
-                    }
-                    IonType::Integer => {
-                        let any_int = try_to!(element.as_integer());
-                        match any_int {
-                            Integer::I64(i64_val) => {
-                                af_writer.write_i64(*i64_val)?;
-                            }
-                            Integer::BigInt(big_val) => {
-                                af_writer.write_bigint(big_val)?;
-                            }
-                        }
-                    }
-                    IonType::Float => {
-                        af_writer.write_f64(try_to!(element.as_f64()))?;
-                    }
-                    IonType::Decimal => {
-                        // TODO reconsider Decimal/BigDecimal internal factoring to avoid the clone
-                        let decimal = try_to!(element.as_decimal());
-                        let big_decimal = decimal.clone().try_into()?;
-                        af_writer.write_bigdecimal(&big_decimal)?;
-                    }
-                    IonType::Timestamp => {
-                        // TODO reconsider Timestamp/IonDateTime factoring to avoid the clone
-                        let timestamp = try_to!(element.as_timestamp());
-                        let ion_dt = timestamp.clone().try_into()?;
-                        af_writer.write_datetime(&ion_dt)?;
-                    }
-                    IonType::Symbol => {
-                        af_writer.write_symbol(try_to!(element.as_str()))?;
-                    }
-                    IonType::String => {
-                        af_writer.write_string(try_to!(element.as_str()))?;
-                    }
-                    IonType::Clob => {
-                        af_writer.write_clob(try_to!(element.as_bytes()))?;
-                    }
-                    IonType::Blob => {
-                        af_writer.write_blob(try_to!(element.as_bytes()))?;
-                    }
-                    IonType::List | IonType::SExpression => {
-                        af_writer.start_container(ion_type.into())?;
-                        {
-                            let seq = try_to!(element.as_sequence());
-                            for child in seq.iter() {
-                                self.write(child)?;
-                            }
-                        }
-                        self.writer.finish_container()?;
-                    }
-                    IonType::Struct => {
-                        af_writer.start_container(ion_type.into())?;
-                        {
-                            let structure = try_to!(element.as_struct());
-                            for (field_name_token, child) in structure.iter() {
-                                let field_name = try_to!(field_name_token.text());
-                                self.write_element(Some(field_name), child)?;
-                            }
-                        }
-                        self.writer.finish_container()?;
-                    }
-                }
-            }
-            Ok(())
-        } else {
-            illegal_operation(format!(
-                "Could not serialize annotation(s) with no text: {:?}",
-                element
-            ))
-        }
-    }
-}
-
-impl<'a> ElementWriter for IonCSliceElementWriter<'a> {
-    type Output = &'a [u8];
-
-    #[inline]
-    fn write<E: Element>(&mut self, element: &E) -> IonResult<()> {
-        self.write_element(None, element)
-    }
-
-    fn finish(self) -> IonResult<Self::Output> {
-        if let Some(error) = self.error {
-            return Err(error);
-        }
-
-        // close out the writer and get the written length
-        let data = self.data;
-        let len = {
-            // consume the writer so that we drop it at the end
-            let mut writer = self.writer;
-            writer.finish()?
-        };
-
-        // at this point we can make a slice reference bound to the lifetime parameter
-        // because the writer is no longer borrowing it implicitly (and has been dropped)
-        let output = unsafe { std::slice::from_raw_parts(data, len) };
-        Ok(output)
-    }
-}
-
 /// Whether or not the text is pretty printed or serialized in a more compact representation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TextKind {
@@ -238,6 +65,7 @@ impl Format {
     /// Creates a [`ElementWriter`] for the format over a slice.
     ///
     /// Returns [`Err`] if the [`ElementWriter`] cannot be constructed.
+    #[cfg(feature = "ion_c")]
     pub fn element_writer_for_slice(self, slice: &mut [u8]) -> IonResult<SliceElementWriter> {
         IonCSliceElementWriter::new(slice, self)
     }
@@ -245,7 +73,7 @@ impl Format {
     // TODO into files, cursors, or other such things
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "ion_c"))]
 mod writer_tests {
     use super::*;
     use crate::result::IonResult;
@@ -254,6 +82,8 @@ mod writer_tests {
     use crate::value::borrowed::BorrowedElement;
     use crate::value::owned::OwnedElement;
     use crate::value::Builder;
+    use crate::value::SymbolToken;
+    use crate::IonType;
     use rstest::*;
     use std::str::from_utf8;
 


### PR DESCRIPTION
`ion-c-sys` provides bindings to the `ion-c` library, allowing Rust
applications to use `ion-c`'s readers and writers to work with Ion data.
Now that the native Rust readers and writers are passing the `ion-tests`
conformance suite, `ion-c-sys` is no longer mandatory.

This PR introduces a new feature, "ion-c-sys", that allows users to opt
into the functionality and dependencies that come with `ion-c-sys`.

For users that do not require `ion-c-sys`, this eliminates the need to
install a C toolchain on their development machine (cmake, clang, etc).
It also cuts build times and test runtimes by more than half.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
