### PR TITLE
Fix bugs in timestamp

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
           # Coverage requires the nightly toolchain because it uses the presently unstable `-Z profile` feature
           # See: https://github.com/rust-lang/rust/issues/42524
           # See also: https://github.com/actions-rs/grcov#usage
-          toolchain: nightly-2022-10-12 # nightly can be very volatile--pin this to a version we know works well
+          toolchain: nightly-2022-12-18 # nightly can be very volatile--pin this to a version we know works well
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/src/result.rs
+++ b/src/result.rs
@@ -144,6 +144,21 @@ pub fn decoding_error_raw<S: AsRef<str>>(description: S) -> IonError {
     }
 }
 
+/// A convenience method for creating an IonResult containing an IonError::EncodingError with the
+/// provided description text.
+pub fn encoding_error<T, S: AsRef<str>>(description: S) -> IonResult<T> {
+    Err(encoding_error_raw(description))
+}
+
+/// A convenience method for creating an IonError::EncodingError with the provided operation
+/// text. Useful for calling Option#ok_or_else.
+#[inline(never)]
+pub fn encoding_error_raw<S: AsRef<str>>(description: S) -> IonError {
+    IonError::EncodingError {
+        description: description.as_ref().to_string(),
+    }
+}
+
 /// A convenience method for creating an IonResult containing an IonError::IllegalOperation with the
 /// provided operation text.
 pub fn illegal_operation<T, S: AsRef<str>>(operation: S) -> IonResult<T> {


### PR DESCRIPTION
* Fix incorrect handling of positive mantissa in fractional seconds for a zero coefficient
* Removes some panics in favor of returning Result::Err

**Issue #, if available:**

None

**Description of changes:**

While working on fixing up `ion-hash` for the next `ion-rs` release, I discovered some minor issues in the timestamp implementation. This PR fixes them.

* TimestampBuilder will now set fractional seconds to `None` if the fractional seconds coefficient is 0 and the exponent is > -1.
* Added test case for the above change
* Two panics are replaced by returning an EncodingError
* Added `encoding_error` functions that mirror the existing `decoding_error` functions.
* Nightly build for the coverage workflow needed to be updated because the prior nightly build was panicking for my changes (even though stable build worked fine).


*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
