### PR TITLE
adds implementation of `Catalog`

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -3,28 +3,25 @@ use crate::result::{illegal_operation, illegal_operation_raw};
 use crate::shared_symbol_table::SharedSymbolTable;
 use std::collections::{BTreeMap, HashMap};
 
-/// Catalog is a collection of Shared Symbol Tables
-/// for more information on [Catalog]: https://amzn.github.io/ion-docs/docs/symbols.html#the-catalog
+/// A Catalog is a collection of Shared Symbol Tables.
+/// For more information about the concept of a catalog,
+/// see [the `symbols` section of the specification](https://amzn.github.io/ion-docs/docs/symbols.html#the-catalog).
 pub trait Catalog {
     /// Returns the Shared Symbol Table with given table name
     /// If a table with the given name doesn't exists or if the table name is an empty string
     /// then returns an error
+    /// If a table with multiple versions exists for the given name then it will return the latest version of table
     fn get_table(&self, name: &str) -> IonResult<SharedSymbolTable>;
     /// Returns the Shared Symbol Table with given table name and version
     /// If a table with given name and version doesn't exists then it returns an error
     fn get_table_with_version(&self, name: &str, version: usize) -> IonResult<SharedSymbolTable>;
 }
 
-pub trait MutableCatalog {
-    /// Adds a Shared Symbol Table with name into the Catalog
-    fn put_table(&mut self, table: SharedSymbolTable);
-}
-
-struct SimpleCatalog {
+struct MapCatalog {
     tables_by_name: HashMap<String, BTreeMap<usize, SharedSymbolTable>>,
 }
 
-impl SimpleCatalog {
+impl MapCatalog {
     pub fn new() -> Self {
         Self {
             tables_by_name: HashMap::new(),
@@ -32,48 +29,49 @@ impl SimpleCatalog {
     }
 }
 
-impl Catalog for SimpleCatalog {
+impl Catalog for MapCatalog {
     fn get_table(&self, name: &str) -> IonResult<SharedSymbolTable> {
         if name.is_empty() {
-            return illegal_operation("Can not get a symbol table where the name is empty");
+            return illegal_operation("symbol table with empty name doesn't exists");
         }
 
         let versions: &BTreeMap<usize, SharedSymbolTable> =
             self.tables_by_name.get(name).ok_or_else(|| {
-                illegal_operation_raw(format!("Symbol table with name: {} does not exist", name))
+                illegal_operation_raw(format!("symbol table with name: {} does not exist", name))
             })?;
 
         let (_highest_version, table) = versions.iter().rev().next().ok_or_else(|| {
-            illegal_operation_raw(format!("Symbol table with name: {} does not exist", name))
+            illegal_operation_raw(format!("symbol table with name: {} does not exist", name))
         })?;
         Ok(table.to_owned())
     }
 
     fn get_table_with_version(&self, name: &str, version: usize) -> IonResult<SharedSymbolTable> {
         if name.is_empty() {
-            return illegal_operation("Can not get a symbol table where the name is empty");
+            return illegal_operation("symbol table with empty name doesn't exists");
         }
 
         let versions: &BTreeMap<usize, SharedSymbolTable> =
             self.tables_by_name.get(name).ok_or_else(|| {
-                illegal_operation_raw(format!("Symbol table with name: {} does not exist", name))
+                illegal_operation_raw(format!("symbol table with name: {} does not exist", name))
             })?;
 
         let table = versions.get(&version).ok_or_else(|| {
-            illegal_operation_raw(format!("Symbol table with name: {} does not exist", name))
+            illegal_operation_raw(format!("symbol table with name: {} does not exist", name))
         })?;
         Ok(table.to_owned())
     }
 }
 
-impl MutableCatalog for SimpleCatalog {
+impl MapCatalog {
+    /// Adds a Shared Symbol Table with name into the Catalog
     fn put_table(&mut self, table: SharedSymbolTable) {
         match self.tables_by_name.get_mut(table.name()) {
             None => {
                 let mut versions: BTreeMap<usize, SharedSymbolTable> = BTreeMap::new();
-                versions.insert(table.version(), table.to_owned());
-                self.tables_by_name
-                    .insert(table.name().to_owned(), versions);
+                let table_name = table.name().to_owned();
+                versions.insert(table.version(), table);
+                self.tables_by_name.insert(table_name, versions);
             }
             Some(versions) => {
                 versions.insert(table.version(), table);
@@ -84,7 +82,7 @@ impl MutableCatalog for SimpleCatalog {
 
 #[cfg(test)]
 mod tests {
-    use crate::catalog::{Catalog, MutableCatalog, SimpleCatalog};
+    use crate::catalog::{Catalog, MapCatalog};
     use crate::shared_symbol_table::SharedSymbolTable;
     use crate::IonResult;
 
@@ -92,10 +90,10 @@ mod tests {
     fn get_table_with_name_test() -> IonResult<()> {
         let sst = SharedSymbolTable::new(
             "T".to_string(),
-            Some(1),
+            1,
             vec![Some("true".to_string()), Some("false".to_string())],
         )?;
-        let mut catalog = SimpleCatalog::new();
+        let mut catalog = MapCatalog::new();
         catalog.put_table(sst);
 
         // get table with name "T"
@@ -110,10 +108,10 @@ mod tests {
     fn get_table_with_version_test() -> IonResult<()> {
         let sst = SharedSymbolTable::new(
             "T".to_string(),
-            Some(1),
+            1,
             vec![Some("true".to_string()), Some("false".to_string())],
         )?;
-        let mut catalog = SimpleCatalog::new();
+        let mut catalog = MapCatalog::new();
         catalog.put_table(sst);
 
         // get table with name "T" and version 1

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,0 +1,126 @@
+use crate::result::IonResult;
+use crate::result::{illegal_operation, illegal_operation_raw};
+use crate::shared_symbol_table::SharedSymbolTable;
+use std::collections::{BTreeMap, HashMap};
+
+/// Catalog is a collection of Shared Symbol Tables
+/// for more information on [Catalog]: https://amzn.github.io/ion-docs/docs/symbols.html#the-catalog
+pub trait Catalog {
+    /// Returns the Shared Symbol Table with given table name
+    /// If a table with the given name doesn't exists or if the table name is an empty string
+    /// then returns an error
+    fn get_table(&self, name: &str) -> IonResult<SharedSymbolTable>;
+    /// Returns the Shared Symbol Table with given table name and version
+    /// If a table with given name and version doesn't exists then it returns an error
+    fn get_table_with_version(&self, name: &str, version: usize) -> IonResult<SharedSymbolTable>;
+}
+
+pub trait MutableCatalog {
+    /// Adds a Shared Symbol Table with name into the Catalog
+    fn put_table(&mut self, table: SharedSymbolTable);
+}
+
+struct SimpleCatalog {
+    tables_by_name: HashMap<String, BTreeMap<usize, SharedSymbolTable>>,
+}
+
+impl SimpleCatalog {
+    pub fn new() -> Self {
+        Self {
+            tables_by_name: HashMap::new(),
+        }
+    }
+}
+
+impl Catalog for SimpleCatalog {
+    fn get_table(&self, name: &str) -> IonResult<SharedSymbolTable> {
+        if name.is_empty() {
+            return illegal_operation("Can not get a symbol table where the name is empty");
+        }
+
+        let versions: &BTreeMap<usize, SharedSymbolTable> =
+            self.tables_by_name.get(name).ok_or_else(|| {
+                illegal_operation_raw(format!("Symbol table with name: {} does not exist", name))
+            })?;
+
+        let (_highest_version, table) = versions.iter().rev().next().ok_or_else(|| {
+            illegal_operation_raw(format!("Symbol table with name: {} does not exist", name))
+        })?;
+        Ok(table.to_owned())
+    }
+
+    fn get_table_with_version(&self, name: &str, version: usize) -> IonResult<SharedSymbolTable> {
+        if name.is_empty() {
+            return illegal_operation("Can not get a symbol table where the name is empty");
+        }
+
+        let versions: &BTreeMap<usize, SharedSymbolTable> =
+            self.tables_by_name.get(name).ok_or_else(|| {
+                illegal_operation_raw(format!("Symbol table with name: {} does not exist", name))
+            })?;
+
+        let table = versions.get(&version).ok_or_else(|| {
+            illegal_operation_raw(format!("Symbol table with name: {} does not exist", name))
+        })?;
+        Ok(table.to_owned())
+    }
+}
+
+impl MutableCatalog for SimpleCatalog {
+    fn put_table(&mut self, table: SharedSymbolTable) {
+        match self.tables_by_name.get_mut(table.name()) {
+            None => {
+                let mut versions: BTreeMap<usize, SharedSymbolTable> = BTreeMap::new();
+                versions.insert(table.version(), table.to_owned());
+                self.tables_by_name
+                    .insert(table.name().to_owned(), versions);
+            }
+            Some(versions) => {
+                versions.insert(table.version(), table);
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::catalog::{Catalog, MutableCatalog, SimpleCatalog};
+    use crate::shared_symbol_table::SharedSymbolTable;
+    use crate::IonResult;
+
+    #[test]
+    fn get_table_with_name_test() -> IonResult<()> {
+        let sst = SharedSymbolTable::new(
+            "T".to_string(),
+            Some(1),
+            vec![Some("true".to_string()), Some("false".to_string())],
+        )?;
+        let mut catalog = SimpleCatalog::new();
+        catalog.put_table(sst);
+
+        // get table with name "T"
+        assert!(catalog.get_table("T").is_ok());
+
+        // verify that table with name "S" doesn't exist
+        assert!(catalog.get_table("S").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn get_table_with_version_test() -> IonResult<()> {
+        let sst = SharedSymbolTable::new(
+            "T".to_string(),
+            Some(1),
+            vec![Some("true".to_string()), Some("false".to_string())],
+        )?;
+        let mut catalog = SimpleCatalog::new();
+        catalog.put_table(sst);
+
+        // get table with name "T" and version 1
+        assert!(catalog.get_table_with_version("T", 1).is_ok());
+
+        // verify that table with name "T" and version 2 doesn't exist
+        assert!(catalog.get_table_with_version("T", 2).is_err());
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,13 @@ pub mod text;
 pub mod types;
 pub mod value;
 
+mod catalog;
 pub mod constants;
 pub mod ion_eq;
 mod raw_symbol_token;
 mod raw_symbol_token_ref;
 mod reader;
+mod shared_symbol_table;
 mod stream_reader;
 mod symbol;
 mod symbol_ref;

--- a/src/shared_symbol_table.rs
+++ b/src/shared_symbol_table.rs
@@ -7,38 +7,21 @@ use crate::IonResult;
 pub struct SharedSymbolTable {
     name: String,
     version: usize,
-    imports: Vec<Option<String>>,
+    symbols: Vec<Option<String>>,
 }
 
 impl SharedSymbolTable {
-    pub fn new(
-        name: String,
-        version: Option<usize>,
-        imports: Vec<Option<String>>,
-    ) -> IonResult<Self> {
+    pub fn new(name: String, version: usize, imports: Vec<Option<String>>) -> IonResult<Self> {
         // As per Ion Specification, the name field should be a string with length at least one.
         // If the field has any other value, then materialization of this symbol table must fail.
         if name.is_empty() {
-            return illegal_operation("Can not define a shared symbol table with empty name");
+            return illegal_operation("shared symbol table with empty name is not allowed");
         }
-        let table_version = match version {
-            None => {
-                // The version field should be at least 1
-                // If the version is missing or has any other value, it is treated as if it were 1
-                1
-            }
-            Some(version_number) if version_number < 1 => {
-                // The version field should be at least 1
-                // If the version is missing or has any other value, it is treated as if it were 1
-                1
-            }
-            Some(version_number) => version_number,
-        };
 
         Ok(Self {
             name,
-            version: table_version,
-            imports,
+            version,
+            symbols: imports,
         })
     }
 
@@ -48,7 +31,7 @@ impl SharedSymbolTable {
     }
 
     /// Returns the name of this [SharedSymbolTable]
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &str {
         &self.name
     }
 }

--- a/src/shared_symbol_table.rs
+++ b/src/shared_symbol_table.rs
@@ -1,0 +1,54 @@
+use crate::result::illegal_operation;
+use crate::IonResult;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Stores [SharedSymbolTable] with the table name, version and imports
+/// For more information on [SharedSymbolTable]: https://amzn.github.io/ion-docs/docs/symbols.html#shared-symbol-tables
+pub struct SharedSymbolTable {
+    name: String,
+    version: usize,
+    imports: Vec<Option<String>>,
+}
+
+impl SharedSymbolTable {
+    pub fn new(
+        name: String,
+        version: Option<usize>,
+        imports: Vec<Option<String>>,
+    ) -> IonResult<Self> {
+        // As per Ion Specification, the name field should be a string with length at least one.
+        // If the field has any other value, then materialization of this symbol table must fail.
+        if name.is_empty() {
+            return illegal_operation("Can not define a shared symbol table with empty name");
+        }
+        let table_version = match version {
+            None => {
+                // The version field should be at least 1
+                // If the version is missing or has any other value, it is treated as if it were 1
+                1
+            }
+            Some(version_number) if version_number < 1 => {
+                // The version field should be at least 1
+                // If the version is missing or has any other value, it is treated as if it were 1
+                1
+            }
+            Some(version_number) => version_number,
+        };
+
+        Ok(Self {
+            name,
+            version: table_version,
+            imports,
+        })
+    }
+
+    /// Returns the version of this [SharedSymbolTable]
+    pub fn version(&self) -> usize {
+        self.version
+    }
+
+    /// Returns the name of this [SharedSymbolTable]
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+}


### PR DESCRIPTION
*Description of changes:*
This PR works on adding implementation of `Catalog`. 

*List of changes:*
- adds implementation of `SharedSymbolTable`
- adds implementation of `Catalog`
  - adds trait `Catalog`, `MutableCatalog`
  - adds struct `SimpleCatalog`

*Test:*
- adds unit tests for `Catalog` implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
