### PR TITLE
Use parse_timestamp instead of chrono to parse Timestamp

### DIFF
--- a/src/binary/timestamp.rs
+++ b/src/binary/timestamp.rs
@@ -162,7 +162,9 @@ mod binary_timestamp_tests {
                 assert_eq!(buf.len(), expected);
                 assert_eq!(written, expected);
             }
-            _ => panic!("reader.next() should only return reader::StreamItem::Value(IonType::Timestamp)"),
+            _ => panic!(
+                "reader.next() should only return reader::StreamItem::Value(IonType::Timestamp)"
+            ),
         }
         Ok(())
     }

--- a/src/binary/timestamp.rs
+++ b/src/binary/timestamp.rs
@@ -134,6 +134,7 @@ where
 #[cfg(test)]
 mod binary_timestamp_tests {
     use super::*;
+    use crate::reader;
     use crate::IonType;
     use crate::reader;
     use crate::ReaderBuilder;
@@ -161,8 +162,8 @@ mod binary_timestamp_tests {
                 let written = buf.encode_timestamp_value(&timestamp)?;
                 assert_eq!(buf.len(), expected);
                 assert_eq!(written, expected);
-            },
-            _ => panic!("parse_timestamp() should only return TextValue::Timestamp"),
+            }
+            _ => panic!("reader.next() should only return reader::StreamItem::Value(IonType::Timestamp)"),
         }
         Ok(())
     }

--- a/src/binary/timestamp.rs
+++ b/src/binary/timestamp.rs
@@ -136,7 +136,6 @@ mod binary_timestamp_tests {
     use super::*;
     use crate::reader;
     use crate::IonType;
-    use crate::reader;
     use crate::ReaderBuilder;
     use crate::StreamReader;
     use rstest::*;

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,6 +1,6 @@
 mod parent_container;
 pub(crate) mod parse_result;
-pub(in crate::text) mod parsers;
+pub(crate) mod parsers;
 pub mod raw_text_reader;
 pub mod raw_text_writer;
 mod text_buffer;

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,6 +1,6 @@
 mod parent_container;
 pub(crate) mod parse_result;
-pub(crate) mod parsers;
+pub(in crate::text) mod parsers;
 pub mod raw_text_reader;
 pub mod raw_text_writer;
 mod text_buffer;


### PR DESCRIPTION
*Issue #, if available:*
#293 

*Description of changes:*
Use parse_timestamp instead of chrono to parse Timestamp. The expected bytes written were checked against using `ion dump`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
