### PR TITLE
Implement blocking RawTextReader wrapper

### DIFF
--- a/src/raw_reader.rs
+++ b/src/raw_reader.rs
@@ -7,13 +7,15 @@ use std::fmt::{Display, Formatter};
 /// `RawReader` is a shorthand for a [Reader](crate::Reader) implementation that returns [RawStreamItem]s and
 /// uses [RawSymbolToken] to represent its field names, annotations, and symbol values.
 pub trait RawReader: IonReader<Item = RawStreamItem, Symbol = RawSymbolToken> {
-    // Defines no additional functionality
+    // Mark the stream as complete. This allows the reader to understand when partial parses on
+    // data boundaries are not possible.
+    fn stream_done(&mut self);
 }
 impl<T> RawReader for T
 where
     T: IonReader<Item = RawStreamItem, Symbol = RawSymbolToken>,
 {
-    // No additional implementations are necessary
+    fn stream_done(&mut self) {}
 }
 
 /// Allows a Box<dyn RawReader> to be used as a RawReader.

--- a/src/raw_reader.rs
+++ b/src/raw_reader.rs
@@ -9,13 +9,13 @@ use std::fmt::{Display, Formatter};
 pub trait RawReader: IonReader<Item = RawStreamItem, Symbol = RawSymbolToken> {
     // Mark the stream as complete. This allows the reader to understand when partial parses on
     // data boundaries are not possible.
-    fn stream_done(&mut self);
+    fn stream_complete(&mut self);
 }
 impl<T> RawReader for T
 where
     T: IonReader<Item = RawStreamItem, Symbol = RawSymbolToken>,
 {
-    fn stream_done(&mut self) {}
+    fn stream_complete(&mut self) {}
 }
 
 /// Allows a Box<dyn RawReader> to be used as a RawReader.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -58,7 +58,7 @@ impl ReaderBuilder {
                 // we can move into the reader.
                 let owned_header = Vec::from(&header[..total_bytes_read]);
                 // The file was too short to be binary Ion. Construct a text Reader.
-                return Ok(Self::make_text_reader(owned_header));
+                return Ok(Self::make_text_reader(owned_header)?);
             }
             total_bytes_read += bytes_read;
         }
@@ -81,17 +81,17 @@ impl ReaderBuilder {
             _ => {
                 // It's not binary, assume it's text
                 let full_input = io::Cursor::new(header).chain(input);
-                Ok(Self::make_text_reader(full_input))
+                Ok(Self::make_text_reader(full_input)?)
             }
         }
     }
 
-    fn make_text_reader<'a, I: 'a + ToIonDataSource>(data: I) -> Reader<'a> {
-        let raw_reader = Box::new(RawTextReader::new(data));
-        Reader {
+    fn make_text_reader<'a, I: 'a + ToIonDataSource>(data: I) -> IonResult<Reader<'a>> {
+        let raw_reader = Box::new(RawTextReader::new(data)?);
+        Ok(Reader {
             raw_reader,
             symbol_table: SymbolTable::new(),
-        }
+        })
     }
 
     fn make_binary_reader<'a, I: 'a + ToIonDataSource>(data: I) -> Reader<'a> {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -58,7 +58,7 @@ impl ReaderBuilder {
                 // we can move into the reader.
                 let owned_header = Vec::from(&header[..total_bytes_read]);
                 // The file was too short to be binary Ion. Construct a text Reader.
-                return Ok(Self::make_text_reader(owned_header)?);
+                return Self::make_text_reader(owned_header);
             }
             total_bytes_read += bytes_read;
         }

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -767,7 +767,7 @@ mod tests {
     use super::*;
 
     fn system_reader_for(ion: &str) -> SystemReader<RawTextReader<&str>> {
-        let raw_reader = RawTextReader::new(ion);
+        let raw_reader = RawTextReader::new(ion).expect("unable to initialize reader");
         SystemReader::new(raw_reader)
     }
 

--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -420,9 +420,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
                 // again. Return the value we found.
                 RootParseResult::Ok(value)
             }
