### PR TITLE
Updates symbol logic in the Element APIs

### DIFF
--- a/src/binary/non_blocking/raw_binary_reader.rs
+++ b/src/binary/non_blocking/raw_binary_reader.rs
@@ -1273,7 +1273,7 @@ impl<'a, A: AsRef<[u8]>> TxReader<'a, A> {
     /// * Out of tx_buffer bytes
     fn is_eof(&self) -> bool {
         // We're at the top level
-        self.parent == None
+        self.parent.is_none()
             && self.encoded_value.annotations_header_length == 0
             && self.tx_buffer.is_empty()
     }

--- a/src/raw_symbol_token_ref.rs
+++ b/src/raw_symbol_token_ref.rs
@@ -43,7 +43,10 @@ impl AsRawSymbolTokenRef for &str {
 
 impl AsRawSymbolTokenRef for Symbol {
     fn as_raw_symbol_token_ref(&self) -> RawSymbolTokenRef {
-        RawSymbolTokenRef::Text(self.as_ref())
+        match self.text() {
+            Some(text) => RawSymbolTokenRef::Text(text),
+            None => RawSymbolTokenRef::SymbolId(0),
+        }
     }
 }
 

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -87,6 +87,12 @@ impl Symbol {
     }
 }
 
+impl From<&str> for Symbol {
+    fn from(text: &str) -> Self {
+        Symbol::owned(text)
+    }
+}
+
 impl Display for Symbol {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.text() {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,39 +1,40 @@
+use crate::result::decoding_error;
+use crate::IonResult;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::ops::Deref;
 use std::rc::Rc;
 
 /// Stores or points to the text of a given [Symbol].
-#[derive(Debug, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 enum SymbolText {
     // This Symbol refers to a string in the symbol table
     Shared(Rc<str>),
     // This Symbol owns its own text
     Owned(String),
+    // This Symbol is equivalent to SID zero (`$0`)
+    Unknown,
 }
 
-impl AsRef<str> for SymbolText {
-    fn as_ref(&self) -> &str {
-        match self {
-            SymbolText::Owned(ref text) => text.as_str(),
-            SymbolText::Shared(ref rc) => rc.as_ref(),
-        }
-    }
-}
-
-impl<A: AsRef<str>> PartialEq<A> for SymbolText {
-    fn eq(&self, other: &A) -> bool {
-        // Compare the Symbols' text, not their ownership models
-        self.as_ref() == other.as_ref()
+impl SymbolText {
+    fn text(&self) -> Option<&str> {
+        let text = match self {
+            SymbolText::Shared(s) => s.as_ref(),
+            SymbolText::Owned(s) => s.as_str(),
+            SymbolText::Unknown => return None,
+        };
+        Some(text)
     }
 }
 
 impl Hash for SymbolText {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // Hash the Symbol's text, ignore where/how it's stored.
-        self.as_ref().hash(state)
+        match self {
+            SymbolText::Shared(text) => text.hash(state),
+            SymbolText::Owned(text) => text.hash(state),
+            SymbolText::Unknown => 0.hash(state),
+        }
     }
 }
 
@@ -42,21 +43,23 @@ impl Clone for SymbolText {
         match self {
             SymbolText::Owned(text) => SymbolText::Owned(text.to_owned()),
             SymbolText::Shared(text) => SymbolText::Shared(Rc::clone(text)),
+            SymbolText::Unknown => SymbolText::Unknown,
         }
     }
 }
 
-/// The text of a fully resolved field name, annotation, or symbol value. The text stored in this
-/// Symbol may be either a `String` or a shared reference to text in a symbol table.
+/// The text of a fully resolved field name, annotation, or symbol value. If the symbol has known
+/// text (that is: the symbol is not `$0`), it will be stored as either a `String` or a shared
+/// reference to text in a symbol table.
 #[derive(Debug, Hash, Clone, Eq)]
 pub struct Symbol {
     text: SymbolText,
 }
 
 impl Symbol {
-    pub fn owned(text: String) -> Symbol {
+    pub fn owned<I: Into<String>>(text: I) -> Symbol {
         Symbol {
-            text: SymbolText::Owned(text),
+            text: SymbolText::Owned(text.into()),
         }
     }
 
@@ -65,62 +68,93 @@ impl Symbol {
             text: SymbolText::Shared(text),
         }
     }
+
+    pub fn unknown_text() -> Symbol {
+        Symbol {
+            text: SymbolText::Unknown,
+        }
+    }
+
+    pub fn text(&self) -> Option<&str> {
+        self.text.text()
+    }
+
+    pub fn text_or_error(&self) -> IonResult<&str> {
+        match self.text() {
+            Some(text) => Ok(text),
+            None => decoding_error("symbol has unknown text"),
+        }
+    }
 }
 
 impl Display for Symbol {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.text.as_ref())
+        match self.text() {
+            None => write!(f, "$0"),
+            Some(text) => write!(f, "'{}'", text),
+        }
     }
 }
 
 impl<A: AsRef<str>> PartialEq<A> for Symbol {
     fn eq(&self, other: &A) -> bool {
-        self.text.as_ref() == other.as_ref()
+        self.text()
+            // If the symbol has known text, compare it to the provide text
+            .map(|t| t == other.as_ref())
+            // If there's no text, it's definitely not equivalent to the provided text
+            .unwrap_or(false)
     }
 }
 
 impl PartialEq<Symbol> for String {
     fn eq(&self, other: &Symbol) -> bool {
-        self.as_str() == other.as_ref()
+        other.text().map(|t| t == self.as_str()).unwrap_or(false)
     }
 }
 
 impl PartialEq<Symbol> for &str {
     fn eq(&self, other: &Symbol) -> bool {
-        self == &other.as_ref()
+        other.text().map(|t| &t == self).unwrap_or(false)
     }
 }
 
