### PR TITLE
Encoding oversized binary decimals no longer fails quietly

### DIFF
--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -6,19 +6,15 @@ use arrayvec::ArrayVec;
 use bigdecimal::Zero;
 
 use crate::ion_eq::IonEq;
-use crate::{
-    binary::{
-        int::DecodedInt, raw_binary_writer::MAX_INLINE_LENGTH, var_int::VarInt, var_uint::VarUInt,
-    },
-    result::IonResult,
-    types::{
-        coefficient::{Coefficient, Sign},
-        decimal::Decimal,
-        magnitude::Magnitude,
-    },
-};
+use crate::{binary::{
+    int::DecodedInt, raw_binary_writer::MAX_INLINE_LENGTH, var_int::VarInt, var_uint::VarUInt,
+}, IonError, result::IonResult, types::{
+    coefficient::{Coefficient, Sign},
+    decimal::Decimal,
+    magnitude::Magnitude,
+}};
 
-const DECIMAL_BUFFER_SIZE: usize = 16;
+const DECIMAL_BUFFER_SIZE: usize = 32;
 const DECIMAL_POSITIVE_ZERO: Decimal = Decimal {
     coefficient: Coefficient {
         sign: Sign::Positive,
@@ -108,24 +104,37 @@ where
 
     fn encode_decimal_value(&mut self, decimal: &Decimal) -> IonResult<usize> {
         let mut bytes_written: usize = 0;
-        // First encode the decimal. We need to know the encoded length before
-        // we can compute and write out the type descriptor.
+        // First encode the decimal value to a stack-allocated buffer.
+        // We need to know its encoded length before we can write out
+        // the preceding type descriptor.
         let mut encoded: ArrayVec<u8, DECIMAL_BUFFER_SIZE> = ArrayVec::new();
-        encoded.encode_decimal(decimal)?;
+        encoded.encode_decimal(decimal).map_err(|_e| {
+            IonError::EncodingError {
+                description: "found a decimal that was too large for the configured buffer".to_string()
+            }
+        })?;
 
+        // Now that we have the value's encoded bytes, we can encode its header
+        // and write it to the output stream.
         let type_descriptor: u8;
         if encoded.len() <= MAX_INLINE_LENGTH {
+            // The value is small enough to encode its length in the type
+            // descriptor byte.
             type_descriptor = 0x50 | encoded.len() as u8;
             self.write_all(&[type_descriptor])?;
             bytes_written += 1;
         } else {
+            // The value is too large to encode its length in the type descriptor
+            // byte; we'll encode it as a VarUInt that follows the type descriptor
+            // byte instead.
             type_descriptor = 0x5E;
             self.write_all(&[type_descriptor])?;
             bytes_written += 1;
             bytes_written += VarUInt::write_u64(self, encoded.len() as u64)?;
         }
 
-        // Now we can write out the encoded decimal!
+        // Now that we've written the header to the output stream, we can write
+        // the value's encoded bytes.
         self.write_all(&encoded[..])?;
         bytes_written += encoded.len();
 
@@ -135,8 +144,11 @@ where
 
 #[cfg(test)]
 mod binary_decimal_tests {
-    use super::*;
+    use num_bigint::BigUint;
     use rstest::*;
+    use std::str::FromStr;
+
+    use super::*;
 
     /// This test ensures that we implement [PartialEq] and [IonEq] correctly for the special
     /// decimal value 0d0.
@@ -162,5 +174,20 @@ mod binary_decimal_tests {
         assert_eq!(buf.len(), expected);
         assert_eq!(written, expected);
         Ok(())
+    }
+
+    #[test]
+    fn oversized_decimal() {
+        let mut buf = vec![];
+        // Even though our output stream is a growable Vec, the encoder uses a
+        // fixed-size, stack-allocated buffer to encode the body of the decimal.
+        // If it's asked to encode a decimal that won't fit (>32 bytes), it should
+        // return an error.
+        let precise_pi = Decimal::new(
+            BigUint::from_str("31415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").unwrap(),
+            -99
+        );
+        let result = buf.encode_decimal_value(&precise_pi);
+        assert!(result.is_err());
     }
 }

--- a/src/binary/raw_binary_writer.rs
+++ b/src/binary/raw_binary_writer.rs
@@ -667,7 +667,7 @@ impl<W: Write> Writer for RawBinaryWriter<W> {
     /// Writes an Ion decimal with the specified value.
     fn write_decimal(&mut self, value: &Decimal) -> IonResult<()> {
         self.write_scalar(|enc_buffer| {
-            let _ = enc_buffer.encode_decimal_value(value);
+            let _ = enc_buffer.encode_decimal_value(value)?;
             Ok(())
         })
     }


### PR DESCRIPTION
The binary decimal encoder uses a fixed-size, stack-allocated buffer
to encode decimal values. Prior to this commit, encoding a decimal
whose encoded representation was too large for the buffer would
fail silently, emitting no bytes but also not raising an error.
This had the potential to corrupt the output.

This PR makes the following changes:
1. Increases the size of the decimal encoding buffer from 16 bytes
   to 32.
2. Maps the IOError representing the buffer overrun to an
   EncodingError.
3. Surfaces any errors that occur to the application instead of
   quietly dropping them.

Fixes #404.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
