### PR TITLE
changes `Struct` and `StructRef` implementations to consider field order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ num-bigint = "0.3"
 num-integer = "0.1.44"
 num-traits = "0.2"
 arrayvec = "0.7"
+hashlink = "0.8.1"
 
 [dev-dependencies]
 rstest = "0.9"

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -14,8 +14,8 @@ use crate::types::timestamp::Timestamp;
 use crate::types::SymbolId;
 use crate::value::Builder;
 use crate::IonType;
+use hashlink::LinkedHashMap;
 use num_bigint::BigInt;
-use std::collections::HashMap;
 use std::iter::FromIterator;
 
 /// A borrowed implementation of [`SymbolToken`].
@@ -215,7 +215,7 @@ impl<'val> Eq for SequenceRef<'val> {}
 /// A borrowed implementation of [`Struct`]
 #[derive(Debug, Clone)]
 pub struct StructRef<'val> {
-    text_fields: HashMap<String, Vec<(SymbolTokenRef<'val>, ElementRef<'val>)>>,
+    text_fields: LinkedHashMap<String, Vec<(SymbolTokenRef<'val>, ElementRef<'val>)>>,
     no_text_fields: Vec<(SymbolTokenRef<'val>, ElementRef<'val>)>,
 }
 
@@ -248,7 +248,8 @@ where
 {
     /// Returns a borrowed struct from the given iterator of field names/values.
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
-        let mut text_fields: HashMap<String, Vec<(SymbolTokenRef, ElementRef)>> = HashMap::new();
+        let mut text_fields: LinkedHashMap<String, Vec<(SymbolTokenRef, ElementRef)>> =
+            LinkedHashMap::new();
         let mut no_text_fields: Vec<(SymbolTokenRef, ElementRef)> = Vec::new();
 
         for (k, v) in iter {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1298,16 +1298,32 @@ mod generic_value_tests {
     {
         Case {
             elem: E::Builder::new_struct(
-                vec![(
-                    E::SymbolToken::text_token("greetings"),
-                    E::Builder::new_string("hello"),
-                )]
+                vec![
+                    (
+                        E::SymbolToken::text_token("greetings"),
+                        E::Builder::new_string("hello"),
+                    ),
+                    (
+                        E::SymbolToken::text_token("name"),
+                        E::Builder::new_string("ion"),
+                    ),
+                ]
                 .into_iter(),
             ),
             ion_type: IonType::Struct,
             ops: vec![AsStruct],
             op_assert: Box::new(|e: &E| {
                 let actual = e.as_struct().unwrap();
+
+                // verify that the field order is maintained when creating Struct
+                assert_eq!(
+                    actual.iter().next(),
+                    Some((
+                        &E::SymbolToken::text_token("greetings"),
+                        &E::Builder::new_string("hello"),
+                    ))
+                );
+
                 assert_eq!(
                     actual.get("greetings"),
                     Some(&E::Builder::new_string("hello"))

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -14,8 +14,8 @@ use crate::types::timestamp::Timestamp;
 use crate::types::SymbolId;
 use crate::value::Builder;
 use crate::{IonType, Symbol};
+use hashlink::LinkedHashMap;
 use num_bigint::BigInt;
-use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::iter::FromIterator;
 use std::rc::Rc;
@@ -188,7 +188,7 @@ impl Eq for Sequence {}
 /// An owned implementation of [`Struct`]
 #[derive(Debug, Clone)]
 pub struct Struct {
-    text_fields: HashMap<Rc<str>, Vec<(Symbol, Element)>>,
+    text_fields: LinkedHashMap<Rc<str>, Vec<(Symbol, Element)>>,
     no_text_fields: Vec<(Symbol, Element)>,
 }
 
@@ -221,7 +221,7 @@ where
 {
     /// Returns an owned struct from the given iterator of field names/values.
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
-        let mut text_fields: HashMap<Rc<str>, Vec<(Symbol, Element)>> = HashMap::new();
+        let mut text_fields: LinkedHashMap<Rc<str>, Vec<(Symbol, Element)>> = LinkedHashMap::new();
         let mut no_text_fields: Vec<(Symbol, Element)> = Vec::new();
 
         for (k, v) in iter {


### PR DESCRIPTION
*Issue #200*

*Description of changes:*
This PR changes `Struct` and `StructRef` implementations to consider field order

*List of changes:*
- replaces usage of `HashMap` with `LinkedHashMap`
- adds dependency to `hashlink` in `Cargo.toml`

*Test:*
Added a unit tests in `mod.rs` which tests operations on struct through generic trait `IonElement`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
