### PR TITLE
changes borrowed module to use `SymbolRef` and simplifies `StructRef`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use raw_symbol_token::RawSymbolToken;
 pub use raw_symbol_token_ref::RawSymbolTokenRef;
 
 pub use symbol::Symbol;
+pub use symbol_ref::SymbolRef;
 pub use symbol_table::SymbolTable;
 
 pub use types::decimal::Decimal;

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -8,94 +8,66 @@
 //! backed by octets or string data, `&[u8]` and `&str` are used.
 
 use super::{IonElement, IonSequence, IonStruct, IonSymbolToken};
-use crate::symbol_ref::AsSymbolRef;
+use crate::ion_eq::IonEq;
+use crate::symbol_ref::{AsSymbolRef, SymbolRef};
 use crate::types::decimal::Decimal;
 use crate::types::integer::Integer;
 use crate::types::timestamp::Timestamp;
-use crate::types::SymbolId;
 use crate::value::Builder;
 use crate::IonType;
 use hashlink::LinkedHashMap;
 use num_bigint::BigInt;
+use smallvec::SmallVec;
 use std::iter::FromIterator;
 
-/// A borrowed implementation of [`SymbolToken`].
-#[derive(Debug, Copy, Clone)]
-pub struct SymbolTokenRef<'val> {
-    text: Option<&'val str>,
-    local_sid: Option<SymbolId>,
-}
-
-impl<'val> SymbolTokenRef<'val> {
-    fn new(text: Option<&'val str>, local_sid: Option<SymbolId>) -> Self {
-        Self { text, local_sid }
-    }
-}
-
-/// Constructs a [`SymbolTokenRef`] with unknown text and a local ID.
-/// A common case for binary parsing (though technically relevant in text).
-#[inline]
-pub fn local_sid_token<'val>(local_sid: SymbolId) -> SymbolTokenRef<'val> {
-    SymbolTokenRef::new(None, Some(local_sid))
-}
-
-/// Constructs a [`SymbolTokenRef`] with just text.
-/// A common case for text and synthesizing tokens.
-#[inline]
-pub fn text_token(text: &str) -> SymbolTokenRef {
-    SymbolTokenRef::new(Some(text), None)
-}
-
-impl<'val> PartialEq for SymbolTokenRef<'val> {
-    fn eq(&self, other: &Self) -> bool {
-        match (self.text(), other.text()) {
-            // SymbolTokenRef is a resolved symbol; if there's no text, it's because the symbol
-            // explicitly has undefined text.
-            (Some(text), Some(other_text)) => text == other_text,
-            (None, None) => true,
-            _ => false,
-        }
-    }
-}
-
-impl<'val> Eq for SymbolTokenRef<'val> {}
-
-impl<'val> From<&'val str> for SymbolTokenRef<'val> {
-    fn from(text: &'val str) -> Self {
-        Self::new(Some(text), None)
-    }
-}
-
-impl<'val> IonSymbolToken for SymbolTokenRef<'val> {
+impl<'a> IonSymbolToken for SymbolRef<'a> {
     fn text(&self) -> Option<&str> {
-        self.text
+        self.text()
     }
 
     fn symbol_id(&self) -> Option<usize> {
-        self.local_sid
+        match self.text() {
+            Some(_) => None,
+            None => Some(0), // unknown text is represented with $0
+        }
     }
 
     fn with_text(self, text: &'static str) -> Self {
-        SymbolTokenRef::new(Some(text), self.local_sid)
+        SymbolRef::with_text(text)
     }
 
-    fn with_symbol_id(self, local_sid: SymbolId) -> Self {
-        SymbolTokenRef::new(self.text, Some(local_sid))
+    fn with_symbol_id(self, _symbol_id: usize) -> Self {
+        // Because `SymbolRef` represents a fully resolved symbol...
+        if self.text().is_some() {
+            // ...if we already have text, we can discard the symbol ID.
+            return self;
+        }
+        // Otherwise, the text is unknown.
+        SymbolRef::with_unknown_text()
     }
 
     fn text_token(text: &'static str) -> Self {
-        SymbolTokenRef::new(Some(text), None)
+        SymbolRef::with_text(text)
     }
 
-    fn symbol_id_token(local_sid: usize) -> Self {
-        SymbolTokenRef::new(None, Some(local_sid))
+    fn symbol_id_token(_symbol_id: usize) -> Self {
+        // Because `SymbolRef` represents a fully resolved symbol, constructing one from a symbol ID
+        // alone means that it has no defined text and is therefore equivalent to SID 0.
+        SymbolRef::with_unknown_text()
     }
+}
+
+/// Constructs a [`SymbolRef`] with just text.
+/// A common case for text and synthesizing tokens.
+#[inline]
+pub fn text_token(text: &str) -> SymbolRef {
+    SymbolRef::with_text(text)
 }
 
 /// A borrowed implementation of [`Builder`].
 impl<'val> Builder for ElementRef<'val> {
     type Element = ElementRef<'val>;
-    type SymbolToken = SymbolTokenRef<'val>;
+    type SymbolToken = SymbolRef<'val>;
     type Sequence = SequenceRef<'val>;
     type Struct = StructRef<'val>;
 
@@ -216,89 +188,114 @@ impl<'val> Eq for SequenceRef<'val> {}
 /// A borrowed implementation of [`Struct`]
 #[derive(Debug, Clone)]
 pub struct StructRef<'val> {
-    text_fields: LinkedHashMap<String, Vec<(SymbolTokenRef<'val>, ElementRef<'val>)>>,
-    no_text_fields: Vec<(SymbolTokenRef<'val>, ElementRef<'val>)>,
+    // A mapping of field name to any values associated with that name.
+    // If a field name is repeated, each value will be in the associated SmallVec.
+    // Since repeated field names are not common, we store the values in a SmallVec;
+    // the first value will be stored directly in the map while additional values will
+    // be stored elsewhere on the heap.
+    fields: LinkedHashMap<SymbolRef<'val>, SmallVec<[ElementRef<'val>; 1]>>,
+    // `fields.len()` will only tell us the number of *distinct* field names. If the struct
+    // contains any repeated field names, it will be an under-count. Therefore, we track the number
+    // of fields separately.
+    number_of_fields: usize,
 }
 
 impl<'val> StructRef<'val> {
-    fn eq_text_fields(&self, other: &Self) -> bool {
-        // check if both the text_fields have same (field_name,value) pairs
-        self.text_fields.iter().all(|(key, value)| {
-            value
-                .iter()
-                .all(|(_my_s, my_v)| other.get_all(key).any(|other_v| my_v == other_v))
-                && value.len() == other.get_all(key).count()
-        })
+    fn fields_eq(&self, other: &Self) -> bool {
+        // For each (field name, field value list) in `self`...
+        for (field_name, field_values) in &self.fields {
+            // ...get the corresponding field value list from `other`.
+            let other_values = match other.fields.get(field_name) {
+                // If there's no such list, they're not equal.
+                None => return false,
+                Some(values) => values,
+            };
+
+            // If `other` has a corresponding list but it's a different length, they're not equal.
+            if field_values.len() != other_values.len() {
+                return false;
+            }
+
+            // If any of the values in `self`'s value list are not also in `other`'s value list,
+            // they're not equal.
+            if field_values.iter().any(|value| {
+                other_values
+                    .iter()
+                    .all(|other_value| !value.ion_eq(other_value))
+            }) {
+                return false;
+            }
+        }
+
+        // If all of the above conditions hold, the two structs are equal.
+        true
     }
 
-    fn eq_no_text_fields(&self, other: &Self) -> bool {
-        // check if both the no_text_fields are same values
-        self.no_text_fields.iter().all(|(my_k, my_v)| {
-            other
-                .no_text_fields
-                .iter()
-                .any(|(other_k, other_v)| my_k == other_k && my_v == other_v)
-        })
+    /// Returns the number of fields in this Struct.
+    pub fn len(&self) -> usize {
+        self.number_of_fields
+    }
+
+    /// Returns `true` if this struct has zero fields.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 
 impl<'val, K, V> FromIterator<(K, V)> for StructRef<'val>
 where
-    K: Into<SymbolTokenRef<'val>>,
+    K: Into<SymbolRef<'val>>,
     V: Into<ElementRef<'val>>,
 {
     /// Returns a borrowed struct from the given iterator of field names/values.
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
-        let mut text_fields: LinkedHashMap<String, Vec<(SymbolTokenRef, ElementRef)>> =
+        let mut fields: LinkedHashMap<SymbolRef<'val>, SmallVec<[ElementRef<'val>; 1]>> =
             LinkedHashMap::new();
-        let mut no_text_fields: Vec<(SymbolTokenRef, ElementRef)> = Vec::new();
+        let mut number_of_fields: usize = 0;
 
         for (k, v) in iter {
             let key = k.into();
             let val = v.into();
 
-            match key.text() {
-                Some(text) => {
-                    let vals = text_fields.entry(text.into()).or_insert_with(Vec::new);
-                    vals.push((key, val));
-                }
-                None => {
-                    no_text_fields.push((key, val));
-                }
-            }
+            fields.entry(key).or_insert_with(SmallVec::new).push(val);
+
+            number_of_fields += 1;
         }
 
         Self {
-            text_fields,
-            no_text_fields,
+            fields,
+            number_of_fields,
         }
     }
 }
 
 impl<'val> IonStruct for StructRef<'val> {
-    type FieldName = SymbolTokenRef<'val>;
+    type FieldName = SymbolRef<'val>;
     type Element = ElementRef<'val>;
 
     fn iter<'a>(
         &'a self,
     ) -> Box<dyn Iterator<Item = (&'a Self::FieldName, &'a Self::Element)> + 'a> {
-        // flattens the text_fields HashMap and chains with no_text_fields
-        // to return all fields with iterator
+        // flattens the fields map
         Box::new(
-            self.text_fields
-                .values()
-                .flatten()
-                .into_iter()
-                .chain(self.no_text_fields.iter())
-                .map(|(s, v)| (s, v)),
+            self.fields
+                .iter()
+                .flat_map(|(name, values)| values.iter().map(move |value| (name, value))),
         )
     }
 
     fn get<T: AsSymbolRef>(&self, field_name: T) -> Option<&Self::Element> {
-        if let Some(text) = field_name.as_symbol_ref().text() {
-            self.text_fields.get(text)?.last().map(|(_s, v)| v)
-        } else {
-            self.no_text_fields.last().map(|(_name, value)| value)
+        match field_name.as_symbol_ref().text() {
+            None => {
+                // Build a cheap, stack-allocated `SymbolRef` that represents unknown text
+                let symbol = SymbolRef::with_unknown_text();
+                // Use the unknown text symbol to look up matching field values
+                self.fields.get(&symbol)?.last()
+            }
+            Some(text) => {
+                // Otherwise, look it up by text
+                self.fields.get(text)?.last()
+            }
         }
     }
 
@@ -306,37 +303,83 @@ impl<'val> IonStruct for StructRef<'val> {
         &'a self,
         field_name: T,
     ) -> Box<dyn Iterator<Item = &'a Self::Element> + 'a> {
-        if let Some(text) = field_name.as_symbol_ref().text() {
-            Box::new(
-                self.text_fields
-                    .get(text)
-                    .into_iter()
-                    .flat_map(|v| v.iter())
-                    .map(|(_s, v)| v),
-            )
-        } else {
-            Box::new(self.no_text_fields.iter().map(|(_name, value)| value))
+        let values = match field_name.as_symbol_ref().text() {
+            None => {
+                // Build a cheap, stack-allocated `SymbolRef` that represents unknown text
+                let symbol = SymbolRef::with_unknown_text();
+                // Use the unknown text symbol to look up matching field values
+                self.fields.get(&symbol)
+            }
+            Some(text) => {
+                // Otherwise, look it up by text
+                self.fields.get(text)
+            }
+        };
+
+        match values {
+            None => Box::new(std::iter::empty()),
+            Some(values) => Box::new(values.iter()),
         }
     }
 }
 
 impl<'val> PartialEq for StructRef<'val> {
     fn eq(&self, other: &Self) -> bool {
-        // check if both text_fields and no_text_fields have same length
-        self.text_fields.len() == other.text_fields.len() && self.no_text_fields.len() == other.no_text_fields.len()
-        // check if text_fields and no_text_fields are equal 
-        // we need to test equality in both directions for both text_fields and no_text_fields
+        // check if both fields have same length
+        self.fields.len() == other.fields.len()
+        // we need to test equality in both directions for both fields
         // A good example for this is annotated vs not annotated values in struct
         //  { a:4, a:4 } vs. { a:4, a:a::4 } // returns true
         //  { a:4, a:a::4 } vs. { a:4, a:4 } // returns false 
-        && self.eq_text_fields(other) && other.eq_text_fields(self)
-            && self.eq_no_text_fields(other) && other.eq_no_text_fields(self)
+        && self.fields_eq(other) && other.fields_eq(self)
     }
 }
 
 impl<'val> Eq for StructRef<'val> {}
 
 // TODO replace the references with `Cow` and bridge to the owned APIs for mutability
+
+impl<'val> IonEq for SequenceRef<'val> {
+    fn ion_eq(&self, other: &Self) -> bool {
+        self.children.ion_eq(&other.children)
+    }
+}
+
+impl<'val> IonEq for ValueRef<'val> {
+    fn ion_eq(&self, other: &Self) -> bool {
+        use ValueRef::*;
+        match (self, other) {
+            (Float(f1), Float(f2)) => return f1.ion_eq(f2),
+            (Decimal(d1), Decimal(d2)) => return d1.ion_eq(d2),
+            (Timestamp(t1), Timestamp(t2)) => return t1.ion_eq(t2),
+            (List(seq1), List(seq2)) => return seq1.ion_eq(seq2),
+            (SExpression(seq1), SExpression(seq2)) => return seq1.ion_eq(seq2),
+            _ => {}
+        };
+        // For any other case, fall back to vanilla equality
+        self == other
+    }
+}
+
+impl<'val> IonEq for ElementRef<'val> {
+    fn ion_eq(&self, other: &Self) -> bool {
+        self.annotations == other.annotations && self.value.ion_eq(&other.value)
+    }
+}
+
+impl<'val> IonEq for Vec<ElementRef<'val>> {
+    fn ion_eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        for (v1, v2) in self.iter().zip(other.iter()) {
+            if !v1.ion_eq(v2) {
+                return false;
+            }
+        }
+        true
+    }
+}
 
 /// Variants for all borrowed version _values_ within an [`Element`].
 #[derive(Debug, Clone, PartialEq)]
@@ -347,7 +390,7 @@ pub enum ValueRef<'val> {
     Decimal(Decimal),
     Timestamp(Timestamp),
     String(&'val str),
-    Symbol(SymbolTokenRef<'val>),
+    Symbol(SymbolRef<'val>),
     Boolean(bool),
     Blob(&'val [u8]),
     Clob(&'val [u8]),
@@ -360,12 +403,12 @@ pub enum ValueRef<'val> {
 /// A borrowed implementation of [`Element`]
 #[derive(Debug, Clone)]
 pub struct ElementRef<'val> {
-    annotations: Vec<SymbolTokenRef<'val>>,
+    annotations: Vec<SymbolRef<'val>>,
     value: ValueRef<'val>,
 }
 
 impl<'val> ElementRef<'val> {
-    pub fn new(annotations: Vec<SymbolTokenRef<'val>>, value: ValueRef<'val>) -> Self {
+    pub fn new(annotations: Vec<SymbolRef<'val>>, value: ValueRef<'val>) -> Self {
         Self { annotations, value }
     }
 }
@@ -433,8 +476,8 @@ impl<'val> From<&'val str> for ElementRef<'val> {
     }
 }
 
-impl<'val> From<SymbolTokenRef<'val>> for ElementRef<'val> {
-    fn from(sym_val: SymbolTokenRef<'val>) -> Self {
+impl<'val> From<SymbolRef<'val>> for ElementRef<'val> {
+    fn from(sym_val: SymbolRef<'val>) -> Self {
         ValueRef::Symbol(sym_val).into()
     }
 }
@@ -446,7 +489,7 @@ impl<'val> From<StructRef<'val>> for ElementRef<'val> {
 }
 
 impl<'val> IonElement for ElementRef<'val> {
-    type SymbolToken = SymbolTokenRef<'val>;
+    type SymbolToken = SymbolRef<'val>;
     type Sequence = SequenceRef<'val>;
     type Struct = StructRef<'val>;
     type Builder = ElementRef<'val>;
@@ -580,8 +623,100 @@ mod borrowed_value_tests {
             StructRef::from_iter(vec![("greetings", ElementRef::from(ValueRef::String("hello")))].into_iter()).into()
         ),
     )]
-    fn owned_element_accessors(elem1: ElementRef, elem2: ElementRef) {
+    fn owned_element_accessors<'a>(elem1: ElementRef<'a>, elem2: ElementRef<'a>) {
         // assert if both the element construction creates the same element
         assert_eq!(elem1, elem2);
+    }
+
+    #[rstest(
+    container, length,
+    case::struct_(
+        ElementRef::new_struct(
+            vec![
+                ("greetings", ElementRef::from(ValueRef::String("hello".into()))),
+                ("name", ElementRef::from(ValueRef::String("Ion".into())))
+            ].into_iter()
+        ),
+        2
+    ),
+    case::list(
+        ElementRef::new_list(
+            vec![
+                ElementRef::from("greetings"),
+                ElementRef::from(5),
+                ElementRef::from(true)
+            ].into_iter()
+        ),
+        3
+    ),
+        case::sexp(
+            ElementRef::new_sexp(vec![ElementRef::from(5), ElementRef::from(true)].into_iter()),
+        2
+    ),
+    )]
+    fn borrowed_container_len_test(container: ElementRef, length: usize) {
+        match container.ion_type() {
+            IonType::List | IonType::SExpression => {
+                // check length for given sequence value
+                assert_eq!(container.as_sequence().unwrap().len(), length);
+            }
+            IonType::Struct => {
+                // check length for given struct value
+                assert_eq!(container.as_struct().unwrap().len(), length);
+            }
+            _ => {
+                unreachable!("This test is only for container type elements")
+            }
+        }
+    }
+
+    #[rstest(
+    container, is_empty,
+    case::struct_(
+        ElementRef::new_struct(
+            vec![
+                ("greetings", ElementRef::from(ValueRef::String("hello".into()))),
+                ("name", ElementRef::from(ValueRef::String("Ion".into())))
+            ].into_iter()
+        ),
+        false
+    ),
+    case::list(
+        ElementRef::new_list(
+            vec![
+                ElementRef::from("greetings"),
+                ElementRef::from(5),
+                ElementRef::from(true)
+            ].into_iter()
+        ),
+        false
+    ),
+    case::list_empty(
+        ElementRef::new_list(vec![].into_iter()),
+        true
+    ),
+    case::sexp(
+        ElementRef::new_sexp(vec![ElementRef::from(5), ElementRef::from(true)].into_iter()),
+        false
+    ),
+    case::sexp_empty(
+        ElementRef::new_sexp(vec![].into_iter()),
+        true
+    ),
+    )]
+    fn borrowed_container_is_empty_test(container: ElementRef, is_empty: bool) {
+        match container.ion_type() {
+            IonType::List | IonType::SExpression => {
+                // check length for given sequence value
+                assert_eq!(container.as_sequence().unwrap().is_empty(), is_empty);
+            }
+            IonType::Struct => {
+                // check length for given struct value
+                assert_eq!(container.as_struct().unwrap().is_empty(), is_empty);
+            }
+            _ => {
+                unreachable!("This test is only for container type elements")
+            }
+        }
     }
 }

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -675,8 +675,8 @@ mod borrowed_value_tests {
     case::struct_(
         ElementRef::new_struct(
             vec![
-                ("greetings", ElementRef::from(ValueRef::String("hello".into()))),
-                ("name", ElementRef::from(ValueRef::String("Ion".into())))
+                ("greetings", ElementRef::from(ValueRef::String("hello"))),
+                ("name", ElementRef::from(ValueRef::String("Ion")))
             ].into_iter()
         ),
         false

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -131,7 +131,7 @@
 //! ```
 //! use ion_rs::Symbol;
 //! use ion_rs::value::IonSymbolToken;
-//! use ion_rs::value::borrowed::SymbolTokenRef;
+//! use ion_rs::SymbolRef;
 //!
 //! fn extract_text<T: IonSymbolToken>(tok: &T) -> String {
 //!     tok.text().unwrap().into()
@@ -141,7 +141,7 @@
 //!
 //! // owned value to emphasize lifetime
 //! let text = String::from("hello");
-//! let borrowed_token: SymbolTokenRef = text.as_str().into();
+//! let borrowed_token: SymbolRef = text.as_str().into();
 //!
 //! let owned_text = extract_text(&owned_token);
 //! let borrowed_text = extract_text(&borrowed_token);

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -59,7 +59,7 @@ impl IonSymbolToken for Symbol {
     }
 }
 
-/// Constructs a [`SymbolTokenRef`] with just text.
+/// Constructs a [`Symbol`] with just text.
 /// A common case for text and synthesizing tokens.
 #[inline]
 pub fn text_token(text: &str) -> Symbol {
@@ -333,9 +333,9 @@ impl IonStruct for Struct {
 
 impl PartialEq for Struct {
     fn eq(&self, other: &Self) -> bool {
-        // check if both text_fields and no_text_fields have same length
+        // check if both fields have same length
         self.len() == other.len()
-            // we need to test equality in both directions for both text_fields and no_text_fields
+            // we need to test equality in both directions for both fields
             // A good example for this is annotated vs not annotated values in struct
             //  { a:4, a:4 } vs. { a:4, a:a::4 } // returns true
             //  { a:4, a:a::4 } vs. { a:4, a:4 } // returns false


### PR DESCRIPTION
*Description of changes:*
This PR works on changes borrowed module to use SymbolRef and simplifies `StructRef`. 

*List of changes:*
* adds implementation of `Hash`, `From<&str>`, `Borrow<str>` for `SymbolRef`
* makes `SymbolRef` publicly visible in crate
* removes usage of `SymboltokenRef` from borrowed module and instead uses `SymbolRef`
* removes the separate `no_text_values` collection in `StructRef`
* adds `len()` and `is_empty()` for `StructRef`
* adds `IonEq` implmentation for `ElementRef`
* some minor doc comment changes for owned module

*Test:*
- modifies doc test use `SymbolRef` for borrowed module tests
- adds tests for `len` and `is_empty` methods of `StructRef`


