### PR TITLE
Return to stable Rust now that 1.65 is released

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,8 +22,10 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2022-10-12
+          # Coverage requires the nightly toolchain because it uses the presently unstable `-Z profile` feature
+          # See: https://github.com/rust-lang/rust/issues/42524
+          # See also: https://github.com/actions-rs/grcov#usage
+          toolchain: nightly-2022-10-12 # nightly can be very volatile--pin this to a version we know works well
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,13 +34,10 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # We're temporarily testing against `beta` to have access to GATs. When Rust v1.65 is released in
-          # 2022-11, we should change this back to `stable`.
-          # See: https://github.com/amzn/ion-rust/issues/443
-          toolchain: beta
+          toolchain: stable
           components: rustfmt, clippy
           override: true
-      - name: Cargo Build 
+      - name: Cargo Build
         uses: actions-rs/cargo@v1
         with:
           command: build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ exclude = [
 ]
 version = "0.14.0"
 edition = "2021"
+# We need at least 1.65 for GATs
+# https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html
+rust-version = "1.65"
 
 [workspace]
 members = [


### PR DESCRIPTION
*Issue #, if available:* #443

Not a lot to say here- this moves back to `stable` and adds a little documentation in comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
