### PR TITLE
adds `PartialOrd` and `Ord` implementations for `Inetger`, `UInteger` and `Timestamp`

### DIFF
--- a/src/ion_eq.rs
+++ b/src/ion_eq.rs
@@ -25,9 +25,6 @@ use num_traits::Zero;
 /// * Timestamps representing the same point in time at different precisions or at different
 /// timezone offsets are not Ion equivalent.
 ///
-// TODO: `Timestamp` and `Decimal` do not currently implement `IonEq` because their implementations
-//       of `PartialEq` use Ion equivalence rules. We need to disentangle these.
-// See https://github.com/amzn/ion-rust/issues/381
 pub trait IonEq {
     fn ion_eq(&self, other: &Self) -> bool;
 }

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -107,11 +107,6 @@ impl Decimal {
 
     // Determines whether the first decimal value is greater than, equal to, or less than
     // the second decimal value.
-    // TODO: This currently uses the rules for Ion equivalence to determine if two values are equal.
-    //       This leads to potentially surprising behavior around zeros; in particular, -0 and 0
-    //       are not equal, and zeros with different exponents are not equal. We need to offer a
-    //       separate method for testing Ion equivalence.
-    //       See: https://github.com/amzn/ion-rust/issues/220
     fn compare(d1: &Decimal, d2: &Decimal) -> Ordering {
         if d1.is_zero() && d2.is_zero() {
             // Ignore the sign/exponent if they're both some flavor of zero.

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -2,6 +2,7 @@ use crate::result::{decoding_error, IonError};
 use crate::value::Element;
 use num_bigint::{BigInt, BigUint};
 use num_traits::{ToPrimitive, Zero};
+use std::cmp::Ordering;
 use std::ops::{Add, Neg};
 
 /// Provides convenient integer accessors for integer values that are like [`Integer`]
@@ -57,10 +58,64 @@ pub trait IntAccess {
 /// Represents a UInt of any size. Used for reading binary integers and symbol IDs.
 ///
 /// Equality tests do NOT compare across storage types; U64(1) is not the same as BigUInt(1).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum UInteger {
     U64(u64),
     BigUInt(BigUint),
+}
+
+impl UInteger {
+    /// Compares a [u64] integer with a [BigUint] to see if they are equal. This method never
+    /// allocates. It will always prefer to downgrade a BigUint and compare the two integers as
+    /// u64 values. If this is not possible, then the two numbers cannot be equal anyway.
+    fn cross_representation_eq(m1: u64, m2: &BigUint) -> bool {
+        UInteger::cross_representation_cmp(m1, m2) == Ordering::Equal
+    }
+
+    /// Compares a [u64] integer with a [BigUint]. This method never allocates. It will always
+    /// prefer to downgrade a BigUint and compare the two integers as u64 values. If this is
+    /// not possible, then the BigUint is larger than the u64.
+    fn cross_representation_cmp(m1: u64, m2: &BigUint) -> Ordering {
+        // Try to downgrade the BigUint first since that's cheaper than upgrading the u64.
+        if let Some(downgraded_m2) = m2.to_u64() {
+            // If the conversion succeeds, compare the resulting values.
+            return m1.cmp(&downgraded_m2);
+        }
+        // Otherwise, the BigUint must be larger than the u64.
+        Ordering::Less
+    }
+}
+
+impl PartialEq for UInteger {
+    fn eq(&self, other: &Self) -> bool {
+        use UInteger::*;
+        match (self, other) {
+            (U64(m1), U64(m2)) => m1 == m2,
+            (BigUInt(m1), BigUInt(m2)) => m1 == m2,
+            (U64(m1), BigUInt(m2)) => UInteger::cross_representation_eq(*m1, m2),
+            (BigUInt(m1), U64(m2)) => UInteger::cross_representation_eq(*m2, m1),
+        }
+    }
+}
+
+impl Eq for UInteger {}
+
+impl PartialOrd for UInteger {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl Ord for UInteger {
+    fn cmp(&self, other: &Self) -> Ordering {
+        use UInteger::*;
+        match (self, other) {
+            (U64(m1), U64(m2)) => m1.cmp(m2),
+            (BigUInt(m1), BigUInt(m2)) => m1.cmp(m2),
+            (U64(m1), BigUInt(m2)) => UInteger::cross_representation_cmp(*m1, m2),
+            (BigUInt(m1), U64(m2)) => UInteger::cross_representation_cmp(*m2, m1).reverse(),
+        }
+    }
 }
 
 impl From<UInteger> for Integer {
@@ -133,6 +188,28 @@ pub enum Integer {
     BigInt(BigInt),
 }
 
+impl Integer {
+    /// Compares a [i64] integer with a [BigInt] to see if they are equal. This method never
+    /// allocates. It will always prefer to downgrade a BigUint and compare the two integers as
+    /// u64 values. If this is not possible, then the two numbers cannot be equal anyway.
+    fn cross_representation_eq(m1: i64, m2: &BigInt) -> bool {
+        Integer::cross_representation_cmp(m1, m2) == Ordering::Equal
+    }
+
+    /// Compares a [i64] integer with a [BigInt]. This method never allocates. It will always
+    /// prefer to downgrade a BigUint and compare the two integers as u64 values. If this is
+    /// not possible, then the BigUint is larger than the u64.
+    fn cross_representation_cmp(m1: i64, m2: &BigInt) -> Ordering {
+        // Try to downgrade the BigUint first since that's cheaper than upgrading the u64.
+        if let Some(downgraded_m2) = m2.to_i64() {
+            // If the conversion succeeds, compare the resulting values.
+            return m1.cmp(&downgraded_m2);
+        }
+        // Otherwise, the BigUint must be larger than the u64.
+        Ordering::Less
+    }
+}
+
 impl IntAccess for Integer {
     #[inline]
     fn as_i64(&self) -> Option<i64> {
@@ -154,15 +231,11 @@ impl IntAccess for Integer {
 impl PartialEq for Integer {
     fn eq(&self, other: &Self) -> bool {
         use Integer::*;
-        match self {
-            I64(my_i64) => match other {
-                I64(other_i64) => my_i64 == other_i64,
-                BigInt(other_bi) => Some(*my_i64) == other_bi.to_i64(),
-            },
-            BigInt(my_bi) => match other {
-                I64(other_i64) => my_bi.to_i64() == Some(*other_i64),
-                BigInt(other_bi) => my_bi == other_bi,
-            },
+        match (self, other) {
+            (I64(m1), I64(m2)) => m1 == m2,
+            (BigInt(m1), BigInt(m2)) => m1 == m2,
+            (I64(m1), BigInt(m2)) => Integer::cross_representation_eq(*m1, m2),
+            (BigInt(m1), I64(m2)) => Integer::cross_representation_eq(*m2, m1),
         }
     }
 }
@@ -177,6 +250,24 @@ impl Neg for Integer {
         match self {
             I64(value) => I64(-value),
             BigInt(value) => BigInt(-value),
+        }
+    }
+}
+
+impl PartialOrd for Integer {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl Ord for Integer {
+    fn cmp(&self, other: &Self) -> Ordering {
+        use Integer::*;
+        match (self, other) {
+            (I64(m1), I64(m2)) => m1.cmp(m2),
+            (BigInt(m1), BigInt(m2)) => m1.cmp(m2),
+            (I64(m1), BigInt(m2)) => Integer::cross_representation_cmp(*m1, m2),
+            (BigInt(m1), I64(m2)) => Integer::cross_representation_cmp(*m2, m1).reverse(),
         }
     }
 }
@@ -237,9 +328,13 @@ where
 #[cfg(test)]
 mod integer_tests {
     use num_bigint::BigInt;
+    use num_bigint::BigUint;
     use num_traits::Zero;
     // The 'Big' alias helps distinguish between the enum variant and the wrapped numeric type
     use crate::types::integer::Integer::{self, BigInt as Big, I64};
+    use crate::types::integer::UInteger;
+    use rstest::*;
+    use std::cmp::Ordering;
 
     #[test]
     fn is_zero() {
@@ -267,5 +362,47 @@ mod integer_tests {
             Big(BigInt::from(100)) + Big(BigInt::from(1000)),
             Big(BigInt::from(1100))
         );
+    }
+
+    #[rstest]
+    #[case::i64(Integer::I64(5), Integer::I64(4), Ordering::Greater)]
+    #[case::i64_gt_big_int(Integer::I64(4), Integer::BigInt(BigInt::from(3)), Ordering::Greater)]
+    #[case::i64_lt_big_int(Integer::I64(-3), Integer::BigInt(BigInt::from(5)), Ordering::Less)]
+    #[case::big_int(
+        Integer::BigInt(BigInt::from(1100)),
+        Integer::BigInt(BigInt::from(-1005)),
+        Ordering::Greater
+    )]
+    fn integer_ordering_tests(
+        #[case] this: Integer,
+        #[case] other: Integer,
+        #[case] expected: Ordering,
+    ) {
+        assert_eq!(this.cmp(&other), expected)
+    }
+
+    #[rstest]
+    #[case::u64(UInteger::U64(5), UInteger::U64(4), Ordering::Greater)]
+    #[case::u64_gt_big_uint(
+        UInteger::U64(4),
+        UInteger::BigUInt(BigUint::from(3u64)),
+        Ordering::Greater
+    )]
+    #[case::u64_lt_big_uint(
+        UInteger::U64(3),
+        UInteger::BigUInt(BigUint::from(5u64)),
+        Ordering::Less
+    )]
+    #[case::big_uint(
+        UInteger::BigUInt(BigUint::from(1100u64)),
+        UInteger::BigUInt(BigUint::from(1005u64)),
+        Ordering::Greater
+    )]
+    fn unsigned_integer_ordering_tests(
+        #[case] this: UInteger,
+        #[case] other: UInteger,
+        #[case] expected: Ordering,
+    ) {
+        assert_eq!(this.cmp(&other), expected)
     }
 }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -14,9 +14,10 @@ use std::ops::Div;
 
 #[cfg(feature = "ion_c")]
 use ion_c_sys::timestamp::{IonDateTime, TSOffsetKind, TSPrecision};
+use std::cmp::Ordering;
 
 /// Indicates the most precise time unit that has been specified in the accompanying [Timestamp].
-#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Precision {
     /// Year-level precision (e.g. `2020T`)
     Year,
@@ -44,7 +45,7 @@ impl Default for Precision {
 /// NaiveDateTime component and the Mantissa will indicate the number of digits from that value
 /// that should be used. If the precision is 10 or more digits, the Mantissa will store the value
 /// itself as a Decimal with the correct precision.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
 pub enum Mantissa {
     /// The number of digits of precision in the Timestamp's fractional seconds. For example, a
     /// value of `3` would indicate millisecond precision. A value of `6` would indicate
@@ -66,6 +67,19 @@ impl Mantissa {
             || d1.eq(d2)
             // Coefficient zeros' signs don't have to match for fractional seconds.
             || (d1.coefficient.is_zero() && d2.coefficient.is_zero() && d1.exponent == d2.exponent)
+    }
+
+    fn decimals_compare(d1: &Decimal, d2: &Decimal) -> Ordering {
+        // See the [EmptyMantissa] trait for details about `is_empty()`
+        if d1.is_empty() && d2.is_empty() {
+            return Ordering::Equal;
+        } else if d1.coefficient.is_zero() && d2.coefficient.is_zero() {
+            // Coefficient zeros' signs don't have to be compared for fractional seconds.
+            return d1.exponent.cmp(&d2.exponent);
+        } else {
+            // Exact comparison test
+            d1.cmp(d2)
+        }
     }
 }
 
@@ -227,6 +241,42 @@ impl Timestamp {
             }
             // This Timestamp's precision is too low to have a fractional seconds field.
             None => None,
+        }
+    }
+
+    /// Tests the fractional seconds fields of two timestamps for ordering. This function will
+    /// only be called if both Timestamps have a precision of [Precision::Second].
+    fn fractional_seconds_compare(&self, other: &Timestamp) -> Ordering {
+        use Mantissa::*;
+        match (
+            self.fractional_seconds.as_ref(),
+            other.fractional_seconds.as_ref(),
+        ) {
+            (None, None) => Ordering::Equal,
+            (Some(m), None) => {
+                if m.is_empty() {
+                    Ordering::Equal
+                } else {
+                    Ordering::Greater
+                }
+            }
+            (None, Some(m)) => {
+                if m.is_empty() {
+                    Ordering::Equal
+                } else {
+                    Ordering::Less
+                }
+            }
+            (Some(Digits(d1)), Some(Digits(d2))) => d1.cmp(d2),
+            (Some(Arbitrary(d1)), Some(Arbitrary(d2))) => Mantissa::decimals_compare(d1, d2),
+            (Some(Digits(_d1)), Some(Arbitrary(d2))) => {
+                let d1 = &self.fractional_seconds_as_decimal().unwrap();
+                Mantissa::decimals_compare(d1, d2)
+            }
+            (Some(Arbitrary(d1)), Some(Digits(_d2))) => {
+                let d2 = &other.fractional_seconds_as_decimal().unwrap();
+                Mantissa::decimals_compare(d1, d2)
+            }
         }
     }
 