-impl AsRef<str> for Symbol {
-    fn as_ref(&self) -> &str {
-        self.text.as_ref()
-    }
-}
-
-impl Deref for Symbol {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        self.text.as_ref()
-    }
-}
-
-// Allows a HashMap<Symbol, _> to do lookups with a &str instead of a &Symbol
+// Note that this method panics if the Symbol has unknown text! This is unfortunate but is required
+// in order to allow a HashMap<Symbol, _> to do lookups with a &str instead of a &Symbol
 impl Borrow<str> for Symbol {
     fn borrow(&self) -> &str {
-        self.as_ref()
+        self.text()
+            .expect("cannot borrow a &str from a Symbol with unknown text")
     }
 }
 
 impl<A: AsRef<str>> PartialOrd<A> for Symbol {
     fn partial_cmp(&self, other: &A) -> Option<Ordering> {
-        self.text.as_ref().partial_cmp(other.as_ref())
+        self.text().map(|t| t.cmp(other.as_ref()))
+    }
+}
+
+impl PartialEq<Self> for Symbol {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl PartialOrd<Self> for Symbol {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Symbol {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.text.as_ref().cmp(other.as_ref())
+        match (self.text(), other.text()) {
+            // If both Symbols have known text, delegate the comparison to their text.
+            (Some(s1), Some(s2)) => s1.cmp(s2),
+            // Otherwise, $0 (unknown text) is treated as 'less than' known text
+            (Some(_), None) => Ordering::Greater,
+            (None, Some(_)) => Ordering::Less,
+            (None, None) => Ordering::Equal,
+        }
     }
 }
 
@@ -131,10 +165,10 @@ mod symbol_tests {
     #[test]
     fn ordering_and_eq() {
         let mut symbols = vec![
-            Symbol::owned("foo".to_owned()),
+            Symbol::owned("foo"),
             Symbol::shared(Rc::from("bar")),
             Symbol::shared(Rc::from("baz")),
-            Symbol::owned("quux".to_owned()),
+            Symbol::owned("quux"),
         ];
         // Sort the list to demonstrate that our Ord implementation works.
         symbols.as_mut_slice().sort();
@@ -142,10 +176,10 @@ mod symbol_tests {
         // We can compare the sorted version of the vec above to this one and it will
         // be considered equal.
         let expected = vec![
-            Symbol::owned("bar".to_owned()),
-            Symbol::owned("baz".to_owned()),
-            Symbol::owned("foo".to_owned()),
-            Symbol::owned("quux".to_owned()),
+            Symbol::owned("bar"),
+            Symbol::owned("baz"),
+            Symbol::owned("foo"),
+            Symbol::owned("quux"),
         ];
         assert_eq!(symbols, expected)
     }

--- a/src/text/raw_text_writer.rs
+++ b/src/text/raw_text_writer.rs
@@ -714,7 +714,7 @@ impl<W: Write> IonWriter for RawTextWriter<W> {
         if popped_encoding_level.child_count > 0 {
             // If this isn't an empty container, put the closing delimiter on the next line
             // with proper indentation.
-            if self.space_between_values.contains(&['\n', '\r']) {
+            if self.space_between_values.contains(['\n', '\r']) {
                 writeln!(&mut self.output)?;
                 for _ in 0..self.depth() {
                     write!(&mut self.output, "{}", self.indentation)?;

--- a/src/text/text_formatter.rs
+++ b/src/text/text_formatter.rs
@@ -1,8 +1,8 @@
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
 use crate::types::timestamp::Precision;
-use crate::value::owned::{Sequence, Struct, SymbolToken};
-use crate::value::{IonSequence, IonStruct, IonSymbolToken};
-use crate::{Decimal, Integer, IonResult, IonType, RawSymbolTokenRef, Timestamp};
+use crate::value::owned::{Sequence, Struct};
+use crate::value::{IonSequence, IonStruct};
+use crate::{Decimal, Integer, IonResult, IonType, RawSymbolTokenRef, Symbol, Timestamp};
 use chrono::{DateTime, Datelike, FixedOffset, NaiveDateTime, TimeZone, Timelike};
 use std::convert::TryInto;
 
@@ -287,9 +287,9 @@ impl<'a, W: std::fmt::Write> IonValueFormatter<'a, W> {
         Ok(())
     }
 
-    pub(crate) fn format_annotations(&mut self, annotations: &Vec<SymbolToken>) -> IonResult<()> {
+    pub(crate) fn format_annotations(&mut self, annotations: &Vec<Symbol>) -> IonResult<()> {
         for annotation in annotations {
-            self.format_symbol(annotation.text().unwrap())?;
+            self.format_symbol(annotation)?;
             write!(self.output, "::")?;
         }
         Ok(())

--- a/src/text/text_formatter.rs
+++ b/src/text/text_formatter.rs
@@ -496,10 +496,10 @@ impl<'a, W: std::fmt::Write> IonValueFormatter<'a, W> {
     pub(crate) fn format_sexp(&mut self, value: &Sequence) -> IonResult<()> {
         write!(self.output, "( ")?;
         let mut peekable_itr = value.iter().peekable();
-        while peekable_itr.peek() != None {
+        while peekable_itr.peek().is_some() {
             let sexp_value = peekable_itr.next().unwrap();
             write!(self.output, "{}", sexp_value)?;
-            if peekable_itr.peek() != None {
+            if peekable_itr.peek().is_some() {
                 write!(self.output, " ")?;
             }
         }
@@ -510,10 +510,10 @@ impl<'a, W: std::fmt::Write> IonValueFormatter<'a, W> {
     pub(crate) fn format_list(&mut self, value: &Sequence) -> IonResult<()> {
         write!(self.output, "[ ")?;
         let mut peekable_itr = value.iter().peekable();
-        while peekable_itr.peek() != None {
+        while peekable_itr.peek().is_some() {
             let list_value = peekable_itr.next().unwrap();
             write!(self.output, "{}", list_value)?;
-            if peekable_itr.peek() != None {
+            if peekable_itr.peek().is_some() {
                 write!(self.output, ", ")?;
             }
         }

--- a/src/value/native_writer.rs
+++ b/src/value/native_writer.rs
@@ -40,7 +40,7 @@ impl<W: IonWriter> NativeElementWriter<W> {
         let element_annotations = element.annotations().map(|token| {
             if let Some(text) = token.text() {
                 RawSymbolTokenRef::Text(text)
-            } else if let Some(sid) = token.local_sid() {
+            } else if let Some(sid) = token.symbol_id() {
                 RawSymbolTokenRef::SymbolId(sid)
             } else {
                 unreachable!("cannot write annotation with neither text nor symbol ID")

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -26,7 +26,10 @@ impl IonSymbolToken for Symbol {
     }
 
     fn symbol_id(&self) -> Option<SymbolId> {
-        self.text().is_none().then_some(0)
+        match self.text() {
+            Some(_) => None,
+            None => Some(0),
+        }
     }
 
     fn with_text(self, text: &'static str) -> Self {

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -26,7 +26,7 @@ impl IonSymbolToken for Symbol {
     }
 
     fn symbol_id(&self) -> Option<SymbolId> {
-        self.text().is_none().then(|| Some(0)).unwrap_or(None)
+        self.text().is_none().then_some(0)
     }
 
     fn with_text(self, text: &'static str) -> Self {

--- a/src/value/reader.rs
+++ b/src/value/reader.rs
@@ -82,7 +82,7 @@ mod reader_tests {
     use crate::value::owned::Value::*;
     use crate::value::owned::*;
     use crate::value::IonElement;
-    use crate::IonType;
+    use crate::{IonType, Symbol};
     use bigdecimal::BigDecimal;
     use num_bigint::BigInt;
     use rstest::*;
@@ -266,15 +266,15 @@ mod reader_tests {
         "#,
         vec![
             vec![
-                (text_token("string_field"), String("oink!".into())),
-                (text_token("string_field"), String("moo!".into())),
-                (text_token("bool_field"), Boolean(true)),
+                (Symbol::owned("string_field"), String("oink!".into())),
+                (Symbol::owned("string_field"), String("moo!".into())),
+                (Symbol::owned("bool_field"), Boolean(true)),
             ]
         ].into_iter()
-            .map(|fields: Vec<(SymbolToken, Value)>| {
+            .map(|fields: Vec<(Symbol, Value)>| {
                 Struct(
                     fields.into_iter().map(|(tok, val)| {
-                        (tok, Element::new(vec![text_token("a")], val))
+                        (tok, Element::new(vec![Symbol::owned("a")], val))
                     }).collect()).into()
             })
             .collect(),

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -6,7 +6,7 @@ use ion_rs::value::native_writer::NativeElementWriter;
 use ion_rs::value::owned::Element;
 use ion_rs::value::reader::ElementReader;
 use ion_rs::value::writer::{ElementWriter, Format, TextKind};
-use ion_rs::value::{IonElement, IonSequence, IonSymbolToken};
+use ion_rs::value::{IonElement, IonSequence};
 use ion_rs::{BinaryWriterBuilder, TextWriterBuilder};
 
 use std::fs::read;


### PR DESCRIPTION
This patch:

* Adds an `Unknown` variant to the inner representation of 
  `Symbol`, allowing it to represent `$0`.
* Removes the `IonImportSource` trait and its implementations.
  This type enabled readers to compare symbols in the event that
  the corresponding shared symbol table could not be found, a niche
  use case. Removing `IonImportSource` eliminates a surprising number
  of allocations.
* Updates the `IonSymbolToken` trait. Now that import source is not
  being tracked/considered, implementations must update their
  behavior for equivalence testing.
* Replaces usages of the `owned::SymbolToken` type with the `Symbol`
  type that is used in all of the `IonReader` APIs. The `Symbol` type
  takes advantage of `String` interning via the symbol table, which
  was still a TODO for `owned::SymbolToken`. This eliminates some
  conversion logic and allocations that were happening for each
  annotation, struct field name, and symbol value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