-            Err(Incomplete(_needed)) => {
-                RootParseResult::Incomplete(self.buffer.lines_loaded(), 0)
-            }
+            Err(Incomplete(_needed)) => RootParseResult::Incomplete(self.buffer.lines_loaded(), 0),
             Err(Error(ion_parse_error)) => {
                 RootParseResult::Failure(format!(
                     "Parsing error occurred near line {}: '{}': '{:?}'",

--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -421,11 +421,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
                 RootParseResult::Ok(value)
             }
             Err(Incomplete(_needed)) => {
-                RootParseResult::Failure(format!(
-                    "Unexpected end of input on line {}: '{}'",
-                    self.buffer.lines_loaded(),
-                    &self.buffer.remaining_text()[..original_length] // Don't show the extra `\n0\n`
-                ))
+                RootParseResult::Incomplete(self.buffer.lines_loaded(), 0)
             }
             Err(Error(ion_parse_error)) => {
                 RootParseResult::Failure(format!(
@@ -461,7 +457,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
 }
 
 impl RawTextReader<Vec<u8>> {
-    fn append_bytes(&mut self, bytes: &[u8]) -> IonResult<()> {
+    pub fn append_bytes(&mut self, bytes: &[u8]) -> IonResult<()> {
         match self.buffer.append_bytes(bytes) {
             Err(e) => decoding_error(e.to_string()),
             Ok(()) => {
@@ -471,12 +467,16 @@ impl RawTextReader<Vec<u8>> {
         }
     }
 
-    fn read_from<R: std::io::Read>(&mut self, source: R, length: usize) -> IonResult<usize> {
+    pub fn read_from<R: std::io::Read>(&mut self, source: R, length: usize) -> IonResult<usize> {
         let res = self.buffer.read_from(source, length);
         if res.is_ok() {
             self.is_eof = false;
         }
         res
+    }
+
+    pub fn buffer_size(&self) -> usize {
+        self.buffer.buffer_size()
     }
 }
 

--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -119,7 +119,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
 
         // Unset variables holding onto information about the previous position.
         self.current_ivm = None;
-        if let None = self.carried_state {
+        if self.carried_state.is_none() {
             self.current_value = None;
             self.current_field_name = None;
         }
@@ -550,10 +550,6 @@ impl RawTextReader<Vec<u8>> {
         }
         res
     }
-
-    pub fn buffer_size(&self) -> usize {
-        self.buffer.buffer_size()
-    }
 }
 
 // Returned by the `annotations()` method below if there is no current value.
@@ -576,8 +572,6 @@ impl<A: AsRef<[u8]>> IonReader for RawTextReader<A> {
     }
 
     fn next(&mut self) -> IonResult<RawStreamItem> {
-        use super::text_buffer::TextError;
-
         // Parse the next value from the stream, storing it in `self.current_value`.
         self.load_next_value()?;
 

--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -338,9 +338,7 @@ impl TextBuffer<Vec<u8>> {
             })?
         }
 
-        if self.data_end > 0 {
-            self.data_exhausted = false;
-        }
+        self.data_exhausted = self.data_end == 0;
 
         Ok(bytes_read)
     }

--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -255,9 +255,6 @@ impl TextBuffer<Vec<u8>> {
     /// This function will invalidate any data returned by `remaining_text` as the bytes in the
     /// buffer will have shifted.
     fn restack(&mut self) {
-        let rem = self.remaining_text().to_owned();
-        // let prev_last = rem[rem.len()-10..];
-        // let prev_first = rem[0..10];
         let shift_offset = self.line.0 + self.line_offset;
 
         // Shift off all of our consumed data, leaving the buffer to start with the current line's
@@ -319,10 +316,6 @@ impl TextBuffer<Vec<u8>> {
         if capacity < length {
             self.data.resize(self.data.len() + length - capacity, 0);
         }
-    }
-
-    pub fn buffer_size(&self) -> usize {
-        self.data.capacity()
     }
 }
 
@@ -409,12 +402,6 @@ mod tests {
             wrong => panic!("Unexpected response from read_from: {:?}", wrong),
         }
         assert_eq!(input.data_end, 12);
-        // we did not load the whole string here, so we want to read the rest, which will trigger
-        // the buffer to grow.
-        match input.read_from((&more[source.len()..]).as_bytes(), 10) {
-            Ok(x) if x == more.len() - source.len() => (),
-            wrong => panic!("Unexpected response from read_from: {:?}", wrong),
-        }
 
         input.load_next_line().unwrap();
         assert_eq!(input.remaining_text(), more);

--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -284,6 +284,7 @@ impl TextBuffer<Vec<u8>> {
 
         let read_buffer = &mut self.data.as_mut_slice()[self.data_end..];
         let bytes_read = source.read(read_buffer)?;
+        self.data.resize(self.data_end + bytes_read, 0);
 
         // We have new data, so we need to ensure that it is valid UTF-8.
         if self.validate_data().is_err() {
@@ -306,6 +307,10 @@ impl TextBuffer<Vec<u8>> {
         if capacity < length {
             self.data.resize(self.data.len() + length - capacity, 0);
         }
+    }
+
+    pub fn buffer_size(&self) -> usize {
+        self.data.len()
     }
 }
 

--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -121,6 +121,11 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
         self.line_number
     }
 
+    /// Returns the number of characters into the line that have been consumed.
+    pub fn line_offset(&self) -> usize {
+        self.line_offset
+    }
+
     pub fn is_exhausted(&self) -> bool {
         self.bytes_remaining() == 0 && self.data_exhausted
     }
@@ -255,6 +260,7 @@ impl TextBuffer<Vec<u8>> {
     /// This function will invalidate any data returned by `remaining_text` as the bytes in the
     /// buffer will have shifted.
     fn restack(&mut self) {
+        println!("restacking..");
         let shift_offset = self.line.0 + self.line_offset;
 
         // Shift off all of our consumed data, leaving the buffer to start with the current line's

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -741,7 +741,6 @@ mod reader_tests {
 
         let mut reader = RawTextReader::new(&source[..]);
 
-
         let result = reader.next();
         // Blob..
         assert!(result.is_ok());
@@ -761,5 +760,4 @@ mod reader_tests {
 
         Ok(())
     }
-
 }

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -59,11 +59,6 @@ impl<T: ToIonDataSource> RawTextReader<T> {
         self.bytes_fed += bytes_read;
         Ok(bytes_read)
     }
-
-    // Returns the number of bytes unconsumed in the underlying reader.
-    fn reader_remaining(&self) -> usize {
-        self.bytes_fed - self.reader.bytes_read()
-    }
 }
 
 impl<T: ToIonDataSource> IonReader for RawTextReader<T> {

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -1,44 +1,24 @@
-use std::fmt::Display;
-
-use nom::Err::{Error, Failure, Incomplete};
+use std::io::BufRead;
 
 use crate::data_source::ToIonDataSource;
 use crate::raw_reader::RawStreamItem;
 use crate::raw_symbol_token::RawSymbolToken;
-use crate::result::{
-    decoding_error, illegal_operation, illegal_operation_raw, IonError, IonResult,
-};
+use crate::result::IonResult;
 use crate::stream_reader::IonReader;
-use crate::text::parent_container::ParentContainer;
-use crate::text::parse_result::IonParseResult;
-use crate::text::parsers::containers::{
-    list_delimiter, list_value_or_end, s_expression_delimiter, s_expression_value_or_end,
-    struct_delimiter, struct_field_name_or_end, struct_field_value,
-};
-use crate::text::parsers::top_level::{stream_item, RawTextStreamItem};
-use crate::text::text_buffer::TextBuffer;
-use crate::text::text_value::{AnnotatedTextValue, TextValue};
-use crate::types::decimal::Decimal;
-use crate::types::integer::Integer;
 use crate::types::timestamp::Timestamp;
-use crate::IonType;
+use crate::{Decimal, Integer, IonError, IonType};
+
+use crate::text::non_blocking::raw_text_reader::RawTextReader as NonBlockingReader;
 
 const INITIAL_PARENTS_CAPACITY: usize = 16;
+const READER_BUFFER_CAPACITY: usize = 1024 * 4;
 
 pub struct RawTextReader<T: ToIonDataSource> {
-    buffer: TextBuffer<T::DataSource>,
-    // If the reader is not positioned over a value inside a struct, this is None.
-    current_field_name: Option<RawSymbolToken>,
-    // If the reader has not yet begun reading at the current level or is positioned over an IVM,
-    // this is None.
-    current_value: Option<AnnotatedTextValue>,
-    // If the reader is positioned over an IVM instead of a value, this is:
-    //     Some(major_version, minor_version)
-    // Otherwise, it is None.
-    current_ivm: Option<(u8, u8)>,
-    bytes_read: usize,
-    is_eof: bool,
-    parents: Vec<ParentContainer>,
+    source: T::DataSource,
+    // The inner non-blocking reader.
+    reader: NonBlockingReader<Vec<u8>>,
+    // The number of bytes fed to the inner reader.
+    bytes_fed: usize,
 }
 
 /// Represents the final outcome of a [RawTextReader]'s attempt to parse the next value in the stream.
@@ -58,419 +38,58 @@ pub(crate) enum RootParseResult<O> {
 
 impl<T: ToIonDataSource> RawTextReader<T> {
     pub fn new(input: T) -> RawTextReader<T> {
-        let text_source = input.to_ion_data_source();
+        let buffer = Vec::with_capacity(READER_BUFFER_CAPACITY);
         RawTextReader {
-            buffer: TextBuffer::new(text_source),
-            current_field_name: None,
-            current_value: None,
-            current_ivm: None,
-            bytes_read: 0,
-            is_eof: false,
-            parents: Vec::with_capacity(INITIAL_PARENTS_CAPACITY),
+            source: input.to_ion_data_source(),
+            reader: NonBlockingReader::new(buffer),
+            bytes_fed: 0,
         }
     }
 
     pub fn bytes_read(&self) -> usize {
-        self.bytes_read
+        self.reader.bytes_read()
     }
 
-    fn load_next_value(&mut self) -> IonResult<()> {
-        // If the reader's current value is the beginning of a container and the user calls `next()`,
-        // we need to skip the entire container. We can do this by stepping into and then out of
-        // that container; `step_out()` has logic that will exhaust the remaining values.
-        let need_to_skip_container = !self.is_null()
-            && self
-                .current_value
-                .as_ref()
-                .map(|v| v.value().ion_type().is_container())
-                .unwrap_or(false);
-
-        if need_to_skip_container {
-            self.step_in()?;
-            self.step_out()?;
-        }
-
-        // Unset variables holding onto information about the previous position.
-        self.current_ivm = None;
-        self.current_value = None;
-        self.current_field_name = None;
-
-        if self.parents.is_empty() {
-            // The `parents` stack is empty. We're at the top level.
-
-            // If the reader has already found EOF (the end of the top level), there's no need to
-            // try to read more data. Return Ok(None).
-            if self.is_eof {
-                self.current_value = None;
-                return Ok(());
-            }
-
-            let next_stream_item = self.parse_next_nom(stream_item);
-            return self.process_stream_item(next_stream_item);
-        }
-
-        // Otherwise, the `parents` stack is not empty. We're inside a container.
-
-        // The `ParentLevel` type is only a couple of stack-allocated bytes. It's very cheap to clone.
-        let parent = *self.parents.last().unwrap();
-        // If the reader had already found the end of this container, return Ok(None).
-        if parent.is_exhausted() {
-            self.current_value = None;
-            return Ok(());
-        }
-        // Otherwise, try to read the next value. The syntax we expect will depend on the
-        // IonType of the parent container.
-        let value = match parent.ion_type() {
-            IonType::List => self.next_list_value(),
-            IonType::SExpression => self.next_s_expression_value(),
-            IonType::Struct => {
-                // If the reader finds a field name...
-                if let Some(field_name) = self.next_struct_field_name()? {
-                    // ...remember it and return the field value that follows.
-                    self.current_field_name = Some(field_name);
-                    let field_value_result = self.next_struct_field_value()?;
-                    Ok(Some(field_value_result))
-                } else {
-                    // Otherwise, this is the end of the struct.
-                    Ok(None)
-                }
-            }
-            other => unreachable!(
-                "The reader's `parents` stack contained a scalar value: {:?}",
-                other
-            ),
-        };
-
-        match value {
-            Ok(None) => {
-                // If the parser returns Ok(None), we've just encountered the end of the container for
-                // the first time. Set `is_exhausted` so we won't try to parse more until `step_out()` is
-                // called.
-                // We previously used a copy of the last `ParentLevel` in the stack to simplify reading.
-                // To modify it, we'll need to get a mutable reference to the original.
-                self.parents.last_mut().unwrap().set_exhausted(true);
-                self.current_value = None;
-            }
-            Ok(Some(value)) => {
-                // We successfully read a value. Set it as the current value.
-                self.current_value = Some(value);
-            }
-            Err(e) => return Err(e),
-        };
-
-        Ok(())
-    }
-
-    fn process_stream_item(
-        &mut self,
-        read_result: RootParseResult<RawTextStreamItem>,
-    ) -> IonResult<()> {
-        match read_result {
-            RootParseResult::Ok(RawTextStreamItem::IonVersionMarker(1, 0)) => {
-                // We found an IVM; we currently only support Ion 1.0.
-                self.current_ivm = Some((1, 0));
-                Ok(())
-            }
-            RootParseResult::Ok(RawTextStreamItem::IonVersionMarker(major, minor)) => {
-                decoding_error(format!(
-                    "Unsupported Ion version: v{}.{}. Only 1.0 is supported.",
-                    major, minor
-                ))
-            }
-            RootParseResult::Ok(RawTextStreamItem::AnnotatedTextValue(value)) => {
-                // We read a value successfully; set it as our current value.
-                self.current_value = Some(value);
-                Ok(())
-            }
-            RootParseResult::Eof => {
-                // The top level is the only depth at which EOF is legal. If we encounter an EOF,
-                // double check that the buffer doesn't actually have a value in it. See the
-                // comments in [parse_value_at_eof] for a detailed explanation of this.
-                let item = self.parse_value_at_eof();
-                if item == RootParseResult::Eof {
-                    // This is a genuine EOF; make a note of it and clear the current value.
-                    self.is_eof = true;
-                    self.current_value = None;
-                    return Ok(());
-                }
-                self.process_stream_item(item)
-            }
-            RootParseResult::NoMatch => {
-                // The parser didn't recognize the text in the input buffer.
-                // Return an error that contains the text we were attempting to parse.
-                let error_message = format!(
-                    "unrecognized input near line {}: '{}'",
-                    self.buffer.lines_loaded(),
-                    self.buffer.remaining_text(),
-                );
-                decoding_error(error_message)
-            }
-            RootParseResult::Failure(error_message) => {
-                // A fatal error occurred while reading the next value.
-                // This could be an I/O error, malformed utf-8 data, or an invalid value.
-                decoding_error(error_message)
-            }
-        }
-    }
-
-    /// Assumes that the reader is inside a list and attempts to parse the next value.
-    /// If the next token in the stream is an end-of-list delimiter (`]`), returns Ok(None).
-    fn next_list_value(&mut self) -> IonResult<Option<AnnotatedTextValue>> {
-        self.parse_expected("a list", list_value_or_end)
-    }
-
-    /// Assumes that the reader is inside an s-expression and attempts to parse the next value.
-    /// If the next token in the stream is an end-of-s-expression delimiter (`)`), returns Ok(None).
-    fn next_s_expression_value(&mut self) -> IonResult<Option<AnnotatedTextValue>> {
-        self.parse_expected("an s-expression", s_expression_value_or_end)
-    }
-
-    /// Assumes that the reader is inside an struct and attempts to parse the next field name.
-    /// If the next token in the stream is an end-of-struct delimiter (`}`), returns Ok(None).
-    fn next_struct_field_name(&mut self) -> IonResult<Option<RawSymbolToken>> {
-        // If there isn't another value, this returns Ok(None).
-        self.parse_expected("a struct field name", struct_field_name_or_end)
-    }
-
-    /// Assumes that the reader is inside a struct AND that a field has already been successfully
-    /// parsed from input using [next_struct_field_name] and attempts to parse the next value.
-    /// In this input position, only a value (or whitespace/comments) are legal. Anything else
-    /// (including EOF) will result in a decoding error.
-    fn next_struct_field_value(&mut self) -> IonResult<AnnotatedTextValue> {
-        // Only called after a call to [next_struct_field_name] that returns Some(field_name).
-        // It is not legal for a field name to be followed by a '}' or EOF.
-        // If there isn't another value, returns an Err.
-        self.parse_expected("a struct field value", struct_field_value)
-    }
-
-    /// Attempts to parse the next entity from the stream using the provided parser.
-    /// Returns a decoding error if EOF is encountered while parsing.
-    /// If the parser encounters an error, it will be returned as-is.
-    fn parse_expected<P, O>(&mut self, entity_name: &str, parser: P) -> IonResult<O>
-    where
-        P: Fn(&str) -> IonParseResult<O>,
-    {
-        match self.parse_next(parser) {
-            Ok(Some(value)) => Ok(value),
-            Ok(None) => decoding_error(format!(
-                "Unexpected end of input while reading {} on line {}: '{}'",
-                entity_name,
-                self.buffer.lines_loaded(),
-                self.buffer.remaining_text()
-            )),
-            Err(e) => decoding_error(format!(
-                "Parsing error occurred while parsing {} near line {}:\n'{}'\n{}",
-                entity_name,
-                self.buffer.lines_loaded(),
-                self.buffer.remaining_text(),
-                e
-            )),
-        }
-    }
-
-    fn parse_next<P, O>(&mut self, parser: P) -> IonResult<Option<O>>
-    where
-        P: Fn(&str) -> IonParseResult<O>,
-    {
-        match self.parse_next_nom(parser) {
-            RootParseResult::Ok(item) => Ok(Some(item)),
-            RootParseResult::Eof => Ok(None),
-            RootParseResult::NoMatch => {
-                // Return an error that contains the text currently in the buffer (i.e. what we
-                // were attempting to parse.)
-                let error_message = format!(
-                    "unrecognized input near line {}: '{}'",
-                    self.buffer.lines_loaded(),
-                    self.buffer.remaining_text(),
-                );
-                decoding_error(error_message)
-            }
-            RootParseResult::Failure(error_message) => decoding_error(error_message),
-        }
-    }
-
-    /// Attempts to parse the next entity from the stream using the provided parser.
-    /// If there isn't enough data in the buffer for the parser to match its input conclusively,
-    /// more data will be loaded into the buffer and the parser will be called again.
-    /// If EOF is encountered, returns `Ok(None)`.
-    fn parse_next_nom<P, O>(&mut self, parser: P) -> RootParseResult<O>
-    where
-        P: Fn(&str) -> IonParseResult<O>,
-    {
-        let RawTextReader {
-            ref mut is_eof,
-            ref mut buffer,
-            ref mut bytes_read,
-            ..
-        } = *self;
-
-        if *is_eof {
-            return RootParseResult::Eof;
-        }
-
+    // Read up to `length` bytes from the source, into the underlying non-blocking reader.
+    fn read_source(&mut self, length: usize) -> IonResult<usize> {
+        let mut bytes_read = 0;
         loop {
-            // Note the number of bytes currently in the text buffer
-            let length_before_parse = buffer.remaining_text().len();
-            // Invoke the top_level_value() parser; this will attempt to recognize the next value
-            // in the stream and return a &str slice containing the remaining, not-yet-parsed text.
-            match parser(buffer.remaining_text()) {
-                // If `top_level_value` returns 'Incomplete', there wasn't enough text in the buffer
-                // to match the next value. No syntax errors have been encountered (yet?), but we
-                // need to load more text into the buffer before we try to parse it again.
-                Err(Incomplete(_needed)) => {
-                    // Ask the buffer to load another line of text.
-                    // TODO: Currently this loads a single line at a time for easier testing.
-                    //       We may wish to bump it to a higher number of lines at a time (8?)
-                    //       for efficiency once we're confident in the correctness.
-                    match buffer.load_next_line() {
-                        Ok(0) => {
-                            // If load_next_line() returns Ok(0), we've reached the end of our input.
-                            *is_eof = true;
-                            // The buffer had an `Incomplete` value in it; now that we know we're at EOF,
-                            // we can determine whether the buffer's contents should actually be
-                            // considered complete.
-                            return RootParseResult::Eof;
-                        }
-                        Ok(_bytes_loaded) => {
-                            // Retry the parser on the extended buffer in the next loop iteration
-                            continue;
-                        }
-                        Err(e) => {
-                            let error_message =
-                                format!("I/O error, could not read more data: {}", e);
-                            return RootParseResult::Failure(error_message);
-                        }
-                    }
-                }
-                Ok((remaining_text, value)) => {
-                    // Our parser successfully matched a value.
-                    // Note the length of the text that remains after parsing.
-                    let length_after_parse = remaining_text.len();
-                    // The difference in length tells us how many bytes were part of the
-                    // text representation of the value that we found.
-                    let bytes_consumed = length_before_parse - length_after_parse;
-                    buffer.consume(bytes_consumed);
-                    *bytes_read += bytes_consumed;
-                    return RootParseResult::Ok(value);
-                }
-                Err(Error(_e)) => return RootParseResult::<O>::NoMatch,
-                Err(Failure(e)) => {
-                    let error_message = format!(
-                        "unrecognized input near line {}: {}: '{}'",
-                        buffer.lines_loaded(),
-                        e.description().unwrap_or("<no description>"),
-                        buffer.remaining_text(),
-                    );
-                    return RootParseResult::Failure(error_message);
-                }
+            let n = self.reader.read_from(&mut self.source, length)?;
+            bytes_read += n;
+            if n == 0 || bytes_read + n >= length {
+                break;
+            }
+        }
+        self.bytes_fed += bytes_read;
+        Ok(bytes_read)
+    }
+
+    // Returns the number of bytes unconsumed in the underlying reader.
+    fn reader_remaining(&self) -> usize {
+        self.bytes_fed - self.reader.bytes_read()
+    }
+
+    // Read data into the underlying non-blocking reader if we have more data in our source,
+    // and the non-blocking reader has less than 1/4 of a full buffer.
+    //
+    // The 1/4 full buffer is fairly arbitrary, but provides some headroom so we're not constantly
+    // reading, while at the same time ensuring we have enough data that we don't land on a false
+    // type boundary.
+    fn feed_if_needed(&mut self) -> IonResult<()> {
+        let more_source = self.source.fill_buf().map(|b| !b.is_empty())?;
+        let add_source = more_source && self.reader_remaining() < self.reader.buffer_size() / 4;
+        if self.bytes_fed == 0 || add_source {
+            let size = if self.bytes_fed == 0 {
+                READER_BUFFER_CAPACITY
+            } else {
+                self.reader.buffer_size() - self.reader_remaining()
             };
+            self.read_source(size)?;
         }
-    }
-
-    // Parses the contents of the text buffer again with the knowledge that we're at the end of the
-    // input stream. This allows us to resolve a number of ambiguous cases.
-    // For a detailed description of the problem that this addresses, please see:
-    // https://github.com/amzn/ion-rust/issues/318
-    // This method should only be called when the reader is at the top level. An EOF at any other
-    // depth is an error.
-    fn parse_value_at_eof(&mut self) -> RootParseResult<RawTextStreamItem> {
-        // An arbitrary, cheap-to-parse Ion value that we append to the buffer when its contents at
-        // EOF are ambiguous.
-        const SENTINEL_ION_TEXT: &str = "\n0\n";
-        // Make a note of the buffer's length; we're about to modify it.
-        let original_length = self.buffer.remaining_text().len();
-        // Append our sentinel value to the end of the input buffer.
-        self.buffer.inner().push_str(SENTINEL_ION_TEXT);
-        // If the buffer contained a value, the newline will indicate that the contents of the
-        // buffer were complete. For example:
-        // * the integer `7` becomes `7\n`; it wasn't the first digit in a truncated `755`.
-        // * the boolean `true` becomes `false\n`; it wasn't actually half of the
-        //   identifier `falseTeeth`.
-        //
-        // If the buffer contained a value that's written in segments, the extra `0` will indicate
-        // that no more segments are coming. For example:
-        // * `foo::bar` becomes `foo::bar\n0\n`; the parser can see that 'bar' is a value, not
-        //    another annotation in the sequence.
-        // * `'''long-form string'''` becomes `'''long-form string'''\n0\n`; the parser can see that
-        //   there aren't any more long-form string segments in the sequence.
-        //
-        // Attempt to parse the updated buffer.
-        let value = match stream_item(self.buffer.remaining_text()) {
-            Ok(("\n", RawTextStreamItem::AnnotatedTextValue(value)))
-                if value.annotations().is_empty()
-                    && *value.value() == TextValue::Integer(Integer::I64(0)) =>
-            {
-                // We found the unannotated zero that we appended to the end of the buffer.
-                // The "\n" in this pattern is the unparsed text left in the buffer,
-                // which indicates that our 0 was parsed.
-                RootParseResult::Eof
-            }
-            Ok((_remaining_text, value)) => {
-                // We found something else. The zero is still in the buffer; we can leave it there.
-                // The reader's `is_eof` flag has been set, so the text buffer will never be used
-                // again. Return the value we found.
-                RootParseResult::Ok(value)
-            }
-            Err(Incomplete(_needed)) => {
-                RootParseResult::Failure(format!(
-                    "Unexpected end of input on line {}: '{}'",
-                    self.buffer.lines_loaded(),
-                    &self.buffer.remaining_text()[..original_length] // Don't show the extra `\n0\n`
-                ))
-            }
-            Err(Error(ion_parse_error)) => {
-                RootParseResult::Failure(format!(
-                    "Parsing error occurred near line {}: '{}': '{:?}'",
-                    self.buffer.lines_loaded(),
-                    &self.buffer.remaining_text()[..original_length], // Don't show the extra `\n0\n`
-                    ion_parse_error
-                ))
-            }
-            Err(Failure(ion_parse_error)) => {
-                RootParseResult::Failure(format!(
-                    "A fatal error occurred while reading near line {}: '{}': '{:?}'",
-                    self.buffer.lines_loaded(),
-                    &self.buffer.remaining_text()[..original_length], // Don't show the extra `\n0\n`
-                    ion_parse_error
-                ))
-            }
-        };
-
-        // If we didn't consume the sentinel value, remove the sentinel value from the buffer.
-        // Doing so makes this method idempotent.
-        if self.buffer.remaining_text().ends_with(SENTINEL_ION_TEXT) {
-            let length = self.buffer.remaining_text().len();
-            self.buffer
-                .inner()
-                .truncate(length - SENTINEL_ION_TEXT.len());
-        }
-
-        value
-    }
-
-    /// Constructs an [IonError::IllegalOperation] which explains that the reader was asked to
-    /// perform an action that is only allowed when it is positioned over the item type described
-    /// by the parameter `expected`.
-    fn expected<E: Display>(&self, expected: E) -> IonError {
-        illegal_operation_raw(format!(
-            "type mismatch: expected a(n) {} but positioned over a(n) {}",
-            expected,
-            self.current()
-        ))
+        Ok(())
     }
 }
 
-// Returned by the `annotations()` method below if there is no current value.
-const EMPTY_SLICE_RAW_SYMBOL_TOKEN: &[RawSymbolToken] = &[];
-
-// TODO: This implementation of the text reader eagerly materializes each value that it encounters
-//       in the stream and stores it in the reader as `current_value`. Each time a user requests
-//       a value via `read_i64`, `read_bool`, etc, a clone of `current_value` is returned (assuming
-//       its type is in alignment with the request).
-//       A better implementation would identify the input slice containing the next value without
-//       materializing it and then attempt to materialize it when the user calls `read_TYPE`. This
-//       would take less memory and would only materialize values that the user requests.
-//       See: https://github.com/amzn/ion-rust/issues/322
 impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
     type Item = RawStreamItem;
     type Symbol = RawSymbolToken;
@@ -480,140 +99,86 @@ impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
     }
 
     fn next(&mut self) -> IonResult<RawStreamItem> {
-        // Parse the next value from the stream, storing it in `self.current_value`.
-        self.load_next_value()?;
+        self.feed_if_needed()?;
 
-        // If we're positioned on an IVM, return the (major, minor) version tuple
-        if let Some((major, minor)) = self.current_ivm {
-            return Ok(RawStreamItem::VersionMarker(major, minor));
-        }
+        match self.reader.next() {
+            Err(err @ IonError::IncompleteText { .. }) => {
+                // We received an incomplete.. and need more data..
+                loop {
+                    // If there is no more data to read, we need to bubble the incomplete up to the
+                    // caller.
+                    if 0 == self.read_source(1024)? {
+                        return Err(err);
+                    }
 
-        // If we're positioned on a value, return its IonType and whether it's null.
-        if let Some(value) = self.current_value.as_ref() {
-            Ok(RawStreamItem::nullable_value(
-                value.ion_type(),
-                value.is_null(),
-            ))
-        } else {
-            Ok(RawStreamItem::Nothing)
+                    match self.reader.next() {
+                        Err(IonError::IncompleteText { .. }) => (),
+                        other => return other,
+                    }
+                }
+            }
+            other => other,
         }
     }
 
     fn current(&self) -> RawStreamItem {
-        if let Some(ref value) = self.current_value {
-            RawStreamItem::nullable_value(value.ion_type(), value.is_null())
-        } else if let Some(ivm) = self.current_ivm {
-            RawStreamItem::VersionMarker(ivm.0, ivm.1)
-        } else {
-            RawStreamItem::Nothing
-        }
+        self.reader.current()
     }
 
     fn ion_type(&self) -> Option<IonType> {
-        if let Some(ref value) = self.current_value {
-            return Some(value.ion_type());
-        }
-        None
+        self.reader.ion_type()
     }
 
     fn is_null(&self) -> bool {
-        if let Some(ref value) = self.current_value {
-            return value.is_null();
-        }
-        false
+        self.reader.is_null()
     }
 
     fn annotations<'a>(&'a self) -> Box<dyn Iterator<Item = IonResult<Self::Symbol>> + 'a> {
-        let iterator = self
-            .current_value
-            .as_ref()
-            .map(|value| value.annotations())
-            .unwrap_or(EMPTY_SLICE_RAW_SYMBOL_TOKEN)
-            .iter()
-            .cloned()
-            // The annotations are already in memory and are already resolved to text, so
-            // this step cannot fail. Map each token to Ok(token).
-            .map(Ok);
-        Box::new(iterator)
+        self.reader.annotations()
     }
 
     fn has_annotations(&self) -> bool {
-        self.current_value
-            .as_ref()
-            .map(|value| !value.annotations().is_empty())
-            .unwrap_or(false)
+        self.reader.has_annotations()
     }
 
     fn number_of_annotations(&self) -> usize {
-        self.current_value
-            .as_ref()
-            .map(|value| value.annotations().len())
-            .unwrap_or(0)
+        self.reader.number_of_annotations()
     }
 
     fn field_name(&self) -> IonResult<Self::Symbol> {
-        match self.current_field_name.as_ref() {
-            Some(name) => Ok(name.clone()),
-            None => illegal_operation(
-                "field_name() can only be called when the reader is positioned inside a struct",
-            ),
-        }
+        self.reader.field_name()
     }
 
     fn read_null(&mut self) -> IonResult<IonType> {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Null(ion_type)) => Ok(*ion_type),
-            _ => Err(self.expected("null value")),
-        }
+        self.reader.read_null()
     }
 
     fn read_bool(&mut self) -> IonResult<bool> {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Boolean(value)) => Ok(*value),
-            _ => Err(self.expected("bool value")),
-        }
+        self.reader.read_bool()
     }
 
     fn read_integer(&mut self) -> IonResult<Integer> {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Integer(value)) => Ok(value.clone()),
-            _ => Err(self.expected("int value")),
-        }
+        self.reader.read_integer()
     }
 
     fn read_i64(&mut self) -> IonResult<i64> {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Integer(Integer::I64(value))) => Ok(*value),
-            Some(TextValue::Integer(Integer::BigInt(value))) => {
-                decoding_error(format!("Integer {} is too large to fit in an i64.", value))
-            }
-            _ => Err(self.expected("int value")),
-        }
+        self.reader.read_i64()
     }
 
     fn read_f32(&mut self) -> IonResult<f32> {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Float(value)) => Ok(*value as f32),
-            _ => Err(self.expected("float value")),
-        }
+        self.reader.read_f32()
     }
 
     fn read_f64(&mut self) -> IonResult<f64> {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Float(value)) => Ok(*value),
