### PR TITLE
adds changes for `Ord` implementation of `Timestamp`

### DIFF
--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -304,7 +304,7 @@ impl Timestamp {
         }
     }
 
-    /// Tests the fractional seconds fields of two timestamps for Ion equality. This function will
+    /// Tests the fractional seconds fields of two timestamps for equality. This function will
     /// only be called if both Timestamps have a precision of [Precision::Second].
     fn fractional_seconds_equal(&self, other: &Timestamp) -> bool {
         use Mantissa::*;
@@ -582,19 +582,6 @@ impl Ord for Timestamp {
             _ => date_time_comparison,
         }
     }
-}
-
-/// Represents the comparison type that will be used by Ord implementation of [Timestamp].
-enum ComparisonType {
-    // Ion comparison is stricter and it will only considers two timestamps to be equal,
-    // if they are the same instant with same precision and offset
-    // following are not equal as per Ion comparison:
-    // 2000T                -> January 1st 2000, year precision, unknown local offset
-    // 2000-01-01T00:00:00Z -> January 1st 2000, second precision, UTC
-    Ion,
-    // Non strict comparison which considers two timestamps to be equal
-    // if they are same instant of time and ignores the precision and offset
-    NonStrict,
 }
 
 /// Two Timestamps are considered equal (though not necessarily IonEq) if they represent the same

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -89,10 +89,10 @@ trait EmptyMantissa {
     /// `Mantissa::Arbitrary(Decimal::new(0, 0))`.
     fn is_empty(&self) -> bool;
 
-    /// Returns true if the Mantissa's value is equivalent to not having specified a
-    /// sub-second precision at all and it ignores the exponent value for a zero coefficient.
-    /// For example, `Mantissa::Digits(0)` or `Mantissa::Arbitrary(Decimal::new(0, 0))`.
-    fn is_empty_ignore_exponent(&self) -> bool;
+    /// Returns true if the Mantissa's value is equivalent to a zero value
+    /// For example, `Mantissa::Digits(0)` or `Mantissa::Arbitrary(Decimal::new(0, x))`.
+    /// For Decimal, it ignores the exponent value for a zero coefficient.
+    fn is_zero(&self) -> bool;
 }
 
 impl EmptyMantissa for Decimal {
@@ -100,7 +100,7 @@ impl EmptyMantissa for Decimal {
         self.coefficient.is_zero() && self.exponent == 0
     }
 
-    fn is_empty_ignore_exponent(&self) -> bool {
+    fn is_zero(&self) -> bool {
         // if the coefficient is zero then ignore the exponent value
         self.coefficient.is_zero()
     }
@@ -117,12 +117,12 @@ impl EmptyMantissa for Mantissa {
         }
     }
 
-    fn is_empty_ignore_exponent(&self) -> bool {
+    fn is_zero(&self) -> bool {
         match self {
             // Look at zero digits of the DateTime's nanoseconds
             Mantissa::Digits(0) => true,
             // Or a Decimal with a coefficient of zero (any sign).
-            Mantissa::Arbitrary(d) => d.is_empty_ignore_exponent(),
+            Mantissa::Arbitrary(d) => d.is_zero(),
             _ => false,
         }
     }
@@ -274,14 +274,14 @@ impl Timestamp {
         ) {
             (None, None) => Ordering::Equal,
             (Some(m), None) => {
-                if m.is_empty_ignore_exponent() {
+                if m.is_zero() {
                     Ordering::Equal
                 } else {
                     Ordering::Greater
                 }
             }
             (None, Some(m)) => {
-                if m.is_empty_ignore_exponent() {
+                if m.is_zero() {
                     Ordering::Equal
                 } else {
                     Ordering::Less


### PR DESCRIPTION
*Description of changes:*
This PR works on changes for `Ord` implementation of `Timestamp` to consider both datetime and fractional seconds for comparison.

* considers datetime comparison result as well as fractional seconds
comparison result for `Ord`
* changes `fractional_seconds_equal()` to convert `Option<&Mantissa>` to `&Mantissa`, where default value `Mantissa::Digits(0)` is used for `None`. This guarantees a `fractional_seconds`  value to be present at all times and makes it easier to compare those fractional seconds.

*Test:*
* adds test case for fractional second and year precision timestamps
ordering