### PR TITLE
Version bump: ion-rs v0.11.0, ion-hash v0.0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 
 [workspace]

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -16,11 +16,11 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 
 [dependencies]
-ion-rs = { path = "../", version = "0.10", features = ["ion_c"]}
+ion-rs = { path = "../", version = "0.11", features = ["ion_c"]}
 ion-c-sys = { path = "../ion-c-sys", version = "0.4" }
 num-bigint = "0.3"
 digest = "0.9"


### PR DESCRIPTION
Version bumps in preparation for a new release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