-            _ => Err(self.expected("float value")),
-        }
+        self.reader.read_f64()
     }
 
     fn read_decimal(&mut self) -> IonResult<Decimal> {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Decimal(ref value)) => Ok(value.clone()),
-            _ => Err(self.expected("decimal value")),
-        }
+        self.reader.read_decimal()
     }
 
     fn read_string(&mut self) -> IonResult<String> {
-        self.map_string(|s| s.to_owned())
+        self.reader.read_string()
     }
 
     fn map_string<F, U>(&mut self, f: F) -> IonResult<U>
@@ -621,10 +186,7 @@ impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
         Self: Sized,
         F: FnOnce(&str) -> U,
     {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::String(ref value)) => Ok(f(value.as_str())),
-            _ => Err(self.expected("string value")),
-        }
+        self.reader.map_string(f)
     }
 
     fn map_string_bytes<F, U>(&mut self, f: F) -> IonResult<U>
@@ -632,18 +194,11 @@ impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
         Self: Sized,
         F: FnOnce(&[u8]) -> U,
     {
-        // In the binary reader, this method can bypass utf-8 validation and return a view of the
-        // raw bytes in the input buffer. In the text reader, this optimization isn't available;
-        // some of the input bytes may be encoded as text unicode escapes and require processing
-        // to turn into &[u8].
-        self.map_string(|s| f(s.as_bytes()))
+        self.reader.map_string_bytes(f)
     }
 
     fn read_symbol(&mut self) -> IonResult<Self::Symbol> {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Symbol(ref value)) => Ok(value.clone()),