@@ -462,6 +512,35 @@ impl Timestamp {
     }
 }
 
+impl PartialOrd for Timestamp {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl Ord for Timestamp {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let fractional_seconds_comparison = self.fractional_seconds_compare(other);
+        if fractional_seconds_comparison != Ordering::Equal {
+            return fractional_seconds_comparison;
+        }
+
+        let self_datetime = self.date_time.with_nanosecond(0).unwrap();
+        let other_datetime = other.date_time.with_nanosecond(0).unwrap();
+
+        let self_datetime = self
+            .offset
+            .map(|offset| offset.from_utc_datetime(&self_datetime))
+            .unwrap_or_else(|| FixedOffset::east(0).from_utc_datetime(&self_datetime));
+        let other_datetime = other
+            .offset
+            .map(|offset| offset.from_utc_datetime(&other_datetime))
+            .unwrap_or_else(|| FixedOffset::east(0).from_utc_datetime(&other_datetime));
+
+        self_datetime.cmp(&other_datetime)
+    }
+}
+
 /// Two Timestamps are considered equal (though not necessarily IonEq) if they represent the same
 /// instant in time. Precision is ignored. Offsets do not have to match as long as the instants
 /// being represented match. Examples:
@@ -540,6 +619,8 @@ impl IonEq for Timestamp {
         true
     }
 }
