### PR TITLE
The IonValueFormatter now uses the correct s-exp delimiter

### DIFF
--- a/src/text/text_formatter.rs
+++ b/src/text/text_formatter.rs
@@ -503,7 +503,7 @@ impl<'a, W: std::fmt::Write> IonValueFormatter<'a, W> {
             let sexp_value = peekable_itr.next().unwrap();
             write!(self.output, "{}", sexp_value)?;
             if peekable_itr.peek() != None {
-                write!(self.output, ", ")?;
+                write!(self.output, " ")?;
             }
         }
         write!(self.output, " )")?;
@@ -650,7 +650,7 @@ mod formatter_test {
                     vec!["hello".to_owned().into(), 5.into(), true.into()].into_iter(),
                 ))
             },
-            "( \"hello\", 5, true )",
+            "( \"hello\" 5 true )",
         );
         Ok(())
     }


### PR DESCRIPTION
Previously, the IonValueFormatter (which is used in the `Display`
impl for the `Element` API) would use commas to delimit child
values in an s-expression. Commas are the delimiter for list values
and struct fields, but s-expressions simply use whitespace.

Following this change, s-expression values are delimited with a
single space.

Fixes #403.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
