### PR TITLE
Updates ion-c to latest commit, fixes clippy warnings

### DIFF
--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -28,7 +28,7 @@ chrono = "0.4"
 
 [build-dependencies]
 cmake = "0.1"
-bindgen = "0.59.2"
+bindgen = "0.60.1"
 
 [dev-dependencies]
 rstest = "0.9"

--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -118,7 +118,7 @@ impl DecodedInt {
     /// Encodes the provided `value` as an Int and writes it to the provided `sink`.
     /// Returns the number of bytes written.
     pub fn write_i64<W: Write>(sink: &mut W, value: i64) -> IonResult<usize> {
-        let magnitude = value.abs() as u64;
+        let magnitude = value.unsigned_abs();
         // Using leading_zeros() to determine how many empty bytes we can ignore.
         // We subtract one from the number of leading bits to leave space for a sign bit
         // and divide by 8 to get the number of bytes.

--- a/src/binary/non_blocking/type_descriptor.rs
+++ b/src/binary/non_blocking/type_descriptor.rs
@@ -120,7 +120,7 @@ impl TypeDescriptor {
 ///
 /// Notably, it stores an `IonType` instead of an `Option<IonType>`, allowing functions that expect
 /// a value header to avoid matching/unwrapping.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Header {
     pub ion_type: IonType,
     // The only time the `ion_type_code` is required is to distinguish between positive

--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -289,7 +289,7 @@ impl<R: IonDataSource> StreamReader for RawBinaryReader<R> {
     #[allow(clippy::should_implement_trait)]
     fn next(&mut self) -> IonResult<RawStreamItem> {
         // Skip the remaining bytes of the current value, if any.
-        let _ = self.skip_current_value()?;
+        self.skip_current_value()?;
 
         if let Some(parent) = self.cursor.parents.last() {
             // If the cursor is nested inside a parent object, don't attempt to read beyond the end of
@@ -370,7 +370,7 @@ impl<R: IonDataSource> StreamReader for RawBinaryReader<R> {
             self.cursor.value.header = header;
         }
 
-        let _ = self.process_header_by_type_code(header)?;
+        self.process_header_by_type_code(header)?;
 
         self.cursor.index_at_depth += 1;
         self.cursor.value.index_at_depth = self.cursor.index_at_depth;
@@ -547,12 +547,10 @@ impl<R: IonDataSource> StreamReader for RawBinaryReader<R> {
     {
         self.map_string_bytes(|buffer| match std::str::from_utf8(buffer) {
             Ok(utf8_text) => Ok(f(utf8_text)),
-            Err(utf8_error) => {
-                return decoding_error(&format!(
-                    "The requested string was not valid UTF-8: {:?}",
-                    utf8_error
-                ))
-            }
+            Err(utf8_error) => decoding_error(&format!(
+                "The requested string was not valid UTF-8: {:?}",
+                utf8_error
+            )),
         })?
     }
 

--- a/src/binary/raw_binary_writer.rs
+++ b/src/binary/raw_binary_writer.rs
@@ -510,7 +510,7 @@ impl<W: Write> RawBinaryWriter<W> {
     }
 }
 
-impl<'a, W: Write> Writer for RawBinaryWriter<W> {
+impl<W: Write> Writer for RawBinaryWriter<W> {
     fn ion_version(&self) -> (u8, u8) {
         (1, 0)
     }

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -132,7 +132,7 @@ impl From<DecodedUInt> for Integer {
 
 /// A buffer for storing a UInt's Big Endian bytes. UInts that can fit in a `u64` will use the
 /// `Stack` storage variant, meaning that no heap allocations are required in the common case.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum UIntBeBytes {
     Stack([u8; mem::size_of::<u64>()]),
     Heap(Vec<u8>),
@@ -143,7 +143,7 @@ pub enum UIntBeBytes {
 /// information.
 ///
 /// [spec]: https://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EncodedUInt {
     be_bytes: UIntBeBytes,
     first_occupied_byte: usize,

--- a/src/binary/var_int.rs
+++ b/src/binary/var_int.rs
@@ -105,7 +105,7 @@ impl VarInt {
         ];
 
         // The absolute value of an i64 can be cast losslessly to a u64.
-        let mut magnitude: u64 = value.abs() as u64;
+        let mut magnitude: u64 = value.unsigned_abs();
 
         // Calculate the number of bytes that the encoded version of our value will occupy.
         // We ignore any leading zeros in the value to minimize the encoded size.

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -337,7 +337,7 @@ impl<'a> ToIonDataSource for &'a [u8] {
     }
 }
 
-impl<'a> ToIonDataSource for Vec<u8> {
+impl ToIonDataSource for Vec<u8> {
     type DataSource = io::Cursor<Self>;
 
     fn to_ion_data_source(self) -> Self::DataSource {

--- a/src/raw_symbol_token.rs
+++ b/src/raw_symbol_token.rs
@@ -4,7 +4,7 @@ use crate::types::SymbolId;
 /// [RawSymbolToken]s do not store import source information for the token encountered. Similarly,
 /// a [RawSymbolToken] cannot store both a symbol ID _and_ text, which means that it is not suitable
 /// for representing a resolved symbol.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RawSymbolToken {
     SymbolId(SymbolId),
     Text(String),

--- a/src/raw_symbol_token_ref.rs
+++ b/src/raw_symbol_token_ref.rs
@@ -3,7 +3,7 @@ use crate::types::SymbolId;
 use crate::Symbol;
 
 /// Like RawSymbolToken, but the Text variant holds a borrowed reference instead of a String.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RawSymbolTokenRef<'a> {
     SymbolId(SymbolId),
     Text(&'a str),
@@ -18,7 +18,7 @@ impl<'a> AsRawSymbolTokenRef for RawSymbolTokenRef<'a> {
     fn as_raw_symbol_token_ref(&self) -> RawSymbolTokenRef {
         match self {
             RawSymbolTokenRef::SymbolId(sid) => RawSymbolTokenRef::SymbolId(*sid),
-            RawSymbolTokenRef::Text(text) => RawSymbolTokenRef::Text(*text),
+            RawSymbolTokenRef::Text(text) => RawSymbolTokenRef::Text(text),
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -376,10 +376,10 @@ impl<R: RawReader> StreamReader for UserReader<R> {
                 if let Some(symbol) = self.symbol_table.symbol_for(symbol_id) {
                     Ok(symbol.clone())
                 } else {
-                    return decoding_error(format!(
+                    decoding_error(format!(
                         "Found symbol ID ${}, which is not defined.",
                         symbol_id
-                    ));
+                    ))
                 }
             }
             RawSymbolToken::Text(text) => Ok(Symbol::owned(text)),

--- a/src/result.rs
+++ b/src/result.rs
@@ -15,7 +15,7 @@ pub type IonCErrorSource = ion_c_sys::result::IonCError;
 pub type IonCErrorSource = ErrorStub;
 
 /// Placeholder Error type for error variants that require conditional compilation.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ErrorStub;
 
 impl Display for ErrorStub {

--- a/src/text/parent_container.rs
+++ b/src/text/parent_container.rs
@@ -1,7 +1,7 @@
 use crate::IonType;
 
 /// Represents a container that the text reader has stepped into.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ParentContainer {
     // The container type the reader has stepped into
     ion_type: IonType,

--- a/src/text/parsers/decimal.rs
+++ b/src/text/parsers/decimal.rs
@@ -106,7 +106,10 @@ fn decimal_from_text_components<'a>(
     let sanitized = exponent_text.trim_start_matches('+').replace('_', "");
     let mut exponent = i64::from_str(&sanitized).expect("parsing exponent as i64 failed");
     // Reduce the exponent by the number of digits that follow the decimal point
-    exponent -= digits_after_dot.chars().filter(|c| c.is_digit(10)).count() as i64;
+    exponent -= digits_after_dot
+        .chars()
+        .filter(|c| c.is_ascii_digit())
+        .count() as i64;
     Ok(("", Decimal::new(coefficient, exponent)))
 }
 

--- a/src/text/parsers/integer.rs
+++ b/src/text/parsers/integer.rs
@@ -58,7 +58,7 @@ fn base_16_integer_digits(input: &str) -> IonParseResult<&str> {
 /// Recognizes 1 or more consecutive base-16 digits.
 // This function's "1" suffix is a style borrowed from `nom`.
 fn take_base_16_digits1(input: &str) -> IonParseResult<&str> {
-    take_while1(|c: char| c.is_digit(16))(input).upgrade()
+    take_while1(|c: char| c.is_ascii_hexdigit())(input).upgrade()
 }
 
 /// Matches a base-2 notation integer (e.g. `0b0`, `0B1`, or `-0b10_10`) and returns the resulting

--- a/src/text/parsers/timestamp.rs
+++ b/src/text/parsers/timestamp.rs
@@ -448,5 +448,5 @@ mod reader_tests {
 /// Matches the next input character if it is a base-10 digit. This wraps [char::is_digit] in the
 /// nom parsing function signature.
 pub(crate) fn digit(input: &str) -> IResult<&str, char> {
-    satisfy(|c| c.is_digit(10))(input)
+    satisfy(|c| c.is_ascii_digit())(input)
 }

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -734,14 +734,13 @@ impl<T: ToIonDataSource> StreamReader for RawTextReader<T> {
         let container_type = self.parents.last().unwrap().ion_type();
         match container_type {
             IonType::List => {
-                let _ = self.parse_expected("list delimiter or end", list_delimiter)?;
+                self.parse_expected("list delimiter or end", list_delimiter)?;
             }
             IonType::SExpression => {
-                let _ =
-                    self.parse_expected("s-expression delimiter or end", s_expression_delimiter)?;
+                self.parse_expected("s-expression delimiter or end", s_expression_delimiter)?;
             }
             IonType::Struct => {
-                let _ = self.parse_expected("struct delimiter or end", struct_delimiter)?;
+                self.parse_expected("struct delimiter or end", struct_delimiter)?;
             }
             scalar => unreachable!("Stepping out of a scalar type: {:?}", scalar),
         };

--- a/src/text/raw_text_writer.rs
+++ b/src/text/raw_text_writer.rs
@@ -406,7 +406,7 @@ impl<W: Write> RawTextWriter<W> {
     }
 }
 
-impl<'a, W: Write> Writer for RawTextWriter<W> {
+impl<W: Write> Writer for RawTextWriter<W> {
     fn ion_version(&self) -> (u8, u8) {
         (1, 0)
     }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -745,7 +745,7 @@ impl TimestampBuilder {
 
         // Otherwise, apply the offset to our (local) NaiveDateTime and make sure the resulting
         // DateTime<FixedOffset> is valid.
-        return match offset.from_local_datetime(&datetime) {
+        match offset.from_local_datetime(&datetime) {
             LocalResult::None => {
                 illegal_operation(
                     format!(
@@ -765,7 +765,7 @@ impl TimestampBuilder {
                     )
                 )
             }
-        };
+        }
     }
 
     /// Attempt to construct a [Timestamp] using the values configured on the [TimestampBuilder].


### PR DESCRIPTION
* Commit 1 updates `ion-c-sys`' dependency on `ion-c` to the latest commit on the `master` branch. 
* Commit 2 addresses several (correct) clippy warnings that seem to have been added in Rust 1.62.

This will be the last change before the version bump to `v0.12.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