+
+impl Eq for Timestamp {}
 
 /// A Builder object for incrementally configuring and finally instantiating a [Timestamp].
 /// For the time being, this type is not publicly visible. Users are expected to use any of the
@@ -1095,6 +1176,8 @@ mod timestamp_tests {
     use crate::types::decimal::Decimal;
     use crate::types::timestamp::{Mantissa, Precision, Timestamp};
     use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, TimeZone, Timelike};
+    use rstest::*;
+    use std::cmp::Ordering;
     use std::convert::TryInto;
     use std::str::FromStr;
 
@@ -1105,6 +1188,16 @@ mod timestamp_tests {
         let timestamp2 = builder.build_at_offset(5 * 60)?;
         assert_eq!(timestamp1, timestamp2);
         assert!(timestamp1.ion_eq(&timestamp2));
+        Ok(())
+    }
+
+    #[test]
+    fn test_timestamps_with_same_ymd_hms_millis_at_known_offset_are_equal_ordering() -> IonResult<()>
+    {
+        let builder = Timestamp::with_ymd_hms_millis(2021, 2, 5, 16, 43, 51, 192);
+        let timestamp1 = builder.clone().build_at_offset(5 * 60)?;
+        let timestamp2 = builder.build_at_offset(5 * 60)?;
+        assert_eq!(timestamp1 == timestamp2, true);
         Ok(())
     }
 
