### PR TITLE
Serde feature and support for ion-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ members = [
 
 [features]
 ion_c = ["dep:ion-c-sys"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:serde_with"]
 
 [dependencies]
 base64 = "0.12"
 bigdecimal = "0.2"
 bytes = "0.4"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 delegate = "0.5"
 thiserror = "1.0"
 nom = "7.1.1"
@@ -49,6 +49,7 @@ arrayvec = "0.7"
 ion-c-sys = { path = "./ion-c-sys", version = "0.4", optional = true }
 
 serde = { version = "1.0", features = ["derive"], optional = true }
+serde_with = { verison = "2.0", optional = true }
 [dev-dependencies]
 rstest = "0.9"
 # Used by ion-tests integration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
 
 [features]
 ion_c = ["dep:ion-c-sys"]
+serde = ["dep:serde"]
 
 [dependencies]
 base64 = "0.12"
@@ -47,6 +48,7 @@ arrayvec = "0.7"
 #     so that users can get the correct underlying ion-c-sys version.
 ion-c-sys = { path = "./ion-c-sys", version = "0.4", optional = true }
 
+serde = { version = "1.0", features = ["derive"], optional = true }
 [dev-dependencies]
 rstest = "0.9"
 # Used by ion-tests integration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ mod symbol;
 mod symbol_table;
 mod system_reader;
 mod writer;
+#[cfg(feature = "serde")]
+pub mod serde;
 
 pub use data_source::IonDataSource;
 pub use raw_symbol_token::RawSymbolToken;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde")]
+use serde::{de, ser};
 use std::convert::From;
 use std::fmt::{Debug, Display, Error, Formatter};
 use std::{fmt, io};
@@ -63,6 +65,24 @@ pub enum IonError {
         #[from]
         source: IonCErrorSource,
     },
+}
+
+#[cfg(feature = "serde")]
+impl de::Error for IonError {
+    fn custom<T: Display>(msg: T) -> Self {
+        IonError::DecodingError {
+            description: msg.to_string(),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl ser::Error for IonError {
+    fn custom<T: Display>(msg: T) -> Self {
+        IonError::EncodingError {
+            description: msg.to_string(),
+        }
+    }
 }
 
 impl From<fmt::Error> for IonError {

--- a/src/serde/datetime.rs
+++ b/src/serde/datetime.rs
@@ -1,0 +1,162 @@
+use crate::Timestamp;
+use chrono::{DateTime, FixedOffset, Utc};
+use serde::{self, de, ser, ser::SerializeStruct, Deserialize, Serialize};
+use serde_with::{DeserializeAs, SerializeAs};
+use std::fmt;
+use std::fmt::Write;
+
+impl Serialize for Timestamp {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let datetime: DateTime<FixedOffset> = self.clone().try_into().unwrap();
+        let mut state = serializer.serialize_struct("$datetime", 1)?;
+        state.serialize_field("$datetime", datetime.to_rfc3339().as_str())?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Timestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Timestamp, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct TimestampVisitor;
+
+        impl<'de> de::Visitor<'de> for TimestampVisitor {
+            type Value = Timestamp;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a ION Timestamp")
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Timestamp, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let value = visitor.next_key::<TimestampKey>()?;
+                if value.is_none() {
+                    return Err(de::Error::custom("timestamp key not found"));
+                }
+                let v: TimestampFromString = visitor.next_value()?;
+                Ok(v.value)
+            }
+        }
+
+        static FIELDS: [&str; 1] = ["$datetime"];
+        deserializer.deserialize_struct("$datetime", &FIELDS, TimestampVisitor)
+    }
+}
+
+struct TimestampKey;
+
+impl<'de> de::Deserialize<'de> for TimestampKey {
+    fn deserialize<D>(deserializer: D) -> Result<TimestampKey, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct FieldVisitor;
+
+        impl<'de> de::Visitor<'de> for FieldVisitor {
+            type Value = ();
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a valid datetime field")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<(), E>
+            where
+                E: de::Error,
+            {
+                if s == "$datetime" {
+                    Ok(())
+                } else {
+                    Err(de::Error::custom("expected field with custom name"))
+                }
+            }
+        }
+
+        deserializer.deserialize_identifier(FieldVisitor)?;
+        Ok(TimestampKey)
+    }
+}
+
+pub struct TimestampFromString {
+    pub value: Timestamp,
+}
+
+impl<'de> de::Deserialize<'de> for TimestampFromString {
+    fn deserialize<D>(deserializer: D) -> Result<TimestampFromString, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = TimestampFromString;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("string containing a datetime")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<TimestampFromString, E>
+            where
+                E: de::Error,
+            {
+                let naive: DateTime<FixedOffset> = DateTime::parse_from_rfc3339(s).unwrap();
+                Ok(TimestampFromString {
+                    value: Timestamp::from(naive),
+                })
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
+}
+
+impl SerializeAs<DateTime<Utc>> for Timestamp {
+    fn serialize_as<S>(source: &chrono::DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let dt0: DateTime<FixedOffset> = source.clone().into();
+        let dt1 = Timestamp::from(dt0);
+        dt1.serialize(serializer)
+    }
+}
+
+impl SerializeAs<DateTime<FixedOffset>> for Timestamp {
+    fn serialize_as<S>(
+        source: &chrono::DateTime<FixedOffset>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let dt = Timestamp::from(source.clone());
+        dt.serialize(serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, DateTime<Utc>> for Timestamp {
+    fn deserialize_as<D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let d0 = Timestamp::deserialize(deserializer)?;
+        let d1: DateTime<FixedOffset> = d0.try_into().unwrap();
+        Ok(d1.into())
+    }
+}
+
+impl<'de> DeserializeAs<'de, DateTime<FixedOffset>> for Timestamp {
+    fn deserialize_as<D>(deserializer: D) -> Result<DateTime<FixedOffset>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let d0 = Timestamp::deserialize(deserializer)?;
+        Ok(d0.try_into().unwrap())
+    }
+}

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,0 +1,857 @@
+use crate::{IonError, IonResult, IonType, ReaderBuilder, StreamItem, StreamReader, Symbol};
+use serde::de;
+use serde::de::{DeserializeSeed, EnumAccess, MapAccess, SeqAccess, Visitor};
+use serde::Deserialize;
+
+pub fn from_slice<'a, T>(s: &'a [u8]) -> IonResult<T>
+where
+    T: Deserialize<'a>,
+{
+    let mut deserializer = IonDeserializer {
+        reader: ReaderBuilder::new().build(s)?,
+    };
+    // Need to move twice
+    deserializer.reader.next()?; // Nothing header
+
+    let t = T::deserialize(&mut deserializer)?;
+
+    if deserializer.reader.ion_type().is_none() {
+        Ok(t)
+    } else {
+        Err(IonError::DecodingError {
+            description: "expected eof".to_string(),
+        })
+    }
+}
+
+pub fn from_str<'a, T>(s: &'a str) -> IonResult<T>
+where
+    T: Deserialize<'a>,
+{
+    let mut deserializer = IonDeserializer {
+        reader: ReaderBuilder::new().build(s)?,
+    };
+    deserializer.reader.next()?; // Nothing header
+
+    let t = T::deserialize(&mut deserializer)?;
+
+    if deserializer.reader.ion_type().is_none() {
+        Ok(t)
+    } else {
+        Err(IonError::DecodingError {
+            description: "expected eof".to_string(),
+        })
+    }
+}
+
+pub struct IonDeserializer<R> {
+    reader: R,
+}
+
+impl<'de, 'a, R> serde::de::Deserializer<'de> for &'a mut IonDeserializer<R>
+where
+    R: StreamReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(ion_type) = self.reader.ion_type() {
+            match ion_type {
+                IonType::Null => self.deserialize_unit(visitor),
+                IonType::Blob | IonType::Clob => self.deserialize_bytes(visitor),
+                IonType::String | IonType::Symbol => self.deserialize_string(visitor),
+                IonType::Float => self.deserialize_f64(visitor),
+                IonType::Integer | IonType::Decimal => self.deserialize_i64(visitor),
+                IonType::Boolean => self.deserialize_bool(visitor),
+                IonType::List => self.deserialize_seq(visitor),
+                IonType::Struct => self.deserialize_struct("", &[], visitor),
+                _ => Err(IonError::DecodingError {
+                    description: "unexpected ion type".to_string(),
+                }),
+            }
+        } else {
+            Err(IonError::DecodingError {
+                description: "unexpected end of file".to_string(),
+            })
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_bool(self.reader.read_bool()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_i8(self.reader.read_i64().map(|x| x as i8)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_i16(self.reader.read_i64().map(|x| x as i16)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_i32(self.reader.read_i64().map(|x| x as i32)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_i64(self.reader.read_i64().map(|x| x as i64)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_u8(self.reader.read_i64().map(|x| x as u8)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_u16(self.reader.read_i64().map(|x| x as u16)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_u32(self.reader.read_i64().map(|x| x as u32)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_u64(self.reader.read_i64().map(|x| x as u64)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_f32(self.reader.read_f32()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_f64(self.reader.read_f64()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_char(
+            self.reader
+                .read_string()
+                .map(|x| x.chars().collect::<Vec<char>>()[0])?,
+        );
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_string(self.reader.read_string()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_string(self.reader.read_string()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_bytes(self.reader.read_blob()?.as_slice());
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_byte_buf(self.reader.read_blob()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.reader.is_null() {
+            self.reader.next()?;
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.reader.is_null() {
+            self.reader.next()?;
+            visitor.visit_unit()
+        } else {
+            Err(IonError::DecodingError {
+                description: "expected a null value".to_string(),
+            })
+        }
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_newtype_struct(&mut *self)?;
+        self.reader.next()?;
+        Ok(result)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_seq(&mut *self);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_seq(&mut *self);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_seq(&mut *self);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_map(&mut *self);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_map(&mut *self)?;
+        self.reader.next()?;
+        Ok(result)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(ion_type) = self.reader.ion_type() {
+            match ion_type {
+                IonType::String => visitor.visit_enum(UnitVariantAccess::new(self)),
+                IonType::Struct => {
+                    self.reader.step_in()?;
+                    self.reader.next()?;
+                    let value = visitor.visit_enum(VariantAccess::new(self))?;
+                    self.reader.step_out()?;
+                    self.reader.next()?;
+                    Ok(value)
+                }
+                _ => Err(IonError::DecodingError {
+                    description: "expeted an enumeration".to_string(),
+                }),
+            }
+        } else {
+            Err(IonError::DecodingError {
+                description: "unexpected end of file".to_string(),
+            })
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_string(self.reader.read_string()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+}
+
+impl<'de, 'a, R> SeqAccess<'de> for &'a mut IonDeserializer<R>
+where
+    R: StreamReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.reader.ion_type().is_none() {
+            if self.reader.depth() > 0 {
+                self.reader.step_out()?;
+            }
+            Ok(None)
+        } else {
+            seed.deserialize(&mut **self).map(Some)
+        }
+    }
+}
+
+impl<'de, 'a, R> MapAccess<'de> for &'a mut IonDeserializer<R>
+where
+    R: StreamReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        if self.reader.ion_type().is_none() {
+            self.reader.step_out()?;
+            Ok(None)
+        } else {
+            let key = self.reader.field_name().map(|x| x.to_string())?;
+            let deserializer = MapKeyDeserializer { key };
+            Ok(Some(seed.deserialize(deserializer)?))
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut **self)
+    }
+}
+
+struct VariantAccess<'a, R: 'a> {
+    de: &'a mut IonDeserializer<R>,
+}
+
+impl<'a, R: 'a> VariantAccess<'a, R> {
+    fn new(de: &'a mut IonDeserializer<R>) -> Self {
+        VariantAccess { de }
+    }
+}
+
+impl<'de, 'a, R: 'a> EnumAccess<'de> for VariantAccess<'a, R>
+where
+    R: StreamReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        Ok((seed.deserialize(&mut *self.de)?, self))
+    }
+}
+
+impl<'de, 'a, R: 'a> de::VariantAccess<'de> for VariantAccess<'a, R>
+where
+    R: StreamReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        de::Deserialize::deserialize(self.de)
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.de)
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        de::Deserializer::deserialize_seq(self.de, visitor)
+    }
+
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        de::Deserializer::deserialize_struct(self.de, "", fields, visitor)
+    }
+}
+
+struct UnitVariantAccess<'a, R: 'a> {
+    de: &'a mut IonDeserializer<R>,
+}
+
+impl<'a, R: 'a> UnitVariantAccess<'a, R> {
+    fn new(de: &'a mut IonDeserializer<R>) -> Self {
+        UnitVariantAccess { de }
+    }
+}
+
+impl<'de, 'a, R: 'a> EnumAccess<'de> for UnitVariantAccess<'a, R>
+where
+    R: StreamReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = seed.deserialize(&mut *self.de)?;
+        Ok((variant, self))
+    }
+}
+
+impl<'de, 'a, R: 'a> de::VariantAccess<'de> for UnitVariantAccess<'a, R>
+where
+    R: StreamReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "Unexpected newtype variant".to_string(),
+        })
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "Unexpected tuple variant".to_string(),
+        })
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "Unexpected struct variant".to_string(),
+        })
+    }
+}
+
+struct MapKeyDeserializer {
+    key: String,
+}
+
+impl<'de> de::Deserializer<'de> for MapKeyDeserializer {
+    type Error = IonError;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_str(self.key.as_str())
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_string(self.key)
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_string(self.key)
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(IonError::DecodingError {
+            description: "expected a string value".to_string(),
+        })
+    }
+}

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,3 +1,4 @@
+pub mod datetime;
 pub mod de;
 pub mod ser;
 
