### PR TITLE
Implement Display for Timestamp

### DIFF
--- a/src/text/text_formatter.rs
+++ b/src/text/text_formatter.rs
@@ -363,7 +363,7 @@ impl<'a, W: std::fmt::Write> IonValueFormatter<'a, W> {
     }
 
     pub fn format_timestamp(&mut self, value: &Timestamp) -> IonResult<()> {
-        value.write_timestamp(self.output)
+        value.format(self.output)
     }
 
     pub(crate) fn format_symbol<A: AsRawSymbolTokenRef>(&mut self, value: A) -> IonResult<()> {


### PR DESCRIPTION
This change fixes GH #434. It moves the (duplicate) Timestamp formatting
logic out of the raw_text_writer and text_formatter and uses it to
implement Display for Timestamp.

In addition to cutting duplicate code, this makes the Timestamp more user
friendly.

### Note:
There is some back-and-forth between Result and IonResult that I don't love.
It appears to me that one cannot capture any info with Result's Err, so I don't 
think there is something better we can do functionally.

That said: I'm pretty new to rust, so feedback welcome!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
