### PR TITLE
bumps `ion-rs` version to `v0.13.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Remove this when we're ready to include Jetbrains IDE settings
-/.idea/
+**/.idea/
 
 # Created by https://www.toptal.com/developers/gitignore/api/c,c++,rust,cmake,clion,visualstudiocode,valgrind
 # Edit at https://www.toptal.com/developers/gitignore?templates=c,c++,rust,cmake,clion,visualstudiocode,valgrind

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 
 [workspace]

--- a/ion-c-sys/Cargo.toml
+++ b/ion-c-sys/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 
 [dependencies]

--- a/ion-c-sys/src/result.rs
+++ b/ion-c-sys/src/result.rs
@@ -34,7 +34,7 @@ pub enum Position {
 }
 
 // see above
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct LineColumn(pub i32, pub i32);
 
 impl Position {

--- a/ion-c-sys/src/result.rs
+++ b/ion-c-sys/src/result.rs
@@ -13,7 +13,7 @@ use std::num::TryFromIntError;
 ///
 /// `position` is populated when errors come from readers. See [`Position`] for
 /// more information.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct IonCError {
     pub code: i32,
     pub message: &'static str,
@@ -26,7 +26,7 @@ pub struct IonCError {
 ///
 /// If a position is set, `bytes` will always be hydrated while `lines` and
 /// `offset` will only be populated for text readers.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Position {
     Unknown,
     Offset(i64),

--- a/ion-c-sys/src/timestamp.rs
+++ b/ion-c-sys/src/timestamp.rs
@@ -91,7 +91,7 @@ pub enum TSOffsetKind {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IonDateTime {
     date_time: DateTime<FixedOffset>,
     precision: TSPrecision,

--- a/ion-c-sys/src/timestamp.rs
+++ b/ion-c-sys/src/timestamp.rs
@@ -60,7 +60,7 @@ pub enum TSPrecision {
 /// but in the case of a timestamp with an *unknown UTC offset*, this will be `Unknown`,
 /// and the effective `FixedOffset` will be UTC+00:00--this allows an application to
 /// preserve the difference between UTC+00:00 (zulu time) and UTC-00:00 which is the unknown offset.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TSOffsetKind {
     KnownOffset,
     UnknownOffset,

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.0.9"
 edition = "2021"
 
 [dependencies]
-ion-rs = { path = "../", version = "0.12", features = ["ion_c"]}
+ion-rs = { path = "../", version = "0.13", features = ["ion_c"]}
 ion-c-sys = { path = "../ion-c-sys", version = "0.4" }
 num-bigint = "0.3"
 digest = "0.9"


### PR DESCRIPTION
*Description of changes:*
This Pr adds version bump for `ion-rs` to `v0.13.0` and also adds `.gitignore` change.