@@ -7,23 +8,38 @@ pub use ser::{to_binary, to_pretty, to_string, Serializer};
 #[cfg(test)]
 mod tests {
     use crate::serde::{from_str, to_binary, to_pretty, to_string};
+    use crate::types::timestamp::Precision;
+    use crate::Timestamp;
+    use chrono::{DateTime, FixedOffset, NaiveDateTime, Utc};
     use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
 
     #[test]
     fn test_struct() {
+        #[serde_as]
         #[derive(Serialize, Deserialize)]
         struct Test {
             int: u32,
             float: f64,
             binary: Vec<u8>,
             seq: Vec<String>,
+            date: Timestamp,
+            #[serde_as(as = "crate::Timestamp")]
+            date0: DateTime<Utc>,
+            #[serde_as(as = "crate::Timestamp")]
+            date1: DateTime<FixedOffset>,
         }
-
+        let datetime: DateTime<FixedOffset> = Utc::now().into();
+        let my_date0 = Utc::now();
+        let my_date = Timestamp::from(datetime);
         let test = Test {
             int: 1,
             float: 3.14,
             binary: b"EDO".to_vec(),
             seq: vec!["a".to_string(), "b".to_string()],
+            date: my_date.clone(),
+            date0: my_date0.clone(),
+            date1: datetime.clone(),
         };
         let result = to_string(&test).expect("failed to serialize");
         let presult = to_pretty(&test).expect("failed to serialize pretty style");
@@ -37,5 +53,8 @@ mod tests {
         assert_eq!(back.float, 3.14);
         assert_eq!(back.binary, b"EDO");
         assert_eq!(back.seq.len(), 2);
+        assert_eq!(back.date, my_date.clone());
+        assert_eq!(back.date0, my_date0.clone());
+        assert_eq!(back.date1, datetime.clone());
     }
 }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,0 +1,41 @@
+pub mod de;
+pub mod ser;
+
+pub use de::{from_slice, from_str, IonDeserializer};
+pub use ser::{to_binary, to_pretty, to_string, Serializer};
+
+#[cfg(test)]
+mod tests {
+    use crate::serde::{from_str, to_binary, to_pretty, to_string};
+    use serde::{Deserialize, Serialize};
+
+    #[test]
+    fn test_struct() {
+        #[derive(Serialize, Deserialize)]
+        struct Test {
+            int: u32,
+            float: f64,
+            binary: Vec<u8>,
+            seq: Vec<String>,
+        }
+
+        let test = Test {
+            int: 1,
+            float: 3.14,
+            binary: b"EDO".to_vec(),
+            seq: vec!["a".to_string(), "b".to_string()],
+        };
+        let result = to_string(&test).expect("failed to serialize");
+        let presult = to_pretty(&test).expect("failed to serialize pretty style");
+        let _bresult = to_binary(&test).expect("failed to serialize to binary");
+
+        println!("Result: {}", presult);
+
+        let back: Test = from_str(result.as_str()).expect("failed to deserialize");
+
+        assert_eq!(back.int, 1);
+        assert_eq!(back.float, 3.14);
+        assert_eq!(back.binary, b"EDO");
+        assert_eq!(back.seq.len(), 2);
+    }
+}

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -1,0 +1,589 @@
+use std::io::Cursor;
+
+use crate::{
+    BinaryWriterBuilder, Integer, IonError, IonResult, IonType, TextWriterBuilder, Writer,
+};
+use serde::ser::Impossible;
+use serde::{ser, Serialize};
+
+pub fn to_pretty<T>(value: &T) -> IonResult<String>
+where
+    T: Serialize,
+{
+    let mut cursor = Cursor::new(Vec::new());
+
+    let mut serializer = Serializer {
+        writer: TextWriterBuilder::pretty().build(&mut cursor)?,
+    };
+
+    value.serialize(&mut serializer)?;
+    serializer.writer.flush()?;
+    drop(serializer);
+
+    let bytes = cursor.get_ref().clone();
+
+    match String::from_utf8(bytes) {
+        Ok(data) => Ok(data),
+        Err(e) => Err(IonError::EncodingError {
+            description: e.to_string(),
+        }),
+    }
+}
+
+pub fn to_string<T>(value: &T) -> IonResult<String>
+where
+    T: Serialize,
+{
+    let mut cursor = Cursor::new(Vec::new());
+
+    let mut serializer = Serializer {
+        writer: TextWriterBuilder::new().build(&mut cursor)?,
+    };
+
+    value.serialize(&mut serializer)?;
+    serializer.writer.flush()?;
+    drop(serializer);
+
+    let bytes = cursor.get_ref().clone();
+
+    match String::from_utf8(bytes) {
+        Ok(data) => Ok(data),
+        Err(e) => Err(IonError::EncodingError {
+            description: e.to_string(),
+        }),
+    }
+}
+
+pub fn to_binary<T>(value: &T) -> IonResult<Vec<u8>>
+where
+    T: Serialize,
+{
+    let mut cursor = Cursor::new(Vec::new());
+
+    let mut serializer = Serializer {
+        writer: BinaryWriterBuilder::new().build(&mut cursor)?,
+    };
+
+    value.serialize(&mut serializer)?;
+    serializer.writer.flush()?;
+    drop(serializer);
+
+    Ok(cursor.get_ref().clone())
+}
+
+pub struct Serializer<E> {
+    writer: E,
+}
+
+impl<'a, E> ser::Serializer for &'a mut Serializer<E>
+where
+    E: Writer,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_bool(v)
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_integer(&Integer::from(v))
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_integer(&Integer::from(v))
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_integer(&Integer::from(v))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_integer(&Integer::from(v))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_integer(&Integer::from(v))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_integer(&Integer::from(v))
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_integer(&Integer::from(v))
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_integer(&Integer::from(v))
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_f32(v)
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_f64(v)
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_string(v.to_string())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_string(v.to_string())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_blob(v.to_owned())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_null(IonType::Null)
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.serialize_none()
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        self.writer.step_in(IonType::Struct)?;
+        self.writer.set_field_name(variant);
+        value.serialize(&mut *self)?;
+        self.writer.step_out()
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        self.writer.step_in(IonType::List)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.writer.step_in(IonType::List)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.writer.step_in(IonType::List)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.writer.step_in(IonType::List)?;
+        Ok(self)
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        self.writer.step_in(IonType::Struct)?;
+        Ok(self)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.writer.step_in(IonType::Struct)?;
+        Ok(self)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.writer.step_in(IonType::Struct)?;
+        Ok(self)
+    }
+}
+
+impl<'a, E> ser::SerializeSeq for &'a mut Serializer<E>
+where
+    E: Writer,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeTuple for &'a mut Serializer<E>
+where
+    E: Writer,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeTupleStruct for &'a mut Serializer<E>
+where
+    E: Writer,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeTupleVariant for &'a mut Serializer<E>
+where
+    E: Writer,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeMap for &'a mut Serializer<E>
+where
+    E: Writer,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        // We need to verify that the key is a string type or can be converted
+        // to string
+        let mk_serializer = MapKeySerializer {};
+        let field: String = key.serialize(mk_serializer)?;
+        Ok(self.writer.set_field_name(field))
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeStruct for &'a mut Serializer<E>
+where
+    E: Writer,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.writer.set_field_name(key);
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeStructVariant for &'a mut Serializer<E>
+where
+    E: Writer,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.writer.set_field_name(key);
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+struct MapKeySerializer {}
+
+fn key_must_be_a_string() -> IonError {
+    IonError::EncodingError {
+        description: "ion does not support non-string keys for maps".to_string(),
+    }
+}
+
+impl<'a> ser::Serializer for MapKeySerializer {
+    type Ok = String;
+    type Error = IonError;
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(variant.to_string())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    type SerializeSeq = Impossible<String, IonError>;
+    type SerializeTuple = Impossible<String, IonError>;
+    type SerializeTupleStruct = Impossible<String, IonError>;
+    type SerializeTupleVariant = Impossible<String, IonError>;
+    type SerializeMap = Impossible<String, IonError>;
+    type SerializeStruct = Impossible<String, IonError>;
+    type SerializeStructVariant = Impossible<String, IonError>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implemented serde deserializer and serializer for ion-rs. This serializer can handle basic serialization of types from ion -> rust, rust -> ion. It even includes support for ion Timestamp objects. In addition you can use serde_with to have chrono datetimes work. The Timestamp solution was inspired by how toml-rs handles a similar problem. There is a single test for now provided that passes.

**Note:** The timestamp support currently only supports timestamps with a proper offset. This is due to how it is implemented as passthrough.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
