### PR TITLE
Version bump to v0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 
 [workspace]


### PR DESCRIPTION
Bumps the crate version to v0.14.0 in anticipation of another dev release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