-            _ => Err(self.expected("symbol value")),
-        }
+        self.reader.read_symbol()
     }
 
     fn read_blob(&mut self) -> IonResult<Vec<u8>> {
@@ -655,10 +210,7 @@ impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
         Self: Sized,
         F: FnOnce(&[u8]) -> U,
     {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Blob(ref value)) => Ok(f(value.as_slice())),
-            _ => Err(self.expected("blob value")),
-        }
+        self.reader.map_blob(f)
     }
 
     fn read_clob(&mut self) -> IonResult<Vec<u8>> {
@@ -670,103 +222,74 @@ impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
         Self: Sized,
         F: FnOnce(&[u8]) -> U,
     {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Clob(ref value)) => Ok(f(value.as_slice())),
-            _ => Err(self.expected("clob value")),
-        }
+        self.reader.map_clob(f)
     }
 
     fn read_timestamp(&mut self) -> IonResult<Timestamp> {
-        match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Timestamp(ref value)) => Ok(value.clone()),
-            _ => Err(self.expected("timestamp value")),
-        }
+        self.reader.read_timestamp()
     }
 
     fn step_in(&mut self) -> IonResult<()> {
-        match &self.current_value {
-            Some(value) if value.ion_type().is_container() => {
-                self.parents
-                    .push(ParentContainer::new(value.value().ion_type()));
-                self.current_value = None;
-                Ok(())
+        self.feed_if_needed()?;
+        match self.reader.step_in() {
+            Err(err @ IonError::IncompleteText { .. }) => {
+                // We received an incomplete.. and need more data..
+                loop {
+                    // If there is no more data to read, we need to bubble the incomplete up to the
+                    // caller.
+                    if 0 == self.read_source(1024)? {
+                        return Err(err);
+                    }
+
+                    match self.reader.step_in() {
+                        Err(IonError::IncompleteText { .. }) => (),
+                        other => return other,
+                    }
+                }
             }
-            Some(value) => {
-                illegal_operation(format!("Cannot step_in() to a {:?}", value.ion_type()))
-            }
-            None => illegal_operation(format!(
-                "{} {}",
-                "Cannot `step_in`: the reader is not positioned on a value.",
-                "Try calling `next()` to advance first."
-            )),
+            other => other,
         }
     }
 
     fn step_out(&mut self) -> IonResult<()> {
-        if self.parents.is_empty() {
-            return illegal_operation(
-                "Cannot call `step_out()` when the reader is at the top level.",
-            );
-        }
+        self.feed_if_needed()?;
+        match self.reader.step_out() {
+            Err(err @ IonError::IncompleteText { .. }) => {
+                // We received an incomplete.. and need more data..
+                loop {
+                    // If there is no more data to read, we need to bubble the incomplete up to the
+                    // caller.
+                    if 0 == self.read_source(1024)? {
+                        return Err(err);
+                    }
 
-        // The container we're stepping out of.
-        let parent = self.parents.last().unwrap();
-
-        // If we're not at the end of the current container, advance the cursor until we are.
-        // Unlike the binary reader, which can skip-scan, the text reader must visit every value
-        // between its current position and the end of the container.
-        if !parent.is_exhausted() {
-            while let RawStreamItem::Value(_) | RawStreamItem::Null(_) = self.next()? {}
-        }
-
-        // Remove the parent container from the stack and clear the current value.
-        let _ = self.parents.pop();
-        self.current_value = None;
-
-        if self.parents.is_empty() {
-            // We're at the top level; nothing left to do.
-            return Ok(());
-        }
-
-        // We've stepped out, but the reader isn't at the top level. We're still inside another
-        // container. Make sure the container was followed by either the appropriate delimiter
-        // or the end of its parent.
-        let container_type = self.parents.last().unwrap().ion_type();
-        match container_type {
-            IonType::List => {
-                self.parse_expected("list delimiter or end", list_delimiter)?;
+                    match self.reader.step_out() {
+                        Err(IonError::IncompleteText { .. }) => (),
+                        other => return other,
+                    }
+                }
             }
-            IonType::SExpression => {
-                self.parse_expected("s-expression delimiter or end", s_expression_delimiter)?;
-            }
-            IonType::Struct => {
-                self.parse_expected("struct delimiter or end", struct_delimiter)?;
-            }
-            scalar => unreachable!("Stepping out of a scalar type: {:?}", scalar),
-        };
-        Ok(())
+            other => other,
+        }
     }
 
     fn parent_type(&self) -> Option<IonType> {
-        self.parents.last().map(|parent| parent.ion_type())
+        self.reader.parent_type()
     }
 
     fn depth(&self) -> usize {
-        self.parents.len()
+        self.reader.depth()
     }
 }
 
 #[cfg(test)]
 mod reader_tests {
-    use rstest::*;
-
-    use super::*;
     use crate::raw_reader::RawStreamItem;
     use crate::raw_symbol_token::{local_sid_token, text_token, RawSymbolToken};
     use crate::result::IonResult;
     use crate::stream_reader::IonReader;
     use crate::text::raw_text_reader::RawTextReader;
-    use crate::text::text_value::{IntoAnnotations, TextValue};
+    use crate::text::text_value::IntoAnnotations;
     use crate::types::decimal::Decimal;
     use crate::types::timestamp::Timestamp;
     use crate::IonType;
@@ -883,32 +406,6 @@ mod reader_tests {
         next_type(reader, IonType::Integer, false);
         assert_eq!(reader.read_i64()?, 42);
         Ok(())
-    }
-
-    #[rstest]
-    #[case(" null ", TextValue::Null(IonType::Null))]
-    #[case(" null.string ", TextValue::Null(IonType::String))]
-    #[case(" true ", TextValue::Boolean(true))]
-    #[case(" false ", TextValue::Boolean(false))]
-    #[case(" 738 ", TextValue::Integer(Integer::I64(738)))]
-    #[case(" 2.5e0 ", TextValue::Float(2.5))]
-    #[case(" 2.5 ", TextValue::Decimal(Decimal::new(25, -1)))]
-    #[case(" 2007-07-12T ", TextValue::Timestamp(Timestamp::with_ymd(2007, 7, 12).build().unwrap()))]
-    #[case(" foo ", TextValue::Symbol(text_token("foo")))]
-    #[case(" \"hi!\" ", TextValue::String("hi!".to_owned()))]
-    #[case(" {{ZW5jb2RlZA==}} ", TextValue::Blob(Vec::from("encoded".as_bytes())))]
-    #[case(" {{\"hello\"}} ", TextValue::Clob(Vec::from("hello".as_bytes())))]
-    fn test_read_single_top_level_values(#[case] text: &str, #[case] expected_value: TextValue) {
-        let reader = &mut RawTextReader::new(text);
-        next_type(
-            reader,
-            expected_value.ion_type(),
-            matches!(expected_value, TextValue::Null(_)),
-        );
-        // TODO: Redo (or remove?) this test. There's not an API that exposes the
-        //       AnnotatedTextValue any more. We're directly accessing `current_value` as a hack.
-        let actual_value = reader.current_value.clone();
-        assert_eq!(actual_value.unwrap(), expected_value.without_annotations());
     }
 
     #[test]
@@ -1182,6 +679,44 @@ mod reader_tests {
         let mut reader = RawTextReader::new(&pretty_ion[..]);
         let result = reader.next();
         println!("{:?}", result);
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    // This test generates a large blob of over 4kb, which exceeds the default buffer size when
+    // reading, which will cause an Incomplete error and trigger the RawTextReader to read more
+    // data from the source.
+    fn incomplete_blob_read() -> IonResult<()> {
+        let mut source = String::from("{{");
+        // Adding a large base64 blob.. the reader defaults to having a 4k buffer,
+        // so we need the blob to be larger than 4K in order to trigger a read in response to an
+        // incomplete.
+        (0..4200).for_each(|_| source.push_str("A"));
+        source.push_str(" }}");
+
+        let mut reader = RawTextReader::new(&source[..]);
+        let result = reader.next();
+        println!("{:?}", result);
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    // This test generates a large, but incomplete, blob of over 4kb, which exceeds the default buffer
+    // size when reading, which will cause an Incomplete error and trigger the RawTextReader to read
+    // more data from the source. Parsing should fail since the blob's closing delimeter is
+    // missing.
+    fn incomplete_blob_error() -> IonResult<()> {
+        let mut source = String::from("{{");
+        // Adding a large base64 blob.. the reader defaults to having a 4k buffer,
+        // so we need the blob to be larger than 4K in order to trigger a read in response to an
+        // incomplete. We then want to form an improper blob in order to generate an error after a
+        // buffer read boundary.
+        (0..4200).for_each(|_| source.push_str("A"));
+
+        let mut reader = RawTextReader::new(&source[..]);
+        let result = reader.next();
         assert!(result.is_err());
         Ok(())
     }

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -642,7 +642,6 @@ mod reader_tests {
     #[test]
     // This test generates a large blob of over 4kb, which exceeds the default buffer size when
     // reading, which will cause an Incomplete error and trigger the RawTextReader to read more
-    //
     // data from the source.
     fn incomplete_blob_read() -> IonResult<()> {
         let mut source = String::from("{{");

--- a/src/value/native_reader.rs
+++ b/src/value/native_reader.rs
@@ -135,7 +135,8 @@ impl ElementReader for NonBlockingNativeElementReader {
             return Ok(Box::new(iterator));
         }
 
-        let raw_reader = RawTextReader::new(data);
+        let mut raw_reader = RawTextReader::new(data);
+        raw_reader.stream_done();
         let reader = UserReader::new(raw_reader);
         let iterator = NativeElementIterator { reader };
         Ok(Box::new(iterator))

--- a/src/value/native_reader.rs
+++ b/src/value/native_reader.rs
@@ -136,7 +136,7 @@ impl ElementReader for NonBlockingNativeElementReader {
         }
 
         let mut raw_reader = RawTextReader::new(data);
-        raw_reader.stream_done();
+        raw_reader.stream_complete();
         let reader = UserReader::new(raw_reader);
         let iterator = NativeElementIterator { reader };
         Ok(Box::new(iterator))


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR adapts the blocking `RawTextReader` to act as a blocking wrapper around the non-blocking `RawTextReader`.

The blocking reader uses a non-blocking reader with a `Vec<u8>` backed text buffer, starting with a default size of 4kb. Data is read from the IonDataSource into the text buffer maintaining the 4kb size unless more data is needed in order to parse a larger value, such as a blob.

With each data consuming call, the reader will perform a check if the underlying source has more data, and if the current text buffer has less than 25% data remaining. If so, then the reader will fill the text buffer before calling the consuming function on the non-blocking reader.

If an incomplete error is returned during a consuming call, the blocking reader will attempt to fill more data into the text buffer. The reader will continue to feed data into the text buffer, until there is no more data, or the consuming function no longer returns an incomplete error. The incomplete error is bubbled up to the caller if the source data is exhausted. 


#### Potential Addition
Right now the blocking reader will use a 4kb buffer unless more space is needed to parse larger values. This is something the user should have control over, and probably warrants having a `with_capacity`-style creation method. I can follow up with a PR to add that too.


#### Discovered Issue
While extending the unit tests in order to pass the reported codecov %s, I ran into an issue where parsing a struct with 4k spaces between the last value and the closing struct delimiter failed. Adding a comma to end the last value resulted in a correct parse. Removing the spaces, also resulted in a correct parse. I updated the code to force newly read characters to be added to the current loaded lines (to see if it was a buffer reading issue), which ensured the closing delimiter was in the buffer when parsing and even saw the delimiter in the error message, but the failure to parse continued.

I'll dig more into this to figure out what the underlying issue is. Adding the `with_capacity`-style method above will help to determine if this is due to this PR's buffer reading, or some other issue. 

#### Update
The most recent commit addresses feedback on this PR, as well as a couple bugs that were discovered while implementing the end of stream signal.

Part of the fixes include adding a "carried state", which is a mechanism to allow tracking of state for more complex `next` logic. The first place this is used is parsing of struct fields where the field name is parsed, then the value, which can fail when an incomplete text error is reached while parsing the value.

The second place is when stepping out of a container. After popping the container from the parent list, if the reader is within another container it needs to find the delimiter or container end. During this, an incomplete text error can be reached, so state needs to be carried for the next call to `next`, after the reader gets more data.

In addition to the bug fixes, the stream end marker was added so that the reader can rely on Incomplete Text errors, rather than trying to read more data when the buffer starts getting low.

#### Update 2 
This round of updates addresses the issues brought up in review. Most of note is the handling of errors in the non-blocking `step_out` method. Details about the fix are left as comments within the `step_out` function.

Another note for this update is that I've included line, and column, numbers for errors that previously had constant placeholders. The implementation for column numbers is currently not accurate and due to recent changes in restack, has the potential to be altered when restacking, causing non-zero column numbers to be shifted by previously consumed lengths. I plan on following up soon with an update to handle lines and columns correctly.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