@@ -1528,6 +1621,20 @@ mod timestamp_tests {
         assert_eq!(1234567, super::first_n_digits_of(7, 123456789));
         assert_eq!(12345678, super::first_n_digits_of(8, 123456789));
         assert_eq!(123456789, super::first_n_digits_of(9, 123456789));
+    }
+
+    #[rstest]
+    #[case::timestamp_with_same_year(Timestamp::with_year(2020).build().unwrap(), Timestamp::with_year(2020).build().unwrap(), Ordering::Equal)]
+    #[case::timestamp_with_different_year(Timestamp::with_year(2020).build().unwrap(), Timestamp::with_year(2021).build().unwrap(), Ordering::Less)]
+    #[case::timestamp_with_different_precision(Timestamp::with_year(2020).with_month(3).build().unwrap(), Timestamp::with_year(2020).build().unwrap(), Ordering::Greater)]
+    #[case::timestamp_with_same_offset(Timestamp::with_ymd_hms(2021, 4, 6, 10, 15, 0).build_at_offset(-5 * 60).unwrap(), Timestamp::with_ymd_hms(2021, 4, 6, 10, 15, 0).build_at_offset(-5 * 60).unwrap(), Ordering::Equal)]
+    #[case::timestamp_with_different_offset(Timestamp::with_ymd_hms(2021, 4, 6, 10, 15, 0).build_at_offset(5 * 60).unwrap(), Timestamp::with_ymd_hms(2021, 4, 6, 10, 15, 0).build_at_offset(-5 * 60).unwrap(), Ordering::Less)]
+    fn timestamp_ordering_tests(
+        #[case] this: Timestamp,
+        #[case] other: Timestamp,
+        #[case] expected: Ordering,
+    ) {
+        assert_eq!(this.partial_cmp(&other), Some(expected))
     }
 
     #[test]


### PR DESCRIPTION
*Related Issue: https://github.com/amzn/ion-schema-rust/issues/89*

*Description of changes:*
This PR works on changes for `PartialOrd` and `Ord` implementation for Ion Types.

*Changes:*
- adds `PartialOrd` and `Ord` implementations for `Integer`, `UInteger` and `Timestamp`
- adds `PartialEq` and `Eq implementations` for `UInteger`
- removes leftover TODO comments

*Test:*
Adds ordering unit tests for `Timestamp`, `UInteger` and `Integer`